### PR TITLE
fix(mobile): improve year selector color contrast in navbar (#75)

### DIFF
--- a/frontend/src/app/core/components/shell/shell.component.html
+++ b/frontend/src/app/core/components/shell/shell.component.html
@@ -52,7 +52,7 @@
       <mat-toolbar class="mobile-header" color="primary">
         <span class="header-title">Property Manager</span>
         <span class="spacer"></span>
-        <app-year-selector class="light-theme" />
+        <app-year-selector />
         <span class="user-name" data-testid="mobile-user-name">{{ userDisplayName }}</span>
         <button
           mat-icon-button


### PR DESCRIPTION
## Summary
- Remove `light-theme` class from mobile header year selector to fix poor color contrast
- The `light-theme` styles were setting dark colors (`rgba(0,0,0,0.54)`) against the dark navbar background
- Calendar icon and year text are now visible with proper white/light colors matching desktop sidebar

## Root Cause
`shell.component.html:55` applied `class="light-theme"` to the year selector in the mobile header, which overrode the default dark theme styles designed for dark backgrounds.

## Test plan
- [x] Verified mobile view (375x667) - calendar icon and year "2026" visible with good contrast
- [x] Verified desktop view (1280x800) - sidebar year selector unchanged
- [x] Frontend unit tests: 696 passed
- [x] Backend unit tests: 514 passed
- [x] E2E tests: 72 passed

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)