### PR TITLE
feat(year-selector): Add localStorage persistence for year selection (#7.3)

### DIFF
--- a/_bmad-output/implementation-artifacts/7-3-year-selection-persistence.md
+++ b/_bmad-output/implementation-artifacts/7-3-year-selection-persistence.md
@@ -1,6 +1,6 @@
 # Story 7.3: Year Selection Persistence
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -268,3 +268,28 @@ None - implementation completed without issues.
 ### Change Log
 
 - 2026-01-08: Implemented year selection persistence (Story 7.3) - All ACs satisfied
+- 2026-01-07: Code Review - Fixed 4 issues, added 3 tests (Dave)
+
+## Senior Developer Review (AI)
+
+**Reviewer:** Dave | **Date:** 2026-01-07 | **Outcome:** APPROVED (after fixes)
+
+### Issues Found & Fixed
+
+| # | Severity | Issue | Resolution |
+|---|----------|-------|------------|
+| 1 | CRITICAL | Task 2.3 marked [x] but logging not implemented | Added `console.warn` in `initializeFromStorage()` and `saveToStorage()` fallback paths |
+| 2 | MEDIUM | `setYear()` accepted invalid years | Added `isValidYear()` check before setting/persisting |
+| 3 | MEDIUM | `reset()` localStorage write not tested | Added test verifying `setItemSpy` called with current year |
+| 4 | LOW | Out-of-range tests didn't verify storage replacement | Added `setItemSpy` assertions to AC-7.3.5 tests |
+
+### Test Coverage
+
+- **Before:** 19 tests
+- **After:** 22 tests (+3 new tests)
+- **All 672 frontend tests pass**
+
+### Files Modified During Review
+
+- `frontend/src/app/core/services/year-selector.service.ts` - Added logging, input validation
+- `frontend/src/app/core/services/year-selector.service.spec.ts` - Added 3 tests for coverage gaps

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -76,7 +76,7 @@ development_status:
   epic-7: in-progress
   7-1-mobile-logout-option: done               # Issue #60 - Review Passed & Fixed
   7-2-profile-display-with-user-name: done   # Issue #57
-  7-3-year-selection-persistence: review # Issue #59
+  7-3-year-selection-persistence: done # Issue #59 - Code Review Passed
   7-4-recent-expense-list-sorting-with-timestamps: backlog  # Issue #61
   7-5-expense-list-pagination: backlog          # Issue #62
   epic-7-retrospective: optional

--- a/frontend/src/app/core/services/year-selector.service.spec.ts
+++ b/frontend/src/app/core/services/year-selector.service.spec.ts
@@ -98,6 +98,28 @@ describe('YearSelectorService', () => {
       service.setYear(testYear);
       expect(service.selectedYear()).toBe(testYear);
     });
+
+    it('should reject year outside available range', () => {
+      service = createService();
+      const invalidYear = currentYear - 10; // Too old
+      const originalYear = service.selectedYear();
+
+      service.setYear(invalidYear);
+
+      // Should not have changed
+      expect(service.selectedYear()).toBe(originalYear);
+    });
+
+    it('should reject future years', () => {
+      service = createService();
+      const futureYear = currentYear + 5;
+      const originalYear = service.selectedYear();
+
+      service.setYear(futureYear);
+
+      // Should not have changed
+      expect(service.selectedYear()).toBe(originalYear);
+    });
   });
 
   describe('reset', () => {
@@ -106,6 +128,16 @@ describe('YearSelectorService', () => {
       service.setYear(currentYear - 3);
       service.reset();
       expect(service.selectedYear()).toBe(currentYear);
+    });
+
+    it('should write current year to localStorage on reset', () => {
+      service = createService();
+      service.setYear(currentYear - 2);
+      setItemSpy.mockClear(); // Clear previous calls
+
+      service.reset();
+
+      expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, currentYear.toString());
     });
   });
 
@@ -161,6 +193,8 @@ describe('YearSelectorService', () => {
       service = createService();
 
       expect(service.selectedYear()).toBe(currentYear);
+      // Should have replaced the invalid value with current year in localStorage
+      expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, currentYear.toString());
     });
 
     it('should fall back to current year when stored year is in the future (AC-7.3.5)', () => {
@@ -169,6 +203,8 @@ describe('YearSelectorService', () => {
       service = createService();
 
       expect(service.selectedYear()).toBe(currentYear);
+      // Should have replaced the invalid value with current year in localStorage
+      expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, currentYear.toString());
     });
 
     it('should handle localStorage getItem exception gracefully (AC-7.3.3)', () => {

--- a/frontend/src/app/core/services/year-selector.service.ts
+++ b/frontend/src/app/core/services/year-selector.service.ts
@@ -31,10 +31,15 @@ export class YearSelectorService {
 
   /**
    * Set the selected year (AC-3.5.5, AC-7.3.1, AC-7.3.2).
+   * Validates year is within available range before setting.
    * Persists to localStorage for cross-session persistence.
    * @param year The year to select
    */
   setYear(year: number): void {
+    if (!this.isValidYear(year)) {
+      console.warn(`YearSelectorService: Invalid year ${year}, ignoring`);
+      return;
+    }
     this._selectedYear.set(year);
     this.saveToStorage(year);
   }
@@ -62,12 +67,14 @@ export class YearSelectorService {
           this._selectedYear.set(year);
           return;
         }
+        // Invalid or out-of-range stored value - log warning and replace (AC-7.3.4, AC-7.3.5)
+        console.warn(`YearSelectorService: Invalid stored year "${stored}", falling back to current year`);
       }
       // Fall through: empty or invalid - save current year to normalize storage
       this.saveToStorage(this._selectedYear());
     } catch {
       // localStorage may be unavailable (private browsing, disabled) - AC-7.3.3
-      // Silently use default current year
+      console.warn('YearSelectorService: localStorage unavailable, using default year');
     }
   }
 
@@ -84,15 +91,15 @@ export class YearSelectorService {
 
   /**
    * Save year to localStorage (AC-7.3.1, AC-7.3.2).
-   * Silently ignores errors (best-effort persistence).
+   * Logs warning on failure (best-effort persistence).
    * @param year Year to save
    */
   private saveToStorage(year: number): void {
     try {
       localStorage.setItem(STORAGE_KEY, year.toString());
     } catch {
-      // Silently ignore - persistence is best-effort
       // May fail in private browsing or if quota exceeded
+      console.warn('YearSelectorService: Failed to save year to localStorage');
     }
   }
 }


### PR DESCRIPTION
## Summary

- Persist selected tax year across page refreshes and browser sessions using localStorage
- Add graceful fallback to current year when storage is empty, invalid, or unavailable
- Add comprehensive unit tests for all persistence scenarios

## Changes

**Service (`year-selector.service.ts`):**
- Add `STORAGE_KEY` constant: `propertyManager.selectedYear`
- Add `initializeFromStorage()` to read from localStorage on construction
- Add `isValidYear()` to validate year is within available range (current year - 5)
- Add `saveToStorage()` to persist year changes
- Wrap all localStorage operations in try-catch for graceful degradation

**Tests (`year-selector.service.spec.ts`):**
- Add 12 new unit tests covering all persistence scenarios
- Mock localStorage using Vitest pattern

## Acceptance Criteria

| AC | Description | Status |
|----|-------------|--------|
| AC-7.3.1 | Persist across page refresh | ✅ |
| AC-7.3.2 | Persist across browser sessions | ✅ |
| AC-7.3.3 | Graceful fallback on data loss | ✅ |
| AC-7.3.4 | Invalid stored value handling | ✅ |
| AC-7.3.5 | Year must be within range | ✅ |

## Test plan

- [x] All 669 frontend unit tests pass
- [x] Manual verification with Playwright: year persists across refresh
- [x] Manual verification: graceful fallback when localStorage cleared
- [x] Manual verification: invalid values replaced with current year

Closes #59

🤖 Generated with [Claude Code](https://claude.ai/code)