### PR TITLE
feat(receipts): Add S3 presigned URL infrastructure for receipt uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,13 @@ Email__SmtpPort=1025
 Email__FromAddress=noreply@property-manager.app
 Email__FromName=Property Manager
 
-# AWS S3 (for receipt storage - future use)
+# AWS S3 (for receipt storage)
+# Create an S3 bucket and IAM user with s3:PutObject, s3:GetObject, s3:DeleteObject permissions
 AWS__AccessKeyId=your_access_key
 AWS__SecretAccessKey=your_secret_key
 AWS__BucketName=property-manager-receipts
 AWS__Region=us-east-1
+AWS__PresignedUrlExpiryMinutes=60
 
 # Environment
 ASPNETCORE_ENVIRONMENT=Development

--- a/_bmad-output/implementation-artifacts/5-1-receipt-upload-infrastructure-s3-presigned-urls.md
+++ b/_bmad-output/implementation-artifacts/5-1-receipt-upload-infrastructure-s3-presigned-urls.md
@@ -1,0 +1,469 @@
+# Story 5.1: Receipt Upload Infrastructure (S3 Presigned URLs)
+
+Status: done
+Completed: 2025-12-31
+
+## Completion Summary
+
+All 14 tasks completed successfully:
+- AWS SDK integration with S3StorageService
+- CQRS commands/queries for receipts (GenerateUploadUrl, CreateReceipt, GetReceipt, DeleteReceipt)
+- ReceiptsController with all endpoints
+- 38 unit tests passing
+- 14 integration tests passing
+- Environment configuration (.env.example, docker-compose.yml)
+- Manual verification with real S3 bucket
+
+## Story
+
+As a developer,
+I want receipt images uploaded directly to S3 via presigned URLs,
+so that uploads are fast, secure, and don't burden the API server.
+
+## Acceptance Criteria
+
+1. **AC-5.1.1**: API generates presigned S3 upload URL
+   - Endpoint `POST /api/v1/receipts/upload-url` returns a presigned S3 PUT URL
+   - URL is valid for 60 minutes (configurable via settings)
+   - Response includes: `uploadUrl`, `storageKey`, `expiresAt`, `httpMethod` ("PUT")
+   - Storage key format: `{accountId}/{year}/{guid}.{extension}`
+   - Requires JWT authentication
+
+2. **AC-5.1.2**: Client uploads directly to S3 without passing through API
+   - Frontend can PUT file bytes directly to the presigned URL
+   - No multipart form data through the backend
+   - S3 accepts the upload with correct Content-Type header
+
+3. **AC-5.1.3**: Confirm upload and create receipt record
+   - Endpoint `POST /api/v1/receipts` creates receipt record after S3 upload
+   - Request body: `{ storageKey, originalFileName, contentType, fileSizeBytes, propertyId? }`
+   - Receipt created with: AccountId (from JWT), CreatedByUserId, CreatedAt
+   - PropertyId is optional (unprocessed receipts may not have a property yet)
+   - Returns `{ id: "guid" }` with 201 Created
+
+4. **AC-5.1.4**: API generates presigned download URL for viewing
+   - Endpoint `GET /api/v1/receipts/{id}` returns receipt details with presigned view URL
+   - Response includes `viewUrl` (presigned GET URL) valid for 60 minutes
+   - Tenant isolation enforced - only receipts for user's AccountId accessible
+
+5. **AC-5.1.5**: S3 bucket is private and secure
+   - Bucket has no public access
+   - Objects are encrypted at rest (S3 managed encryption)
+   - Presigned URLs are the only access method
+   - Credentials stored in environment variables (not in code)
+
+6. **AC-5.1.6**: Supported file types and size limits
+   - Allowed content types: `image/jpeg`, `image/png`, `application/pdf`
+   - Maximum file size: 10MB (validated before generating upload URL)
+   - Invalid content type returns 400 Bad Request with clear error
+
+7. **AC-5.1.7**: Receipt can be deleted
+   - Endpoint `DELETE /api/v1/receipts/{id}` soft-deletes the receipt
+   - Optionally deletes the file from S3 (or marks for cleanup)
+   - Returns 204 No Content on success
+   - Tenant isolation enforced
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add AWS SDK NuGet Package (AC: 5.1.1)
+  - [ ] Add `AWSSDK.S3` package to `PropertyManager.Infrastructure.csproj`
+  - [ ] Verify package version compatible with .NET 10
+  - [ ] Run `dotnet restore` to verify
+
+- [ ] Task 2: Create Storage Settings and Interface (AC: 5.1.5)
+  - [ ] Create `IStorageService.cs` interface in `Application/Common/Interfaces/`
+    - Methods: `GeneratePresignedUploadUrlAsync()`, `GeneratePresignedDownloadUrlAsync()`, `DeleteFileAsync()`
+  - [ ] Create `S3StorageSettings.cs` in `Infrastructure/Storage/`
+    - Properties: `AccessKeyId`, `SecretAccessKey`, `BucketName`, `Region`, `PresignedUrlExpiryMinutes`
+    - Add `SectionName = "AWS"` constant
+
+- [ ] Task 3: Implement S3StorageService (AC: 5.1.1, 5.1.2, 5.1.4, 5.1.5)
+  - [ ] Create `S3StorageService.cs` in `Infrastructure/Storage/`
+  - [ ] Implement `GeneratePresignedUploadUrlAsync(string storageKey, string contentType, long fileSizeBytes)`
+  - [ ] Implement `GeneratePresignedDownloadUrlAsync(string storageKey)`
+  - [ ] Implement `DeleteFileAsync(string storageKey)`
+  - [ ] Configure AmazonS3Client with credentials from settings
+  - [ ] Handle AWS exceptions with appropriate error messages
+
+- [ ] Task 4: Register Storage Service in DI (AC: 5.1.5)
+  - [ ] Add `S3StorageSettings` configuration in `Program.cs`
+  - [ ] Register `IStorageService` with `S3StorageService` implementation
+  - [ ] Register in `DependencyInjection.cs` in Infrastructure layer
+
+- [ ] Task 5: Create Upload URL Command (AC: 5.1.1, 5.1.6)
+  - [ ] Create `Application/Receipts/` folder
+  - [ ] Create `GenerateUploadUrl.cs` with:
+    - `GenerateUploadUrlCommand(string ContentType, long FileSizeBytes, Guid? PropertyId)`
+    - `GenerateUploadUrlHandler` using IStorageService and ICurrentUser
+    - `UploadUrlResponse(string UploadUrl, string StorageKey, DateTime ExpiresAt, string HttpMethod)`
+  - [ ] Create `GenerateUploadUrlValidator.cs` with FluentValidation
+    - Validate ContentType is in allowed list
+    - Validate FileSizeBytes <= 10MB
+
+- [ ] Task 6: Create Receipt Confirmation Command (AC: 5.1.3)
+  - [ ] Create `CreateReceipt.cs` with:
+    - `CreateReceiptCommand(string StorageKey, string OriginalFileName, string ContentType, long FileSizeBytes, Guid? PropertyId)`
+    - `CreateReceiptHandler` using AppDbContext and ICurrentUser
+  - [ ] Create `CreateReceiptValidator.cs` with FluentValidation
+    - Validate StorageKey is not empty
+    - Validate OriginalFileName is not empty
+    - Validate ContentType is in allowed list
+
+- [ ] Task 7: Create Get Receipt Query (AC: 5.1.4)
+  - [ ] Create `GetReceipt.cs` with:
+    - `GetReceiptQuery(Guid Id)`
+    - `GetReceiptHandler` using AppDbContext and IStorageService
+    - `ReceiptDto(Guid Id, string OriginalFileName, string ContentType, long FileSizeBytes, Guid? PropertyId, Guid? ExpenseId, DateTime CreatedAt, DateTime? ProcessedAt, string ViewUrl)`
+  - [ ] Generate presigned download URL for ViewUrl
+
+- [ ] Task 8: Create Delete Receipt Command (AC: 5.1.7)
+  - [ ] Create `DeleteReceipt.cs` with:
+    - `DeleteReceiptCommand(Guid Id)`
+    - `DeleteReceiptHandler` using AppDbContext and IStorageService
+  - [ ] Soft-delete receipt record (set DeletedAt)
+  - [ ] Optionally delete from S3 (or queue for cleanup)
+
+- [ ] Task 9: Create ReceiptsController (AC: 5.1.1, 5.1.3, 5.1.4, 5.1.7)
+  - [ ] Create `ReceiptsController.cs` in `Api/Controllers/`
+  - [ ] `POST /api/v1/receipts/upload-url` → GenerateUploadUrlCommand
+  - [ ] `POST /api/v1/receipts` → CreateReceiptCommand (returns 201 Created)
+  - [ ] `GET /api/v1/receipts/{id}` → GetReceiptQuery
+  - [ ] `DELETE /api/v1/receipts/{id}` → DeleteReceiptCommand (returns 204)
+  - [ ] Add `[Authorize]` attribute for JWT authentication
+
+- [ ] Task 10: Regenerate TypeScript API Client
+  - [ ] Run NSwag to regenerate API client
+  - [ ] Verify `UploadUrlResponse` type generated
+  - [ ] Verify `ReceiptDto` type generated
+
+- [ ] Task 11: Write Backend Unit Tests
+  - [ ] `GenerateUploadUrlHandlerTests.cs`:
+    - [ ] Generates valid presigned URL
+    - [ ] Rejects invalid content type
+    - [ ] Rejects file size over 10MB
+    - [ ] Includes correct storage key format
+  - [ ] `CreateReceiptHandlerTests.cs`:
+    - [ ] Creates receipt with correct AccountId
+    - [ ] Creates receipt without PropertyId
+    - [ ] Creates receipt with PropertyId
+  - [ ] `GetReceiptHandlerTests.cs`:
+    - [ ] Returns receipt with presigned view URL
+    - [ ] Throws NotFoundException for invalid ID
+    - [ ] Enforces tenant isolation
+  - [ ] `DeleteReceiptHandlerTests.cs`:
+    - [ ] Soft-deletes receipt
+    - [ ] Enforces tenant isolation
+
+- [ ] Task 12: Write Backend Integration Tests
+  - [ ] `ReceiptsControllerTests.cs`:
+    - [ ] POST /upload-url returns presigned URL
+    - [ ] POST /upload-url rejects invalid content type
+    - [ ] POST /receipts creates receipt
+    - [ ] GET /receipts/{id} returns receipt with view URL
+    - [ ] DELETE /receipts/{id} soft-deletes
+    - [ ] Unauthorized requests return 401
+    - [ ] Account isolation enforced
+
+- [ ] Task 13: Environment Configuration
+  - [ ] Update `.env.example` with AWS settings (already has placeholders)
+  - [ ] Add environment variables to local development setup
+  - [ ] Document configuration in README or dev notes
+
+- [ ] Task 14: Manual Verification
+  - [ ] All backend tests pass (`dotnet test`)
+  - [ ] API endpoints work in Swagger
+  - [ ] Presigned URL upload works with curl/Postman
+  - [ ] Presigned URL download works
+  - [ ] Tenant isolation verified
+
+## Dev Notes
+
+### Architecture Patterns and Constraints
+
+**Backend Clean Architecture:**
+- Application Layer: Commands/Queries in `Receipts/` folder
+- Infrastructure Layer: `S3StorageService` implements `IStorageService` interface
+- Dependency injection via `Program.cs` and `DependencyInjection.cs`
+- Use MediatR for command/query dispatch
+- Global query filters enforce AccountId tenant isolation
+
+**S3 Presigned URL Pattern (ADR-004):**
+```
+Client requests upload URL → API generates presigned PUT URL
+Client PUTs file directly to S3 → No backend involvement
+Client confirms upload → API creates receipt record
+```
+
+**Storage Key Format:**
+```
+{accountId}/{year}/{guid}.{extension}
+Example: a1b2c3d4-e5f6/2025/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg
+```
+
+**IStorageService Interface:**
+```csharp
+public interface IStorageService
+{
+    Task<UploadUrlResult> GeneratePresignedUploadUrlAsync(
+        string storageKey,
+        string contentType,
+        long fileSizeBytes,
+        CancellationToken cancellationToken = default);
+
+    Task<string> GeneratePresignedDownloadUrlAsync(
+        string storageKey,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteFileAsync(
+        string storageKey,
+        CancellationToken cancellationToken = default);
+}
+
+public record UploadUrlResult(string Url, DateTime ExpiresAt);
+```
+
+**S3StorageSettings:**
+```csharp
+public class S3StorageSettings
+{
+    public const string SectionName = "AWS";
+
+    public string AccessKeyId { get; set; } = string.Empty;
+    public string SecretAccessKey { get; set; } = string.Empty;
+    public string BucketName { get; set; } = string.Empty;
+    public string Region { get; set; } = "us-east-1";
+    public int PresignedUrlExpiryMinutes { get; set; } = 60;
+}
+```
+
+**API Contracts:**
+```
+POST /api/v1/receipts/upload-url
+Request:
+{
+  "contentType": "image/jpeg",
+  "fileSizeBytes": 2048576,
+  "propertyId": "optional-guid"
+}
+
+Response: 200 OK
+{
+  "uploadUrl": "https://bucket.s3.amazonaws.com/...",
+  "storageKey": "accountId/2025/guid.jpg",
+  "expiresAt": "2025-01-15T11:30:00Z",
+  "httpMethod": "PUT"
+}
+```
+
+```
+POST /api/v1/receipts
+Request:
+{
+  "storageKey": "accountId/2025/guid.jpg",
+  "originalFileName": "receipt-123.jpg",
+  "contentType": "image/jpeg",
+  "fileSizeBytes": 2048576,
+  "propertyId": "optional-guid"
+}
+
+Response: 201 Created
+{
+  "id": "new-receipt-guid"
+}
+Location: /api/v1/receipts/new-receipt-guid
+```
+
+```
+GET /api/v1/receipts/{id}
+
+Response: 200 OK
+{
+  "id": "guid",
+  "originalFileName": "receipt-123.jpg",
+  "contentType": "image/jpeg",
+  "fileSizeBytes": 2048576,
+  "propertyId": "optional-guid",
+  "expenseId": null,
+  "createdAt": "2025-01-15T10:30:00Z",
+  "processedAt": null,
+  "viewUrl": "https://bucket.s3.amazonaws.com/..."
+}
+```
+
+```
+DELETE /api/v1/receipts/{id}
+
+Response: 204 No Content
+```
+
+### Project Structure Notes
+
+**Backend files to create:**
+```
+backend/src/PropertyManager.Application/Common/Interfaces/
+    └── IStorageService.cs
+
+backend/src/PropertyManager.Application/Receipts/
+    ├── GenerateUploadUrl.cs
+    ├── CreateReceipt.cs
+    ├── GetReceipt.cs
+    ├── DeleteReceipt.cs
+    └── Dtos/
+        ├── UploadUrlResponse.cs
+        └── ReceiptDto.cs
+
+backend/src/PropertyManager.Infrastructure/Storage/
+    ├── S3StorageService.cs
+    └── S3StorageSettings.cs
+
+backend/src/PropertyManager.Api/Controllers/
+    └── ReceiptsController.cs
+
+backend/tests/PropertyManager.Application.Tests/Receipts/
+    ├── GenerateUploadUrlHandlerTests.cs
+    ├── CreateReceiptHandlerTests.cs
+    ├── GetReceiptHandlerTests.cs
+    └── DeleteReceiptHandlerTests.cs
+
+backend/tests/PropertyManager.Api.Tests/
+    └── ReceiptsControllerTests.cs
+```
+
+**Backend files to modify:**
+```
+backend/src/PropertyManager.Infrastructure/PropertyManager.Infrastructure.csproj
+    # Add AWSSDK.S3 package
+
+backend/src/PropertyManager.Infrastructure/DependencyInjection.cs
+    # Register IStorageService with S3StorageService
+
+backend/src/PropertyManager.Api/Program.cs
+    # Configure S3StorageSettings
+```
+
+### What Already Exists
+
+**Receipt Entity (Domain Layer):**
+- `Receipt.cs` with all required properties
+- `StorageKey`, `OriginalFileName`, `ContentType`, `FileSizeBytes`
+- `AccountId`, `PropertyId`, `CreatedByUserId`, `ExpenseId`
+- Soft delete via `DeletedAt`
+
+**EF Core Configuration (Infrastructure Layer):**
+- `ReceiptConfiguration.cs` fully configured
+- `DbSet<Receipt> Receipts` in AppDbContext
+- Global query filter for tenant isolation and soft delete
+
+**Environment Variables (already in .env.example):**
+```
+AWS__AccessKeyId=your_access_key
+AWS__SecretAccessKey=your_secret_key
+AWS__BucketName=property-manager-receipts
+AWS__Region=us-east-1
+```
+
+**Expense Entity Integration:**
+- `Expense.ReceiptId` nullable foreign key exists
+- Ready for linking in Story 5.4
+
+### Learnings from Previous Stories
+
+**From Story 4.4 (Dashboard Income and Net Income Totals):**
+- Follow existing controller patterns (DashboardController, ExpensesController)
+- Use `[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]`
+- Return 201 Created with Location header for create operations
+- Follow existing test patterns in `PropertyManager.Api.Tests/`
+
+**From Story 3.1 (Expense Workspace):**
+- MediatR command/query pattern is established
+- FluentValidation is registered automatically via pipeline behavior
+- ICurrentUser provides AccountId and UserId from JWT
+
+**Existing Service Registration Pattern:**
+```csharp
+// In DependencyInjection.cs
+services.Configure<S3StorageSettings>(configuration.GetSection(S3StorageSettings.SectionName));
+services.AddScoped<IStorageService, S3StorageService>();
+```
+
+### Testing Strategy
+
+**Unit Tests (xUnit):**
+- Mock `IStorageService` for handler tests
+- Mock `AppDbContext` for CRUD operations
+- Mock `ICurrentUser` for tenant context
+- Test validation rules (content type, file size)
+
+**Integration Tests (xUnit):**
+- Use mock S3 or LocalStack for storage tests
+- Test full request/response cycle
+- Verify tenant isolation
+- Verify 401 for unauthorized requests
+
+**Manual Verification Checklist:**
+```markdown
+## Smoke Test: Receipt Upload Infrastructure
+
+### API Verification
+- [ ] POST /upload-url returns presigned URL with correct format
+- [ ] Presigned URL works with curl PUT
+- [ ] POST /receipts creates record in database
+- [ ] GET /receipts/{id} returns receipt with viewUrl
+- [ ] DELETE /receipts/{id} soft-deletes receipt
+- [ ] Unauthorized requests return 401
+- [ ] Invalid content type returns 400
+- [ ] File size over 10MB returns 400
+
+### Database Verification
+- [ ] Receipt record created with correct AccountId
+- [ ] Receipt record has correct StorageKey format
+- [ ] Soft delete sets DeletedAt timestamp
+- [ ] Query filters exclude deleted receipts
+
+### S3 Verification
+- [ ] File uploads successfully via presigned URL
+- [ ] File accessible via presigned download URL
+- [ ] Bucket is private (no public access)
+- [ ] Storage key matches expected format
+```
+
+### AWS S3 Setup Notes
+
+**Bucket Policy (for reference - not in code):**
+- Private bucket, no public access
+- IAM user with minimal permissions: `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`
+- Server-side encryption enabled (AES-256 or KMS)
+
+**CORS Configuration (if frontend uploads directly):**
+```json
+[
+  {
+    "AllowedHeaders": ["*"],
+    "AllowedMethods": ["PUT"],
+    "AllowedOrigins": ["http://localhost:4200", "https://your-domain.com"],
+    "ExposeHeaders": ["ETag"]
+  }
+]
+```
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-004: S3 Direct Upload]
+- [Source: _bmad-output/planning-artifacts/architecture.md#Receipt Storage]
+- [Source: _bmad-output/planning-artifacts/architecture.md#API Contracts - Receipts]
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 5.1: Receipt Upload Infrastructure]
+- [Source: backend/src/PropertyManager.Domain/Entities/Receipt.cs]
+- [Source: backend/src/PropertyManager.Infrastructure/Persistence/Configurations/ReceiptConfiguration.cs]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List
+

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -84,8 +84,8 @@ development_status:
   td-6-invitation-only-registration: done            # Remove public registration, add email invitation system (PR #42)
 
   # Epic 5: Receipt Capture
-  epic-5: backlog
-  5-1-receipt-upload-infrastructure-s3-presigned-urls: backlog
+  epic-5: in-progress
+  5-1-receipt-upload-infrastructure-s3-presigned-urls: done
   5-2-mobile-receipt-capture-with-camera: backlog
   5-3-unprocessed-receipt-queue: backlog
   5-4-process-receipt-into-expense: backlog

--- a/backend/src/PropertyManager.Api/Controllers/ReceiptsController.cs
+++ b/backend/src/PropertyManager.Api/Controllers/ReceiptsController.cs
@@ -1,0 +1,216 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PropertyManager.Application.Receipts;
+
+namespace PropertyManager.Api.Controllers;
+
+/// <summary>
+/// Receipt management endpoints for S3 presigned URL uploads.
+/// </summary>
+[ApiController]
+[Route("api/v1/receipts")]
+[Produces("application/json")]
+[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+public class ReceiptsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly IValidator<GenerateUploadUrlCommand> _uploadUrlValidator;
+    private readonly IValidator<CreateReceiptCommand> _createValidator;
+    private readonly ILogger<ReceiptsController> _logger;
+
+    public ReceiptsController(
+        IMediator mediator,
+        IValidator<GenerateUploadUrlCommand> uploadUrlValidator,
+        IValidator<CreateReceiptCommand> createValidator,
+        ILogger<ReceiptsController> logger)
+    {
+        _mediator = mediator;
+        _uploadUrlValidator = uploadUrlValidator;
+        _createValidator = createValidator;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Generate a presigned S3 upload URL (AC-5.1.1, AC-5.1.6).
+    /// </summary>
+    /// <param name="request">Content type and file size</param>
+    /// <returns>Presigned upload URL details</returns>
+    /// <response code="200">Returns presigned upload URL</response>
+    /// <response code="400">If validation fails (invalid content type or file size)</response>
+    /// <response code="401">If user is not authenticated</response>
+    [HttpPost("upload-url")]
+    [ProducesResponseType(typeof(UploadUrlResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GenerateUploadUrl([FromBody] GenerateUploadUrlRequest request)
+    {
+        var command = new GenerateUploadUrlCommand(
+            request.ContentType,
+            request.FileSizeBytes,
+            request.PropertyId);
+
+        // Validate command
+        var validationResult = await _uploadUrlValidator.ValidateAsync(command);
+        if (!validationResult.IsValid)
+        {
+            var problemDetails = CreateValidationProblemDetails(validationResult);
+            return BadRequest(problemDetails);
+        }
+
+        var response = await _mediator.Send(command);
+
+        _logger.LogInformation(
+            "Generated presigned upload URL: StorageKey={StorageKey}, ExpiresAt={ExpiresAt} at {Timestamp}",
+            response.StorageKey,
+            response.ExpiresAt,
+            DateTime.UtcNow);
+
+        return Ok(response);
+    }
+
+    /// <summary>
+    /// Confirm S3 upload and create receipt record (AC-5.1.3).
+    /// </summary>
+    /// <param name="request">Receipt details after S3 upload</param>
+    /// <returns>The newly created receipt's ID</returns>
+    /// <response code="201">Returns the newly created receipt ID</response>
+    /// <response code="400">If validation fails</response>
+    /// <response code="401">If user is not authenticated</response>
+    /// <response code="404">If property not found (when PropertyId provided)</response>
+    [HttpPost]
+    [ProducesResponseType(typeof(CreateReceiptResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateReceipt([FromBody] CreateReceiptRequest request)
+    {
+        var command = new CreateReceiptCommand(
+            request.StorageKey,
+            request.OriginalFileName,
+            request.ContentType,
+            request.FileSizeBytes,
+            request.PropertyId);
+
+        // Validate command
+        var validationResult = await _createValidator.ValidateAsync(command);
+        if (!validationResult.IsValid)
+        {
+            var problemDetails = CreateValidationProblemDetails(validationResult);
+            return BadRequest(problemDetails);
+        }
+
+        var receiptId = await _mediator.Send(command);
+
+        _logger.LogInformation(
+            "Receipt created: {ReceiptId} for StorageKey={StorageKey} at {Timestamp}",
+            receiptId,
+            request.StorageKey,
+            DateTime.UtcNow);
+
+        var response = new CreateReceiptResponse(receiptId);
+
+        return CreatedAtAction(
+            nameof(GetReceipt),
+            new { id = receiptId },
+            response);
+    }
+
+    /// <summary>
+    /// Get a receipt by ID with presigned view URL (AC-5.1.4).
+    /// </summary>
+    /// <param name="id">Receipt GUID</param>
+    /// <returns>Receipt details with presigned view URL</returns>
+    /// <response code="200">Returns the receipt</response>
+    /// <response code="401">If user is not authenticated</response>
+    /// <response code="404">If receipt not found</response>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ReceiptDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetReceipt(Guid id)
+    {
+        var query = new GetReceiptQuery(id);
+        var receipt = await _mediator.Send(query);
+
+        _logger.LogInformation(
+            "Retrieved receipt {ReceiptId} at {Timestamp}",
+            id,
+            DateTime.UtcNow);
+
+        return Ok(receipt);
+    }
+
+    /// <summary>
+    /// Delete a receipt (soft delete) (AC-5.1.7).
+    /// Sets DeletedAt timestamp and optionally removes file from S3.
+    /// </summary>
+    /// <param name="id">Receipt GUID</param>
+    /// <returns>No content on success</returns>
+    /// <response code="204">Receipt deleted successfully</response>
+    /// <response code="401">If user is not authenticated</response>
+    /// <response code="404">If receipt not found</response>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteReceipt(Guid id)
+    {
+        var command = new DeleteReceiptCommand(id);
+        await _mediator.Send(command);
+
+        _logger.LogInformation(
+            "Receipt deleted: {ReceiptId} at {Timestamp}",
+            id,
+            DateTime.UtcNow);
+
+        return NoContent();
+    }
+
+    private ValidationProblemDetails CreateValidationProblemDetails(FluentValidation.Results.ValidationResult validationResult)
+    {
+        var errors = validationResult.Errors
+            .GroupBy(e => e.PropertyName)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(e => e.ErrorMessage).ToArray());
+
+        return new ValidationProblemDetails(errors)
+        {
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+            Title = "One or more validation errors occurred.",
+            Status = StatusCodes.Status400BadRequest,
+            Instance = HttpContext.Request.Path,
+            Extensions = { ["traceId"] = HttpContext.TraceIdentifier }
+        };
+    }
+}
+
+/// <summary>
+/// Request model for generating a presigned upload URL (AC-5.1.1).
+/// </summary>
+public record GenerateUploadUrlRequest(
+    string ContentType,
+    long FileSizeBytes,
+    Guid? PropertyId = null
+);
+
+/// <summary>
+/// Request model for creating a receipt after S3 upload (AC-5.1.3).
+/// </summary>
+public record CreateReceiptRequest(
+    string StorageKey,
+    string OriginalFileName,
+    string ContentType,
+    long FileSizeBytes,
+    Guid? PropertyId = null
+);
+
+/// <summary>
+/// Response model for successful receipt creation.
+/// </summary>
+public record CreateReceiptResponse(
+    Guid Id
+);

--- a/backend/src/PropertyManager.Api/Program.cs
+++ b/backend/src/PropertyManager.Api/Program.cs
@@ -10,6 +10,7 @@ using PropertyManager.Application.Common.Interfaces;
 using PropertyManager.Infrastructure.Email;
 using PropertyManager.Infrastructure.Identity;
 using PropertyManager.Infrastructure.Persistence;
+using PropertyManager.Infrastructure.Storage;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -51,6 +52,11 @@ builder.Services.AddScoped<IEmailService, SmtpEmailService>();
 // Configure Email settings
 builder.Services.Configure<EmailSettings>(
     builder.Configuration.GetSection(EmailSettings.SectionName));
+
+// Configure S3 Storage settings
+builder.Services.Configure<S3StorageSettings>(
+    builder.Configuration.GetSection(S3StorageSettings.SectionName));
+builder.Services.AddScoped<IStorageService, S3StorageService>();
 
 // Configure JWT settings
 builder.Services.Configure<JwtSettings>(

--- a/backend/src/PropertyManager.Application/Common/Interfaces/IStorageService.cs
+++ b/backend/src/PropertyManager.Application/Common/Interfaces/IStorageService.cs
@@ -1,0 +1,48 @@
+namespace PropertyManager.Application.Common.Interfaces;
+
+/// <summary>
+/// Interface for cloud storage operations.
+/// Implementation in Infrastructure layer (S3StorageService).
+/// </summary>
+public interface IStorageService
+{
+    /// <summary>
+    /// Generates a presigned URL for uploading a file directly to storage.
+    /// </summary>
+    /// <param name="storageKey">The storage key (path) where the file will be stored.</param>
+    /// <param name="contentType">The MIME type of the file being uploaded.</param>
+    /// <param name="fileSizeBytes">The size of the file in bytes.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The presigned upload URL and expiration time.</returns>
+    Task<UploadUrlResult> GeneratePresignedUploadUrlAsync(
+        string storageKey,
+        string contentType,
+        long fileSizeBytes,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates a presigned URL for downloading/viewing a file from storage.
+    /// </summary>
+    /// <param name="storageKey">The storage key (path) of the file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The presigned download URL.</returns>
+    Task<string> GeneratePresignedDownloadUrlAsync(
+        string storageKey,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a file from storage.
+    /// </summary>
+    /// <param name="storageKey">The storage key (path) of the file to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteFileAsync(
+        string storageKey,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of generating a presigned upload URL.
+/// </summary>
+/// <param name="Url">The presigned URL for uploading.</param>
+/// <param name="ExpiresAt">When the presigned URL expires.</param>
+public record UploadUrlResult(string Url, DateTime ExpiresAt);

--- a/backend/src/PropertyManager.Application/Receipts/CreateReceipt.cs
+++ b/backend/src/PropertyManager.Application/Receipts/CreateReceipt.cs
@@ -1,0 +1,69 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Receipts;
+
+/// <summary>
+/// Command to confirm S3 upload and create receipt record (AC-5.1.3).
+/// </summary>
+public record CreateReceiptCommand(
+    string StorageKey,
+    string OriginalFileName,
+    string ContentType,
+    long FileSizeBytes,
+    Guid? PropertyId = null
+) : IRequest<Guid>;
+
+/// <summary>
+/// Handler for CreateReceiptCommand.
+/// Creates a receipt record after client has uploaded to S3.
+/// </summary>
+public class CreateReceiptHandler : IRequestHandler<CreateReceiptCommand, Guid>
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly ICurrentUser _currentUser;
+
+    public CreateReceiptHandler(
+        IAppDbContext dbContext,
+        ICurrentUser currentUser)
+    {
+        _dbContext = dbContext;
+        _currentUser = currentUser;
+    }
+
+    public async Task<Guid> Handle(
+        CreateReceiptCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Validate property exists if provided (global query filter handles account isolation)
+        if (request.PropertyId.HasValue)
+        {
+            var propertyExists = await _dbContext.Properties
+                .AnyAsync(p => p.Id == request.PropertyId.Value, cancellationToken);
+
+            if (!propertyExists)
+            {
+                throw new NotFoundException(nameof(Property), request.PropertyId.Value);
+            }
+        }
+
+        var receipt = new Receipt
+        {
+            AccountId = _currentUser.AccountId,
+            StorageKey = request.StorageKey,
+            OriginalFileName = request.OriginalFileName,
+            ContentType = request.ContentType,
+            FileSizeBytes = request.FileSizeBytes,
+            PropertyId = request.PropertyId,
+            CreatedByUserId = _currentUser.UserId
+        };
+
+        _dbContext.Receipts.Add(receipt);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return receipt.Id;
+    }
+}

--- a/backend/src/PropertyManager.Application/Receipts/CreateReceiptValidator.cs
+++ b/backend/src/PropertyManager.Application/Receipts/CreateReceiptValidator.cs
@@ -1,0 +1,38 @@
+using FluentValidation;
+
+namespace PropertyManager.Application.Receipts;
+
+/// <summary>
+/// Validator for CreateReceiptCommand (AC-5.1.3, AC-5.1.6).
+/// </summary>
+public class CreateReceiptValidator : AbstractValidator<CreateReceiptCommand>
+{
+    public CreateReceiptValidator()
+    {
+        RuleFor(x => x.StorageKey)
+            .NotEmpty().WithMessage("Storage key is required")
+            .MaximumLength(500).WithMessage("Storage key must be 500 characters or less");
+
+        RuleFor(x => x.OriginalFileName)
+            .NotEmpty().WithMessage("Original file name is required")
+            .MaximumLength(255).WithMessage("Original file name must be 255 characters or less");
+
+        RuleFor(x => x.ContentType)
+            .NotEmpty().WithMessage("Content type is required")
+            .Must(BeAllowedContentType)
+            .WithMessage($"Content type must be one of: {string.Join(", ", GenerateUploadUrlValidator.AllowedContentTypes)}");
+
+        RuleFor(x => x.FileSizeBytes)
+            .GreaterThan(0).WithMessage("File size must be greater than 0")
+            .LessThanOrEqualTo(GenerateUploadUrlValidator.MaxFileSizeBytes)
+            .WithMessage($"File size must not exceed {GenerateUploadUrlValidator.MaxFileSizeBytes / (1024 * 1024)}MB");
+    }
+
+    private static bool BeAllowedContentType(string contentType)
+    {
+        if (string.IsNullOrEmpty(contentType))
+            return false;
+
+        return GenerateUploadUrlValidator.AllowedContentTypes.Contains(contentType.ToLowerInvariant());
+    }
+}

--- a/backend/src/PropertyManager.Application/Receipts/DeleteReceipt.cs
+++ b/backend/src/PropertyManager.Application/Receipts/DeleteReceipt.cs
@@ -1,0 +1,74 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Receipts;
+
+/// <summary>
+/// Command to soft-delete a receipt (AC-5.1.7).
+/// </summary>
+public record DeleteReceiptCommand(Guid Id) : IRequest<Unit>;
+
+/// <summary>
+/// Handler for DeleteReceiptCommand.
+/// Soft-deletes receipt record and optionally deletes from S3.
+/// Tenant isolation is enforced via global query filter.
+/// </summary>
+public class DeleteReceiptHandler : IRequestHandler<DeleteReceiptCommand, Unit>
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IStorageService _storageService;
+    private readonly ILogger<DeleteReceiptHandler> _logger;
+
+    public DeleteReceiptHandler(
+        IAppDbContext dbContext,
+        IStorageService storageService,
+        ILogger<DeleteReceiptHandler> logger)
+    {
+        _dbContext = dbContext;
+        _storageService = storageService;
+        _logger = logger;
+    }
+
+    public async Task<Unit> Handle(
+        DeleteReceiptCommand request,
+        CancellationToken cancellationToken)
+    {
+        var receipt = await _dbContext.Receipts
+            .FirstOrDefaultAsync(r => r.Id == request.Id, cancellationToken);
+
+        if (receipt == null)
+        {
+            throw new NotFoundException(nameof(Receipt), request.Id);
+        }
+
+        // Soft-delete the receipt
+        receipt.DeletedAt = DateTime.UtcNow;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        // Optionally delete from S3 (fire-and-forget, don't fail if S3 delete fails)
+        try
+        {
+            await _storageService.DeleteFileAsync(receipt.StorageKey, cancellationToken);
+            _logger.LogInformation(
+                "Deleted file {StorageKey} from S3 for receipt {ReceiptId}",
+                receipt.StorageKey,
+                receipt.Id);
+        }
+        catch (Exception ex)
+        {
+            // Log but don't fail - the receipt is already soft-deleted
+            // A cleanup job can retry failed S3 deletions later
+            _logger.LogWarning(ex,
+                "Failed to delete file {StorageKey} from S3 for receipt {ReceiptId}. Will retry in cleanup job.",
+                receipt.StorageKey,
+                receipt.Id);
+        }
+
+        return Unit.Value;
+    }
+}

--- a/backend/src/PropertyManager.Application/Receipts/GenerateUploadUrl.cs
+++ b/backend/src/PropertyManager.Application/Receipts/GenerateUploadUrl.cs
@@ -1,0 +1,75 @@
+using MediatR;
+using PropertyManager.Application.Common.Interfaces;
+
+namespace PropertyManager.Application.Receipts;
+
+/// <summary>
+/// Command to generate a presigned S3 upload URL for receipt upload (AC-5.1.1).
+/// </summary>
+public record GenerateUploadUrlCommand(
+    string ContentType,
+    long FileSizeBytes,
+    Guid? PropertyId = null
+) : IRequest<UploadUrlResponse>;
+
+/// <summary>
+/// Response containing presigned upload URL details (AC-5.1.1).
+/// </summary>
+public record UploadUrlResponse(
+    string UploadUrl,
+    string StorageKey,
+    DateTime ExpiresAt,
+    string HttpMethod
+);
+
+/// <summary>
+/// Handler for GenerateUploadUrlCommand.
+/// Generates a presigned S3 PUT URL for direct client upload.
+/// Storage key format: {accountId}/{year}/{guid}.{extension}
+/// </summary>
+public class GenerateUploadUrlHandler : IRequestHandler<GenerateUploadUrlCommand, UploadUrlResponse>
+{
+    private readonly IStorageService _storageService;
+    private readonly ICurrentUser _currentUser;
+
+    public GenerateUploadUrlHandler(
+        IStorageService storageService,
+        ICurrentUser currentUser)
+    {
+        _storageService = storageService;
+        _currentUser = currentUser;
+    }
+
+    public async Task<UploadUrlResponse> Handle(
+        GenerateUploadUrlCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Generate storage key: {accountId}/{year}/{guid}.{extension}
+        var extension = GetExtensionFromContentType(request.ContentType);
+        var storageKey = $"{_currentUser.AccountId}/{DateTime.UtcNow.Year}/{Guid.NewGuid()}.{extension}";
+
+        var result = await _storageService.GeneratePresignedUploadUrlAsync(
+            storageKey,
+            request.ContentType,
+            request.FileSizeBytes,
+            cancellationToken);
+
+        return new UploadUrlResponse(
+            UploadUrl: result.Url,
+            StorageKey: storageKey,
+            ExpiresAt: result.ExpiresAt,
+            HttpMethod: "PUT"
+        );
+    }
+
+    private static string GetExtensionFromContentType(string contentType)
+    {
+        return contentType.ToLowerInvariant() switch
+        {
+            "image/jpeg" => "jpg",
+            "image/png" => "png",
+            "application/pdf" => "pdf",
+            _ => "bin" // Fallback, but validator should prevent this
+        };
+    }
+}

--- a/backend/src/PropertyManager.Application/Receipts/GenerateUploadUrlValidator.cs
+++ b/backend/src/PropertyManager.Application/Receipts/GenerateUploadUrlValidator.cs
@@ -1,0 +1,46 @@
+using FluentValidation;
+
+namespace PropertyManager.Application.Receipts;
+
+/// <summary>
+/// Validator for GenerateUploadUrlCommand (AC-5.1.6).
+/// Validates content type and file size before generating upload URL.
+/// </summary>
+public class GenerateUploadUrlValidator : AbstractValidator<GenerateUploadUrlCommand>
+{
+    /// <summary>
+    /// Allowed content types for receipt uploads.
+    /// </summary>
+    public static readonly string[] AllowedContentTypes =
+    [
+        "image/jpeg",
+        "image/png",
+        "application/pdf"
+    ];
+
+    /// <summary>
+    /// Maximum file size in bytes (10MB).
+    /// </summary>
+    public const long MaxFileSizeBytes = 10 * 1024 * 1024; // 10MB
+
+    public GenerateUploadUrlValidator()
+    {
+        RuleFor(x => x.ContentType)
+            .NotEmpty().WithMessage("Content type is required")
+            .Must(BeAllowedContentType)
+            .WithMessage($"Content type must be one of: {string.Join(", ", AllowedContentTypes)}");
+
+        RuleFor(x => x.FileSizeBytes)
+            .GreaterThan(0).WithMessage("File size must be greater than 0")
+            .LessThanOrEqualTo(MaxFileSizeBytes)
+            .WithMessage($"File size must not exceed {MaxFileSizeBytes / (1024 * 1024)}MB");
+    }
+
+    private static bool BeAllowedContentType(string contentType)
+    {
+        if (string.IsNullOrEmpty(contentType))
+            return false;
+
+        return AllowedContentTypes.Contains(contentType.ToLowerInvariant());
+    }
+}

--- a/backend/src/PropertyManager.Application/Receipts/GetReceipt.cs
+++ b/backend/src/PropertyManager.Application/Receipts/GetReceipt.cs
@@ -1,0 +1,76 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Receipts;
+
+/// <summary>
+/// Query to get a receipt by ID with presigned view URL (AC-5.1.4).
+/// </summary>
+public record GetReceiptQuery(Guid Id) : IRequest<ReceiptDto>;
+
+/// <summary>
+/// DTO for receipt details including presigned view URL.
+/// </summary>
+public record ReceiptDto(
+    Guid Id,
+    string OriginalFileName,
+    string ContentType,
+    long FileSizeBytes,
+    Guid? PropertyId,
+    Guid? ExpenseId,
+    DateTime CreatedAt,
+    DateTime? ProcessedAt,
+    string ViewUrl
+);
+
+/// <summary>
+/// Handler for GetReceiptQuery.
+/// Returns receipt details with a presigned download URL.
+/// Tenant isolation is enforced via global query filter.
+/// </summary>
+public class GetReceiptHandler : IRequestHandler<GetReceiptQuery, ReceiptDto>
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IStorageService _storageService;
+
+    public GetReceiptHandler(
+        IAppDbContext dbContext,
+        IStorageService storageService)
+    {
+        _dbContext = dbContext;
+        _storageService = storageService;
+    }
+
+    public async Task<ReceiptDto> Handle(
+        GetReceiptQuery request,
+        CancellationToken cancellationToken)
+    {
+        var receipt = await _dbContext.Receipts
+            .FirstOrDefaultAsync(r => r.Id == request.Id, cancellationToken);
+
+        if (receipt == null)
+        {
+            throw new NotFoundException(nameof(Receipt), request.Id);
+        }
+
+        // Generate presigned download URL
+        var viewUrl = await _storageService.GeneratePresignedDownloadUrlAsync(
+            receipt.StorageKey,
+            cancellationToken);
+
+        return new ReceiptDto(
+            Id: receipt.Id,
+            OriginalFileName: receipt.OriginalFileName ?? string.Empty,
+            ContentType: receipt.ContentType ?? string.Empty,
+            FileSizeBytes: receipt.FileSizeBytes ?? 0,
+            PropertyId: receipt.PropertyId,
+            ExpenseId: receipt.ExpenseId,
+            CreatedAt: receipt.CreatedAt,
+            ProcessedAt: receipt.ProcessedAt,
+            ViewUrl: viewUrl
+        );
+    }
+}

--- a/backend/src/PropertyManager.Infrastructure/PropertyManager.Infrastructure.csproj
+++ b/backend/src/PropertyManager.Infrastructure/PropertyManager.Infrastructure.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="4.0.16.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />

--- a/backend/src/PropertyManager.Infrastructure/Storage/S3StorageService.cs
+++ b/backend/src/PropertyManager.Infrastructure/Storage/S3StorageService.cs
@@ -1,0 +1,137 @@
+using Amazon;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using PropertyManager.Application.Common.Interfaces;
+
+namespace PropertyManager.Infrastructure.Storage;
+
+/// <summary>
+/// AWS S3 implementation of IStorageService.
+/// Generates presigned URLs for direct client-to-S3 uploads and downloads.
+/// </summary>
+public class S3StorageService : IStorageService
+{
+    private readonly IAmazonS3 _s3Client;
+    private readonly S3StorageSettings _settings;
+    private readonly ILogger<S3StorageService> _logger;
+
+    public S3StorageService(
+        IOptions<S3StorageSettings> settings,
+        ILogger<S3StorageService> logger)
+    {
+        _settings = settings.Value;
+        _logger = logger;
+
+        var config = new AmazonS3Config
+        {
+            RegionEndpoint = RegionEndpoint.GetBySystemName(_settings.Region)
+        };
+
+        _s3Client = new AmazonS3Client(
+            _settings.AccessKeyId,
+            _settings.SecretAccessKey,
+            config);
+    }
+
+    /// <inheritdoc />
+    public Task<UploadUrlResult> GeneratePresignedUploadUrlAsync(
+        string storageKey,
+        string contentType,
+        long fileSizeBytes,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var expiresAt = DateTime.UtcNow.AddMinutes(_settings.PresignedUrlExpiryMinutes);
+            var request = new GetPreSignedUrlRequest
+            {
+                BucketName = _settings.BucketName,
+                Key = storageKey,
+                Verb = HttpVerb.PUT,
+                ContentType = contentType,
+                Expires = expiresAt
+            };
+
+            var url = _s3Client.GetPreSignedURL(request);
+
+            _logger.LogInformation(
+                "Generated presigned upload URL for key {StorageKey}, expires at {ExpiresAt}",
+                storageKey,
+                expiresAt);
+
+            return Task.FromResult(new UploadUrlResult(url, expiresAt));
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to generate presigned upload URL for key {StorageKey}",
+                storageKey);
+            throw new InvalidOperationException(
+                $"Failed to generate upload URL: {ex.Message}", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<string> GeneratePresignedDownloadUrlAsync(
+        string storageKey,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = new GetPreSignedUrlRequest
+            {
+                BucketName = _settings.BucketName,
+                Key = storageKey,
+                Verb = HttpVerb.GET,
+                Expires = DateTime.UtcNow.AddMinutes(_settings.PresignedUrlExpiryMinutes)
+            };
+
+            var url = _s3Client.GetPreSignedURL(request);
+
+            _logger.LogInformation(
+                "Generated presigned download URL for key {StorageKey}",
+                storageKey);
+
+            return Task.FromResult(url);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to generate presigned download URL for key {StorageKey}",
+                storageKey);
+            throw new InvalidOperationException(
+                $"Failed to generate download URL: {ex.Message}", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteFileAsync(
+        string storageKey,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = new DeleteObjectRequest
+            {
+                BucketName = _settings.BucketName,
+                Key = storageKey
+            };
+
+            await _s3Client.DeleteObjectAsync(request, cancellationToken);
+
+            _logger.LogInformation(
+                "Deleted file with key {StorageKey} from S3",
+                storageKey);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to delete file with key {StorageKey} from S3",
+                storageKey);
+            throw new InvalidOperationException(
+                $"Failed to delete file: {ex.Message}", ex);
+        }
+    }
+}

--- a/backend/src/PropertyManager.Infrastructure/Storage/S3StorageSettings.cs
+++ b/backend/src/PropertyManager.Infrastructure/Storage/S3StorageSettings.cs
@@ -1,0 +1,36 @@
+namespace PropertyManager.Infrastructure.Storage;
+
+/// <summary>
+/// Configuration settings for AWS S3 storage.
+/// Bound from appsettings.json "AWS" section.
+/// </summary>
+public class S3StorageSettings
+{
+    public const string SectionName = "AWS";
+
+    /// <summary>
+    /// AWS access key ID for S3 operations.
+    /// </summary>
+    public string AccessKeyId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// AWS secret access key for S3 operations.
+    /// </summary>
+    public string SecretAccessKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The S3 bucket name for receipt storage.
+    /// </summary>
+    public string BucketName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// AWS region for the S3 bucket (e.g., "us-east-1").
+    /// </summary>
+    public string Region { get; set; } = "us-east-1";
+
+    /// <summary>
+    /// Duration in minutes for presigned URL validity.
+    /// Default is 60 minutes.
+    /// </summary>
+    public int PresignedUrlExpiryMinutes { get; set; } = 60;
+}

--- a/backend/tests/PropertyManager.Api.Tests/ReceiptsControllerTests.cs
+++ b/backend/tests/PropertyManager.Api.Tests/ReceiptsControllerTests.cs
@@ -1,0 +1,429 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using PropertyManager.Infrastructure.Persistence;
+
+namespace PropertyManager.Api.Tests;
+
+/// <summary>
+/// Integration tests for ReceiptsController (AC-5.1.1 through AC-5.1.7).
+/// </summary>
+public class ReceiptsControllerTests : IClassFixture<PropertyManagerWebApplicationFactory>
+{
+    private readonly PropertyManagerWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public ReceiptsControllerTests(PropertyManagerWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    #region POST /api/v1/receipts/upload-url Tests
+
+    [Fact]
+    public async Task GenerateUploadUrl_WithoutAuth_Returns401()
+    {
+        // Arrange
+        var request = new
+        {
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024
+        };
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/v1/receipts/upload-url", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GenerateUploadUrl_WithValidRequest_Returns200WithPresignedUrl()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+
+        var request = new
+        {
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024
+        };
+
+        // Act
+        var response = await PostAsJsonWithAuthAsync("/api/v1/receipts/upload-url", request, accessToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadFromJsonAsync<ReceiptsUploadUrlResponse>();
+        content.Should().NotBeNull();
+        content!.UploadUrl.Should().StartWith("https://");
+        content.StorageKey.Should().NotBeNullOrEmpty();
+        content.HttpMethod.Should().Be("PUT");
+        content.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task GenerateUploadUrl_WithInvalidContentType_Returns400()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+
+        var request = new
+        {
+            ContentType = "image/gif", // Not allowed
+            FileSizeBytes = 1024 * 1024
+        };
+
+        // Act
+        var response = await PostAsJsonWithAuthAsync("/api/v1/receipts/upload-url", request, accessToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("ContentType");
+    }
+
+    [Fact]
+    public async Task GenerateUploadUrl_WithFileSizeOver10MB_Returns400()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+
+        var request = new
+        {
+            ContentType = "image/jpeg",
+            FileSizeBytes = (10 * 1024 * 1024) + 1 // 10MB + 1 byte
+        };
+
+        // Act
+        var response = await PostAsJsonWithAuthAsync("/api/v1/receipts/upload-url", request, accessToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("FileSizeBytes");
+    }
+
+    #endregion
+
+    #region POST /api/v1/receipts Tests
+
+    [Fact]
+    public async Task CreateReceipt_WithoutAuth_Returns401()
+    {
+        // Arrange
+        var request = new
+        {
+            StorageKey = "test-account/2025/test.jpg",
+            OriginalFileName = "receipt.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024
+        };
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/v1/receipts", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CreateReceipt_WithValidRequest_Returns201WithId()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+
+        var request = new
+        {
+            StorageKey = $"{Guid.NewGuid()}/2025/{Guid.NewGuid()}.jpg",
+            OriginalFileName = "receipt.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024
+        };
+
+        // Act
+        var response = await PostAsJsonWithAuthAsync("/api/v1/receipts", request, accessToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var content = await response.Content.ReadFromJsonAsync<ReceiptsCreateResponse>();
+        content.Should().NotBeNull();
+        content!.Id.Should().NotBe(Guid.Empty);
+
+        // Verify Location header is present
+        response.Headers.Location.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateReceipt_WithMissingStorageKey_Returns400()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+
+        var request = new
+        {
+            StorageKey = "",
+            OriginalFileName = "receipt.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024
+        };
+
+        // Act
+        var response = await PostAsJsonWithAuthAsync("/api/v1/receipts", request, accessToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("StorageKey");
+    }
+
+    #endregion
+
+    #region GET /api/v1/receipts/{id} Tests
+
+    [Fact]
+    public async Task GetReceipt_WithoutAuth_Returns401()
+    {
+        // Act
+        var response = await _client.GetAsync($"/api/v1/receipts/{Guid.NewGuid()}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetReceipt_WithValidId_Returns200WithViewUrl()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+
+        // First create a receipt
+        var createRequest = new
+        {
+            StorageKey = $"{Guid.NewGuid()}/2025/{Guid.NewGuid()}.jpg",
+            OriginalFileName = "receipt.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024
+        };
+
+        var createResponse = await PostAsJsonWithAuthAsync("/api/v1/receipts", createRequest, accessToken);
+        var createContent = await createResponse.Content.ReadFromJsonAsync<ReceiptsCreateResponse>();
+
+        // Act
+        var response = await GetWithAuthAsync($"/api/v1/receipts/{createContent!.Id}", accessToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadFromJsonAsync<ReceiptsDetailDto>();
+        content.Should().NotBeNull();
+        content!.Id.Should().Be(createContent.Id);
+        content.OriginalFileName.Should().Be("receipt.jpg");
+        content.ContentType.Should().Be("image/jpeg");
+        content.ViewUrl.Should().StartWith("https://");
+    }
+
+    [Fact]
+    public async Task GetReceipt_WithNonExistentId_Returns404()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+
+        // Act
+        var response = await GetWithAuthAsync($"/api/v1/receipts/{Guid.NewGuid()}", accessToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    #endregion
+
+    #region DELETE /api/v1/receipts/{id} Tests
+
+    [Fact]
+    public async Task DeleteReceipt_WithoutAuth_Returns401()
+    {
+        // Act
+        var response = await _client.DeleteAsync($"/api/v1/receipts/{Guid.NewGuid()}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task DeleteReceipt_WithValidId_Returns204()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+
+        // First create a receipt
+        var createRequest = new
+        {
+            StorageKey = $"{Guid.NewGuid()}/2025/{Guid.NewGuid()}.jpg",
+            OriginalFileName = "receipt.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024
+        };
+
+        var createResponse = await PostAsJsonWithAuthAsync("/api/v1/receipts", createRequest, accessToken);
+        var createContent = await createResponse.Content.ReadFromJsonAsync<ReceiptsCreateResponse>();
+
+        // Act
+        var response = await DeleteWithAuthAsync($"/api/v1/receipts/{createContent!.Id}", accessToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Verify the receipt is no longer accessible
+        var getResponse = await GetWithAuthAsync($"/api/v1/receipts/{createContent.Id}", accessToken);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteReceipt_WithNonExistentId_Returns404()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+
+        // Act
+        var response = await DeleteWithAuthAsync($"/api/v1/receipts/{Guid.NewGuid()}", accessToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    #endregion
+
+    #region Account Isolation Tests
+
+    [Fact]
+    public async Task GetReceipt_FromDifferentAccount_Returns404()
+    {
+        // Arrange - Create a receipt with first user
+        var email1 = $"user1-isolation-{Guid.NewGuid():N}@test.com";
+        var (accessToken1, _) = await RegisterAndLoginAsync(email1);
+
+        var createRequest = new
+        {
+            StorageKey = $"{Guid.NewGuid()}/2025/{Guid.NewGuid()}.jpg",
+            OriginalFileName = "receipt.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024
+        };
+
+        var createResponse = await PostAsJsonWithAuthAsync("/api/v1/receipts", createRequest, accessToken1);
+        var createContent = await createResponse.Content.ReadFromJsonAsync<ReceiptsCreateResponse>();
+
+        // Create a second user and try to access the receipt
+        var email2 = $"user2-isolation-{Guid.NewGuid():N}@test.com";
+        var (accessToken2, _) = await RegisterAndLoginAsync(email2);
+
+        // Act - Try to get the receipt created by user1 using user2's token
+        var response = await GetWithAuthAsync($"/api/v1/receipts/{createContent!.Id}", accessToken2);
+
+        // Assert - Should return 404 due to account isolation
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task<string> GetAccessTokenAsync()
+    {
+        var email = $"test-{Guid.NewGuid():N}@example.com";
+        var (accessToken, _) = await RegisterAndLoginAsync(email);
+        return accessToken;
+    }
+
+    private async Task<(string AccessToken, Guid UserId)> RegisterAndLoginAsync(string email)
+    {
+        var password = "Test@123456";
+
+        // Create user directly in database (bypasses removed registration endpoint)
+        var (userId, _) = await _factory.CreateTestUserAsync(email, password);
+
+        // Login
+        var loginRequest = new { Email = email, Password = password };
+        var loginResponse = await _client.PostAsJsonAsync("/api/v1/auth/login", loginRequest);
+        loginResponse.EnsureSuccessStatusCode();
+
+        var loginContent = await loginResponse.Content.ReadFromJsonAsync<ReceiptsLoginResponse>();
+        return (loginContent!.AccessToken, userId);
+    }
+
+    private async Task<string> GetAccessTokenForUserAsync(string email, Guid accountId)
+    {
+        var password = "Test@123456";
+
+        var loginResponse = await _client.PostAsJsonAsync("/api/v1/auth/login", new { Email = email, Password = password });
+        loginResponse.EnsureSuccessStatusCode();
+        var loginContent = await loginResponse.Content.ReadFromJsonAsync<ReceiptsLoginResponse>();
+
+        return loginContent!.AccessToken;
+    }
+
+    private async Task<HttpResponseMessage> PostAsJsonWithAuthAsync<T>(string url, T content, string accessToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(content)
+        };
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+
+        return await _client.SendAsync(request);
+    }
+
+    private async Task<HttpResponseMessage> GetWithAuthAsync(string url, string accessToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+
+        return await _client.SendAsync(request);
+    }
+
+    private async Task<HttpResponseMessage> DeleteWithAuthAsync(string url, string accessToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+
+        return await _client.SendAsync(request);
+    }
+
+    #endregion
+}
+
+#region Response Types
+
+public record ReceiptsUploadUrlResponse(
+    string UploadUrl,
+    string StorageKey,
+    DateTime ExpiresAt,
+    string HttpMethod
+);
+
+public record ReceiptsCreateResponse(Guid Id);
+
+public record ReceiptsDetailDto(
+    Guid Id,
+    string OriginalFileName,
+    string ContentType,
+    long FileSizeBytes,
+    Guid? PropertyId,
+    Guid? ExpenseId,
+    DateTime CreatedAt,
+    DateTime? ProcessedAt,
+    string ViewUrl
+);
+
+public record ReceiptsLoginResponse(string AccessToken, int ExpiresIn);
+
+#endregion

--- a/backend/tests/PropertyManager.Application.Tests/Receipts/CreateReceiptHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Receipts/CreateReceiptHandlerTests.cs
@@ -1,0 +1,184 @@
+using FluentAssertions;
+using MockQueryable.Moq;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.Receipts;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.Receipts;
+
+/// <summary>
+/// Unit tests for CreateReceiptHandler (AC-5.1.3).
+/// </summary>
+public class CreateReceiptHandlerTests
+{
+    private readonly Mock<IAppDbContext> _dbContextMock;
+    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly CreateReceiptHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+    private readonly Guid _testUserId = Guid.NewGuid();
+    private readonly Guid _testPropertyId = Guid.NewGuid();
+
+    public CreateReceiptHandlerTests()
+    {
+        _dbContextMock = new Mock<IAppDbContext>();
+        _currentUserMock = new Mock<ICurrentUser>();
+
+        _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
+        _currentUserMock.Setup(x => x.UserId).Returns(_testUserId);
+
+        // Setup receipts DbSet for Add operations
+        var receipts = new List<Receipt>();
+        var mockReceiptsDbSet = receipts.AsQueryable().BuildMockDbSet();
+        mockReceiptsDbSet.Setup(x => x.Add(It.IsAny<Receipt>()))
+            .Callback<Receipt>(r =>
+            {
+                // Simulate EF Core generating an ID on Add
+                r.Id = Guid.NewGuid();
+                receipts.Add(r);
+            });
+        _dbContextMock.Setup(x => x.Receipts).Returns(mockReceiptsDbSet.Object);
+        _dbContextMock.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new CreateReceiptHandler(
+            _dbContextMock.Object,
+            _currentUserMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequestWithoutPropertyId_CreatesReceipt()
+    {
+        // Arrange
+        var command = new CreateReceiptCommand(
+            StorageKey: $"{_testAccountId}/2025/test-guid.jpg",
+            OriginalFileName: "receipt.jpg",
+            ContentType: "image/jpeg",
+            FileSizeBytes: 1024 * 1024,
+            PropertyId: null);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeEmpty();
+        _dbContextMock.Verify(x => x.Receipts.Add(It.Is<Receipt>(r =>
+            r.StorageKey == command.StorageKey &&
+            r.OriginalFileName == command.OriginalFileName &&
+            r.ContentType == command.ContentType &&
+            r.FileSizeBytes == command.FileSizeBytes &&
+            r.AccountId == _testAccountId &&
+            r.CreatedByUserId == _testUserId &&
+            r.PropertyId == null)), Times.Once);
+        _dbContextMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequestWithPropertyId_CreatesReceipt()
+    {
+        // Arrange
+        SetupPropertiesDbSet(new List<Property>
+        {
+            new Property
+            {
+                Id = _testPropertyId,
+                AccountId = _testAccountId,
+                Name = "Test Property",
+                Street = "123 Test St",
+                City = "Austin",
+                State = "TX",
+                ZipCode = "78701"
+            }
+        });
+
+        var command = new CreateReceiptCommand(
+            StorageKey: $"{_testAccountId}/2025/test-guid.jpg",
+            OriginalFileName: "receipt.jpg",
+            ContentType: "image/jpeg",
+            FileSizeBytes: 1024 * 1024,
+            PropertyId: _testPropertyId);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeEmpty();
+        _dbContextMock.Verify(x => x.Receipts.Add(It.Is<Receipt>(r =>
+            r.PropertyId == _testPropertyId)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_PropertyNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        SetupPropertiesDbSet(new List<Property>());
+
+        var nonExistentPropertyId = Guid.NewGuid();
+        var command = new CreateReceiptCommand(
+            StorageKey: $"{_testAccountId}/2025/test-guid.jpg",
+            OriginalFileName: "receipt.jpg",
+            ContentType: "image/jpeg",
+            FileSizeBytes: 1024 * 1024,
+            PropertyId: nonExistentPropertyId);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"*{nonExistentPropertyId}*");
+    }
+
+    [Fact]
+    public async Task Handle_SetsCorrectAccountId()
+    {
+        // Arrange
+        Receipt? addedReceipt = null;
+        _dbContextMock.Setup(x => x.Receipts.Add(It.IsAny<Receipt>()))
+            .Callback<Receipt>(r => addedReceipt = r);
+
+        var command = new CreateReceiptCommand(
+            StorageKey: $"{_testAccountId}/2025/test-guid.jpg",
+            OriginalFileName: "receipt.jpg",
+            ContentType: "image/jpeg",
+            FileSizeBytes: 1024 * 1024,
+            PropertyId: null);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        addedReceipt.Should().NotBeNull();
+        addedReceipt!.AccountId.Should().Be(_testAccountId);
+    }
+
+    [Fact]
+    public async Task Handle_SetsCorrectCreatedByUserId()
+    {
+        // Arrange
+        Receipt? addedReceipt = null;
+        _dbContextMock.Setup(x => x.Receipts.Add(It.IsAny<Receipt>()))
+            .Callback<Receipt>(r => addedReceipt = r);
+
+        var command = new CreateReceiptCommand(
+            StorageKey: $"{_testAccountId}/2025/test-guid.jpg",
+            OriginalFileName: "receipt.jpg",
+            ContentType: "image/jpeg",
+            FileSizeBytes: 1024 * 1024,
+            PropertyId: null);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        addedReceipt.Should().NotBeNull();
+        addedReceipt!.CreatedByUserId.Should().Be(_testUserId);
+    }
+
+    private void SetupPropertiesDbSet(List<Property> properties)
+    {
+        var mockDbSet = properties.AsQueryable().BuildMockDbSet();
+        _dbContextMock.Setup(x => x.Properties).Returns(mockDbSet.Object);
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/Receipts/DeleteReceiptHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Receipts/DeleteReceiptHandlerTests.cs
@@ -1,0 +1,187 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using MockQueryable.Moq;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.Receipts;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.Receipts;
+
+/// <summary>
+/// Unit tests for DeleteReceiptHandler (AC-5.1.7).
+/// </summary>
+public class DeleteReceiptHandlerTests
+{
+    private readonly Mock<IAppDbContext> _dbContextMock;
+    private readonly Mock<IStorageService> _storageServiceMock;
+    private readonly Mock<ILogger<DeleteReceiptHandler>> _loggerMock;
+    private readonly DeleteReceiptHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+    private readonly Guid _testUserId = Guid.NewGuid();
+
+    public DeleteReceiptHandlerTests()
+    {
+        _dbContextMock = new Mock<IAppDbContext>();
+        _storageServiceMock = new Mock<IStorageService>();
+        _loggerMock = new Mock<ILogger<DeleteReceiptHandler>>();
+
+        _dbContextMock.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new DeleteReceiptHandler(
+            _dbContextMock.Object,
+            _storageServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidId_SoftDeletesReceipt()
+    {
+        // Arrange
+        var receipt = CreateTestReceipt();
+        SetupReceiptsDbSet(new List<Receipt> { receipt });
+        _storageServiceMock
+            .Setup(x => x.DeleteFileAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var command = new DeleteReceiptCommand(receipt.Id);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        receipt.DeletedAt.Should().NotBeNull();
+        receipt.DeletedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        _dbContextMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidId_DeletesFileFromS3()
+    {
+        // Arrange
+        var receipt = CreateTestReceipt();
+        SetupReceiptsDbSet(new List<Receipt> { receipt });
+        _storageServiceMock
+            .Setup(x => x.DeleteFileAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var command = new DeleteReceiptCommand(receipt.Id);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _storageServiceMock.Verify(x => x.DeleteFileAsync(
+            receipt.StorageKey,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_S3DeleteFails_StillSoftDeletesReceipt()
+    {
+        // Arrange
+        var receipt = CreateTestReceipt();
+        SetupReceiptsDbSet(new List<Receipt> { receipt });
+        _storageServiceMock
+            .Setup(x => x.DeleteFileAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("S3 error"));
+
+        var command = new DeleteReceiptCommand(receipt.Id);
+
+        // Act - should not throw despite S3 failure
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert - receipt should still be soft-deleted
+        receipt.DeletedAt.Should().NotBeNull();
+        _dbContextMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        SetupReceiptsDbSet(new List<Receipt>());
+
+        var nonExistentId = Guid.NewGuid();
+        var command = new DeleteReceiptCommand(nonExistentId);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"*{nonExistentId}*");
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyDeletedReceipt_ThrowsNotFoundException()
+    {
+        // Arrange
+        var deletedReceipt = CreateTestReceipt();
+        deletedReceipt.DeletedAt = DateTime.UtcNow.AddDays(-1);
+        SetupReceiptsDbSet(new List<Receipt> { deletedReceipt });
+
+        var command = new DeleteReceiptCommand(deletedReceipt.Id);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_EnforcesTenantIsolation()
+    {
+        // Arrange - with global query filter, other account receipts not visible
+        SetupReceiptsDbSet(new List<Receipt>());
+
+        var otherAccountReceiptId = Guid.NewGuid();
+        var command = new DeleteReceiptCommand(otherAccountReceiptId);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    private Receipt CreateTestReceipt()
+    {
+        return new Receipt
+        {
+            Id = Guid.NewGuid(),
+            AccountId = _testAccountId,
+            StorageKey = $"{_testAccountId}/2025/test-guid.jpg",
+            OriginalFileName = "receipt.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024,
+            PropertyId = null,
+            ExpenseId = null,
+            CreatedByUserId = _testUserId,
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1),
+            ProcessedAt = null,
+            DeletedAt = null
+        };
+    }
+
+    private void SetupReceiptsDbSet(List<Receipt> receipts)
+    {
+        // Filter to simulate global query filter (soft delete)
+        var filteredReceipts = receipts
+            .Where(r => r.DeletedAt == null)
+            .ToList();
+
+        var mockDbSet = filteredReceipts.AsQueryable().BuildMockDbSet();
+        _dbContextMock.Setup(x => x.Receipts).Returns(mockDbSet.Object);
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/Receipts/GenerateUploadUrlHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Receipts/GenerateUploadUrlHandlerTests.cs
@@ -1,0 +1,165 @@
+using FluentAssertions;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.Receipts;
+
+namespace PropertyManager.Application.Tests.Receipts;
+
+/// <summary>
+/// Unit tests for GenerateUploadUrlHandler (AC-5.1.1).
+/// </summary>
+public class GenerateUploadUrlHandlerTests
+{
+    private readonly Mock<IStorageService> _storageServiceMock;
+    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly GenerateUploadUrlHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+    private readonly Guid _testUserId = Guid.NewGuid();
+
+    public GenerateUploadUrlHandlerTests()
+    {
+        _storageServiceMock = new Mock<IStorageService>();
+        _currentUserMock = new Mock<ICurrentUser>();
+
+        _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
+        _currentUserMock.Setup(x => x.UserId).Returns(_testUserId);
+
+        _handler = new GenerateUploadUrlHandler(
+            _storageServiceMock.Object,
+            _currentUserMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_GeneratesPresignedUrl()
+    {
+        // Arrange
+        var expiresAt = DateTime.UtcNow.AddMinutes(60);
+        var presignedUrl = "https://bucket.s3.amazonaws.com/presigned-url";
+
+        _storageServiceMock
+            .Setup(x => x.GeneratePresignedUploadUrlAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UploadUrlResult(presignedUrl, expiresAt));
+
+        var command = new GenerateUploadUrlCommand("image/jpeg", 1024 * 1024, null);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.UploadUrl.Should().Be(presignedUrl);
+        result.ExpiresAt.Should().Be(expiresAt);
+        result.HttpMethod.Should().Be("PUT");
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_IncludesCorrectStorageKeyFormat()
+    {
+        // Arrange
+        var expiresAt = DateTime.UtcNow.AddMinutes(60);
+        string? capturedStorageKey = null;
+
+        _storageServiceMock
+            .Setup(x => x.GeneratePresignedUploadUrlAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, long, CancellationToken>((key, _, _, _) => capturedStorageKey = key)
+            .ReturnsAsync(new UploadUrlResult("https://example.com", expiresAt));
+
+        var command = new GenerateUploadUrlCommand("image/jpeg", 1024 * 1024, null);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert - Storage key format: {accountId}/{year}/{guid}.{extension}
+        capturedStorageKey.Should().NotBeNullOrEmpty();
+        capturedStorageKey.Should().StartWith($"{_testAccountId}/{DateTime.UtcNow.Year}/");
+        capturedStorageKey.Should().EndWith(".jpg");
+        result.StorageKey.Should().Be(capturedStorageKey);
+    }
+
+    [Theory]
+    [InlineData("image/jpeg", ".jpg")]
+    [InlineData("image/png", ".png")]
+    [InlineData("application/pdf", ".pdf")]
+    public async Task Handle_DifferentContentTypes_GeneratesCorrectExtension(string contentType, string expectedExtension)
+    {
+        // Arrange
+        var expiresAt = DateTime.UtcNow.AddMinutes(60);
+
+        _storageServiceMock
+            .Setup(x => x.GeneratePresignedUploadUrlAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UploadUrlResult("https://example.com", expiresAt));
+
+        var command = new GenerateUploadUrlCommand(contentType, 1024 * 1024, null);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.StorageKey.Should().EndWith(expectedExtension);
+    }
+
+    [Fact]
+    public async Task Handle_CallsStorageServiceWithCorrectParameters()
+    {
+        // Arrange
+        var expiresAt = DateTime.UtcNow.AddMinutes(60);
+        var contentType = "image/jpeg";
+        var fileSizeBytes = 2048576L;
+
+        _storageServiceMock
+            .Setup(x => x.GeneratePresignedUploadUrlAsync(
+                It.IsAny<string>(),
+                contentType,
+                fileSizeBytes,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UploadUrlResult("https://example.com", expiresAt));
+
+        var command = new GenerateUploadUrlCommand(contentType, fileSizeBytes, null);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _storageServiceMock.Verify(x => x.GeneratePresignedUploadUrlAsync(
+            It.IsAny<string>(),
+            contentType,
+            fileSizeBytes,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsUniqueStorageKeyEachTime()
+    {
+        // Arrange
+        var expiresAt = DateTime.UtcNow.AddMinutes(60);
+
+        _storageServiceMock
+            .Setup(x => x.GeneratePresignedUploadUrlAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UploadUrlResult("https://example.com", expiresAt));
+
+        var command = new GenerateUploadUrlCommand("image/jpeg", 1024 * 1024, null);
+
+        // Act
+        var result1 = await _handler.Handle(command, CancellationToken.None);
+        var result2 = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result1.StorageKey.Should().NotBe(result2.StorageKey);
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/Receipts/GenerateUploadUrlValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Receipts/GenerateUploadUrlValidatorTests.cs
@@ -1,0 +1,158 @@
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using PropertyManager.Application.Receipts;
+
+namespace PropertyManager.Application.Tests.Receipts;
+
+/// <summary>
+/// Unit tests for GenerateUploadUrlValidator (AC-5.1.6).
+/// </summary>
+public class GenerateUploadUrlValidatorTests
+{
+    private readonly GenerateUploadUrlValidator _validator;
+
+    public GenerateUploadUrlValidatorTests()
+    {
+        _validator = new GenerateUploadUrlValidator();
+    }
+
+    [Fact]
+    public void Validate_ValidJpegRequest_PassesValidation()
+    {
+        // Arrange
+        var command = new GenerateUploadUrlCommand("image/jpeg", 1024 * 1024, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ValidPngRequest_PassesValidation()
+    {
+        // Arrange
+        var command = new GenerateUploadUrlCommand("image/png", 1024 * 1024, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ValidPdfRequest_PassesValidation()
+    {
+        // Arrange
+        var command = new GenerateUploadUrlCommand("application/pdf", 1024 * 1024, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData("image/gif")]
+    [InlineData("image/webp")]
+    [InlineData("text/plain")]
+    [InlineData("application/json")]
+    [InlineData("video/mp4")]
+    public void Validate_InvalidContentType_FailsValidation(string invalidContentType)
+    {
+        // Arrange
+        var command = new GenerateUploadUrlCommand(invalidContentType, 1024 * 1024, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.ContentType)
+            .WithErrorMessage($"Content type must be one of: {string.Join(", ", GenerateUploadUrlValidator.AllowedContentTypes)}");
+    }
+
+    [Fact]
+    public void Validate_EmptyContentType_FailsValidation()
+    {
+        // Arrange
+        var command = new GenerateUploadUrlCommand("", 1024 * 1024, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.ContentType);
+    }
+
+    [Fact]
+    public void Validate_FileSizeExceeds10MB_FailsValidation()
+    {
+        // Arrange
+        var tenMBPlusOne = (10 * 1024 * 1024) + 1;
+        var command = new GenerateUploadUrlCommand("image/jpeg", tenMBPlusOne, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.FileSizeBytes)
+            .WithErrorMessage("File size must not exceed 10MB");
+    }
+
+    [Fact]
+    public void Validate_FileSizeExactly10MB_PassesValidation()
+    {
+        // Arrange
+        var tenMB = 10 * 1024 * 1024;
+        var command = new GenerateUploadUrlCommand("image/jpeg", tenMB, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.FileSizeBytes);
+    }
+
+    [Fact]
+    public void Validate_FileSizeZero_FailsValidation()
+    {
+        // Arrange
+        var command = new GenerateUploadUrlCommand("image/jpeg", 0, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.FileSizeBytes)
+            .WithErrorMessage("File size must be greater than 0");
+    }
+
+    [Fact]
+    public void Validate_NegativeFileSize_FailsValidation()
+    {
+        // Arrange
+        var command = new GenerateUploadUrlCommand("image/jpeg", -1, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.FileSizeBytes);
+    }
+
+    [Fact]
+    public void Validate_ContentTypeCaseInsensitive_PassesValidation()
+    {
+        // Arrange - using uppercase
+        var command = new GenerateUploadUrlCommand("IMAGE/JPEG", 1024 * 1024, null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/Receipts/GetReceiptHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Receipts/GetReceiptHandlerTests.cs
@@ -1,0 +1,188 @@
+using FluentAssertions;
+using MockQueryable.Moq;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.Receipts;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.Receipts;
+
+/// <summary>
+/// Unit tests for GetReceiptHandler (AC-5.1.4).
+/// </summary>
+public class GetReceiptHandlerTests
+{
+    private readonly Mock<IAppDbContext> _dbContextMock;
+    private readonly Mock<IStorageService> _storageServiceMock;
+    private readonly GetReceiptHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+    private readonly Guid _testUserId = Guid.NewGuid();
+
+    public GetReceiptHandlerTests()
+    {
+        _dbContextMock = new Mock<IAppDbContext>();
+        _storageServiceMock = new Mock<IStorageService>();
+
+        _handler = new GetReceiptHandler(
+            _dbContextMock.Object,
+            _storageServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidId_ReturnsReceiptWithViewUrl()
+    {
+        // Arrange
+        var receipt = CreateTestReceipt();
+        var viewUrl = "https://bucket.s3.amazonaws.com/presigned-download-url";
+
+        SetupReceiptsDbSet(new List<Receipt> { receipt });
+        _storageServiceMock
+            .Setup(x => x.GeneratePresignedDownloadUrlAsync(
+                receipt.StorageKey,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(viewUrl);
+
+        var query = new GetReceiptQuery(receipt.Id);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Id.Should().Be(receipt.Id);
+        result.ViewUrl.Should().Be(viewUrl);
+    }
+
+    [Fact]
+    public async Task Handle_ValidId_ReturnsAllReceiptDetails()
+    {
+        // Arrange
+        var receipt = CreateTestReceipt();
+        SetupReceiptsDbSet(new List<Receipt> { receipt });
+        _storageServiceMock
+            .Setup(x => x.GeneratePresignedDownloadUrlAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://example.com");
+
+        var query = new GetReceiptQuery(receipt.Id);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Id.Should().Be(receipt.Id);
+        result.OriginalFileName.Should().Be(receipt.OriginalFileName);
+        result.ContentType.Should().Be(receipt.ContentType);
+        result.FileSizeBytes.Should().Be(receipt.FileSizeBytes!.Value);
+        result.PropertyId.Should().Be(receipt.PropertyId);
+        result.ExpenseId.Should().Be(receipt.ExpenseId);
+        result.CreatedAt.Should().Be(receipt.CreatedAt);
+        result.ProcessedAt.Should().Be(receipt.ProcessedAt);
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        SetupReceiptsDbSet(new List<Receipt>());
+
+        var nonExistentId = Guid.NewGuid();
+        var query = new GetReceiptQuery(nonExistentId);
+
+        // Act
+        var act = () => _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"*{nonExistentId}*");
+    }
+
+    [Fact]
+    public async Task Handle_DeletedReceipt_ThrowsNotFoundException()
+    {
+        // Arrange
+        var deletedReceipt = CreateTestReceipt();
+        deletedReceipt.DeletedAt = DateTime.UtcNow;
+        SetupReceiptsDbSet(new List<Receipt> { deletedReceipt });
+
+        var query = new GetReceiptQuery(deletedReceipt.Id);
+
+        // Act
+        var act = () => _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_EnforcesTenantIsolation()
+    {
+        // Arrange - with global query filter, other account receipts not visible
+        SetupReceiptsDbSet(new List<Receipt>());
+
+        var otherAccountReceiptId = Guid.NewGuid();
+        var query = new GetReceiptQuery(otherAccountReceiptId);
+
+        // Act
+        var act = () => _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_CallsStorageServiceForViewUrl()
+    {
+        // Arrange
+        var receipt = CreateTestReceipt();
+        SetupReceiptsDbSet(new List<Receipt> { receipt });
+        _storageServiceMock
+            .Setup(x => x.GeneratePresignedDownloadUrlAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://example.com");
+
+        var query = new GetReceiptQuery(receipt.Id);
+
+        // Act
+        await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        _storageServiceMock.Verify(x => x.GeneratePresignedDownloadUrlAsync(
+            receipt.StorageKey,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private Receipt CreateTestReceipt()
+    {
+        return new Receipt
+        {
+            Id = Guid.NewGuid(),
+            AccountId = _testAccountId,
+            StorageKey = $"{_testAccountId}/2025/test-guid.jpg",
+            OriginalFileName = "receipt.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024 * 1024,
+            PropertyId = null,
+            ExpenseId = null,
+            CreatedByUserId = _testUserId,
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1),
+            ProcessedAt = null,
+            DeletedAt = null
+        };
+    }
+
+    private void SetupReceiptsDbSet(List<Receipt> receipts)
+    {
+        // Filter to simulate global query filter (soft delete)
+        var filteredReceipts = receipts
+            .Where(r => r.DeletedAt == null)
+            .ToList();
+
+        var mockDbSet = filteredReceipts.AsQueryable().BuildMockDbSet();
+        _dbContextMock.Setup(x => x.Receipts).Returns(mockDbSet.Object);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - Email__SmtpHost=mailhog
       - Email__SmtpPort=1025
       - Email__FromAddress=noreply@localhost
+      - AWS__AccessKeyId=${AWS_ACCESS_KEY_ID:-}
+      - AWS__SecretAccessKey=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS__BucketName=${AWS_BUCKET_NAME:-property-manager-receipts}
+      - AWS__Region=${AWS_REGION:-us-east-1}
+      - AWS__PresignedUrlExpiryMinutes=${AWS_PRESIGNED_URL_EXPIRY_MINUTES:-60}
       - ASPNETCORE_ENVIRONMENT=Development
     depends_on:
       db:

--- a/frontend/src/app/core/api/api.service.ts
+++ b/frontend/src/app/core/api/api.service.ts
@@ -48,6 +48,10 @@ export interface IApiClient {
     properties_GetPropertyById(id: string, year?: number | null | undefined): Observable<PropertyDetailDto>;
     properties_UpdateProperty(id: string, request: UpdatePropertyRequest): Observable<void>;
     properties_DeleteProperty(id: string): Observable<void>;
+    receipts_GenerateUploadUrl(request: GenerateUploadUrlRequest): Observable<UploadUrlResponse>;
+    receipts_CreateReceipt(request: CreateReceiptRequest): Observable<CreateReceiptResponse>;
+    receipts_GetReceipt(id: string): Observable<ReceiptDto>;
+    receipts_DeleteReceipt(id: string): Observable<void>;
 }
 
 @Injectable({
@@ -2090,6 +2094,263 @@ export class ApiClient implements IApiClient {
         }
         return _observableOf(null as any);
     }
+
+    receipts_GenerateUploadUrl(request: GenerateUploadUrlRequest): Observable<UploadUrlResponse> {
+        let url_ = this.baseUrl + "/api/v1/receipts/upload-url";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_ : any = {
+            body: content_,
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("post", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processReceipts_GenerateUploadUrl(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processReceipts_GenerateUploadUrl(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<UploadUrlResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<UploadUrlResponse>;
+        }));
+    }
+
+    protected processReceipts_GenerateUploadUrl(response: HttpResponseBase): Observable<UploadUrlResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 200) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as UploadUrlResponse;
+            return _observableOf(result200);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ValidationProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    receipts_CreateReceipt(request: CreateReceiptRequest): Observable<CreateReceiptResponse> {
+        let url_ = this.baseUrl + "/api/v1/receipts";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_ : any = {
+            body: content_,
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("post", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processReceipts_CreateReceipt(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processReceipts_CreateReceipt(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<CreateReceiptResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<CreateReceiptResponse>;
+        }));
+    }
+
+    protected processReceipts_CreateReceipt(response: HttpResponseBase): Observable<CreateReceiptResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 201) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result201: any = null;
+            result201 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as CreateReceiptResponse;
+            return _observableOf(result201);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ValidationProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    receipts_GetReceipt(id: string): Observable<ReceiptDto> {
+        let url_ = this.baseUrl + "/api/v1/receipts/{id}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("get", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processReceipts_GetReceipt(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processReceipts_GetReceipt(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<ReceiptDto>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<ReceiptDto>;
+        }));
+    }
+
+    protected processReceipts_GetReceipt(response: HttpResponseBase): Observable<ReceiptDto> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 200) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ReceiptDto;
+            return _observableOf(result200);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    receipts_DeleteReceipt(id: string): Observable<void> {
+        let url_ = this.baseUrl + "/api/v1/receipts/{id}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+            })
+        };
+
+        return this.http.request("delete", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processReceipts_DeleteReceipt(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processReceipts_DeleteReceipt(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<void>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<void>;
+        }));
+    }
+
+    protected processReceipts_DeleteReceipt(response: HttpResponseBase): Observable<void> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return _observableOf(null as any);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
 }
 
 export interface ProblemDetails {
@@ -2393,6 +2654,43 @@ export interface UpdatePropertyRequest {
     city?: string;
     state?: string;
     zipCode?: string;
+}
+
+export interface UploadUrlResponse {
+    uploadUrl?: string;
+    storageKey?: string;
+    expiresAt?: Date;
+    httpMethod?: string;
+}
+
+export interface GenerateUploadUrlRequest {
+    contentType?: string;
+    fileSizeBytes?: number;
+    propertyId?: string | undefined;
+}
+
+export interface CreateReceiptResponse {
+    id?: string;
+}
+
+export interface CreateReceiptRequest {
+    storageKey?: string;
+    originalFileName?: string;
+    contentType?: string;
+    fileSizeBytes?: number;
+    propertyId?: string | undefined;
+}
+
+export interface ReceiptDto {
+    id?: string;
+    originalFileName?: string;
+    contentType?: string;
+    fileSizeBytes?: number;
+    propertyId?: string | undefined;
+    expenseId?: string | undefined;
+    createdAt?: Date;
+    processedAt?: Date | undefined;
+    viewUrl?: string;
 }
 
 export class ApiException extends Error {


### PR DESCRIPTION
## Summary

Implements receipt upload infrastructure using AWS S3 presigned URLs for Story 5.1.

### Backend Changes
- **S3StorageService**: Generates presigned upload/download URLs using AWS SDK
- **CQRS Commands/Queries**:
  - `GenerateUploadUrl` - Creates presigned PUT URL for direct S3 upload
  - `CreateReceipt` - Confirms upload and creates receipt record
  - `GetReceipt` - Returns receipt with presigned view URL
  - `DeleteReceipt` - Soft-deletes receipt and removes S3 file
- **ReceiptsController**: 4 new endpoints under `/api/v1/receipts`
- **Validation**: Content type (jpeg/png/pdf) and size limit (10MB)

### API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/v1/receipts/upload-url` | Generate presigned upload URL |
| POST | `/api/v1/receipts` | Create receipt after S3 upload |
| GET | `/api/v1/receipts/{id}` | Get receipt with view URL |
| DELETE | `/api/v1/receipts/{id}` | Soft-delete receipt |

### Tests
- 38 unit tests for handlers and validators
- 14 integration tests with FakeStorageService

### Configuration
- Updated `.env.example` with AWS settings
- Updated `docker-compose.yml` with AWS environment variables
- Regenerated TypeScript API client

## Render Deployment

**Required environment variables for Render:**
```
AWS__AccessKeyId=<your-access-key>
AWS__SecretAccessKey=<your-secret-key>
AWS__BucketName=property-manager-receipts-417355468534
AWS__Region=us-east-1
AWS__PresignedUrlExpiryMinutes=60
```

## Test plan
- [x] All 38 unit tests pass
- [x] All 14 integration tests pass
- [x] Manual verification with real S3 bucket
- [ ] CI/CD pipeline passes
- [ ] Verify endpoints in Swagger UI after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)