### PR TITLE
fix: Use explicit route navigation in Property Detail back button

### DIFF
--- a/frontend/src/app/features/properties/property-detail/property-detail.component.spec.ts
+++ b/frontend/src/app/features/properties/property-detail/property-detail.component.spec.ts
@@ -159,7 +159,7 @@ describe('PropertyDetailComponent', () => {
       expect(backButton.textContent).toContain('Go Back');
     });
 
-    it('should call location.back() when go back button clicked on error', () => {
+    it('should navigate to properties list when go back button clicked on error', () => {
       mockPropertyStore.detailError = signal('Property not found');
       fixture = TestBed.createComponent(PropertyDetailComponent);
       fixture.detectChanges();
@@ -167,7 +167,7 @@ describe('PropertyDetailComponent', () => {
       const backButton = fixture.nativeElement.querySelector('.error-card button');
       backButton.click();
 
-      expect(mockLocation.back).toHaveBeenCalled();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/properties']);
     });
   });
 
@@ -291,11 +291,11 @@ describe('PropertyDetailComponent', () => {
       expect(backButton.getAttribute('aria-label')).toBe('Go back');
     });
 
-    it('should call location.back() when back button clicked', () => {
+    it('should navigate to properties list when back button clicked', () => {
       const backButton = fixture.nativeElement.querySelector('.back-button');
       backButton.click();
 
-      expect(mockLocation.back).toHaveBeenCalled();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/properties']);
     });
   });
 

--- a/frontend/src/app/features/properties/property-detail/property-detail.component.ts
+++ b/frontend/src/app/features/properties/property-detail/property-detail.component.ts
@@ -510,7 +510,7 @@ export class PropertyDetailComponent implements OnInit, OnDestroy {
   }
 
   goBack(): void {
-    this.location.back();
+    this.router.navigate(['/properties']);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replaced `location.back()` with `router.navigate(['/properties'])` in Property Detail's `goBack()` method
- Updated unit tests to verify the new navigation behavior
- Prevents circular navigation loops when users drill down through multiple views

## Changes

### `property-detail.component.ts`
Changed the `goBack()` method from using browser history (`location.back()`) to explicit route navigation (`router.navigate(['/properties'])`). This ensures users are always taken to the Properties List view regardless of their navigation history.

### `property-detail.component.spec.ts`
Updated two tests to verify the new navigation behavior:
- "should navigate to properties list when go back button clicked on error"
- "should navigate to properties list when back button clicked"

## Test Plan

- [x] Unit tests pass (310 tests)
- [x] E2E tests pass (6 tests)
- [x] Frontend build succeeds
- [x] Backend build succeeds

## Manual Testing Scenarios

**Scenario 1: Properties List Flow**
1. Click on "Properties" in the side navigation
2. Click on any property to view details
3. Click "Add Expense" button
4. Click the back arrow (←) in the Expense Workspace header → Returns to Property Detail ✅
5. Click the back arrow (←) in the Property Detail header → Returns to Properties List ✅

**Scenario 2: Dashboard Flow**
1. Start on the Dashboard view
2. Click on a property card/link
3. Click "Add Expense"
4. Click back → Returns to Property Detail ✅
5. Click back → Returns to Properties List ✅

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)