### PR TITLE
fix(expenses): correct date display timezone issue (#77)

### DIFF
--- a/frontend/src/app/features/expenses/components/duplicate-warning-dialog/duplicate-warning-dialog.component.ts
+++ b/frontend/src/app/features/expenses/components/duplicate-warning-dialog/duplicate-warning-dialog.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { formatDateShort } from '../../../../shared/utils/date.utils';
 
 /**
  * Data interface for DuplicateWarningDialogComponent (AC-3.6.2)
@@ -167,14 +168,10 @@ export class DuplicateWarningDialogComponent {
 
   /**
    * Format date as "Nov 28, 2025"
+   * Uses formatDateShort utility for correct timezone handling
    */
   formatDate(dateString: string): string {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
+    return formatDateShort(dateString);
   }
 
   /**

--- a/frontend/src/app/features/expenses/components/expense-list-row/expense-list-row.component.ts
+++ b/frontend/src/app/features/expenses/components/expense-list-row/expense-list-row.component.ts
@@ -10,6 +10,7 @@ import {
   ReceiptLightboxDialogComponent,
   ReceiptLightboxDialogData,
 } from '../../../receipts/components/receipt-lightbox-dialog/receipt-lightbox-dialog.component';
+import { formatDateShort } from '../../../../shared/utils/date.utils';
 
 /**
  * ExpenseListRowComponent (AC-3.4.2)
@@ -206,14 +207,10 @@ export class ExpenseListRowComponent {
 
   /**
    * Format date as "Dec 08, 2025" (AC-3.4.2)
+   * Uses formatDateShort utility for correct timezone handling
    */
   formatDate(dateString: string): string {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: '2-digit',
-      year: 'numeric',
-    });
+    return formatDateShort(dateString);
   }
 
   /**

--- a/frontend/src/app/features/expenses/components/expense-row/expense-row.component.ts
+++ b/frontend/src/app/features/expenses/components/expense-row/expense-row.component.ts
@@ -11,6 +11,7 @@ import {
   ReceiptLightboxDialogComponent,
   ReceiptLightboxDialogData,
 } from '../../../receipts/components/receipt-lightbox-dialog/receipt-lightbox-dialog.component';
+import { formatDateShort } from '../../../../shared/utils/date.utils';
 
 /**
  * ExpenseRowComponent (AC-3.1.7, AC-3.2.1, AC-3.3.1)
@@ -208,14 +209,10 @@ export class ExpenseRowComponent {
 
   /**
    * Format date as "Nov 28, 2025"
+   * Uses formatDateShort utility for correct timezone handling
    */
   protected formatDate(dateString: string): string {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
+    return formatDateShort(dateString);
   }
 
   /**

--- a/frontend/src/app/features/expenses/expense-workspace/expense-workspace.component.ts
+++ b/frontend/src/app/features/expenses/expense-workspace/expense-workspace.component.ts
@@ -17,6 +17,7 @@ import {
   ConfirmDialogComponent,
   ConfirmDialogData,
 } from '../../../shared/components/confirm-dialog/confirm-dialog.component';
+import { formatDateShort } from '../../../shared/utils/date.utils';
 
 /**
  * ExpenseWorkspaceComponent (AC-3.1.1, AC-3.1.6, AC-3.1.7, AC-3.2, AC-3.3)
@@ -421,14 +422,10 @@ export class ExpenseWorkspaceComponent implements OnInit {
 
   /**
    * Format date as "Nov 28, 2025"
+   * Uses formatDateShort utility for correct timezone handling
    */
   private formatDate(dateString: string): string {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
+    return formatDateShort(dateString);
   }
 
   /**

--- a/frontend/src/app/shared/utils/date.utils.spec.ts
+++ b/frontend/src/app/shared/utils/date.utils.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { parseLocalDate, formatDateShort, formatDateLong } from './date.utils';
+
+describe('Date Utils', () => {
+  describe('parseLocalDate', () => {
+    it('should parse ISO date string (YYYY-MM-DD) to local date', () => {
+      const result = parseLocalDate('2025-12-28');
+
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(11); // December is month 11 (0-indexed)
+      expect(result.getDate()).toBe(28);
+    });
+
+    it('should parse ISO datetime string (YYYY-MM-DDTHH:mm:ss) to local date', () => {
+      const result = parseLocalDate('2025-12-28T10:30:00');
+
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(11);
+      expect(result.getDate()).toBe(28);
+    });
+
+    it('should parse ISO datetime string with timezone to local date', () => {
+      const result = parseLocalDate('2025-12-28T00:00:00.000Z');
+
+      // Should still be Dec 28, not Dec 27 (the UTC issue we're fixing)
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(11);
+      expect(result.getDate()).toBe(28);
+    });
+
+    it('should handle first day of month', () => {
+      const result = parseLocalDate('2025-03-01');
+
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(2); // March is month 2
+      expect(result.getDate()).toBe(1);
+    });
+
+    it('should handle last day of month', () => {
+      const result = parseLocalDate('2025-01-31');
+
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(0); // January is month 0
+      expect(result.getDate()).toBe(31);
+    });
+
+    it('should handle first day of year', () => {
+      const result = parseLocalDate('2025-01-01');
+
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(0);
+      expect(result.getDate()).toBe(1);
+    });
+
+    it('should handle last day of year', () => {
+      const result = parseLocalDate('2025-12-31');
+
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(11);
+      expect(result.getDate()).toBe(31);
+    });
+
+    it('should handle leap year date', () => {
+      const result = parseLocalDate('2024-02-29');
+
+      expect(result.getFullYear()).toBe(2024);
+      expect(result.getMonth()).toBe(1); // February is month 1
+      expect(result.getDate()).toBe(29);
+    });
+
+    it('should return current date for empty string', () => {
+      const result = parseLocalDate('');
+      const now = new Date();
+
+      expect(result.getFullYear()).toBe(now.getFullYear());
+      expect(result.getMonth()).toBe(now.getMonth());
+      expect(result.getDate()).toBe(now.getDate());
+    });
+  });
+
+  describe('formatDateShort', () => {
+    it('should format date as "MMM DD, YYYY"', () => {
+      const result = formatDateShort('2025-12-28');
+
+      expect(result).toBe('Dec 28, 2025');
+    });
+
+    it('should format January date correctly', () => {
+      const result = formatDateShort('2025-01-15');
+
+      expect(result).toBe('Jan 15, 2025');
+    });
+
+    it('should format single-digit day with leading zero', () => {
+      const result = formatDateShort('2025-03-05');
+
+      expect(result).toBe('Mar 05, 2025');
+    });
+
+    it('should handle datetime string correctly', () => {
+      const result = formatDateShort('2025-12-28T10:30:00');
+
+      expect(result).toBe('Dec 28, 2025');
+    });
+
+    it('should handle UTC datetime string correctly', () => {
+      // This is the key test - UTC string should still show Dec 28, not Dec 27
+      const result = formatDateShort('2025-12-28T00:00:00.000Z');
+
+      expect(result).toBe('Dec 28, 2025');
+    });
+  });
+
+  describe('formatDateLong', () => {
+    it('should format date as "MMMM D, YYYY"', () => {
+      const result = formatDateLong('2025-12-28');
+
+      expect(result).toBe('December 28, 2025');
+    });
+
+    it('should format January date correctly', () => {
+      const result = formatDateLong('2025-01-15');
+
+      expect(result).toBe('January 15, 2025');
+    });
+
+    it('should handle datetime string correctly', () => {
+      const result = formatDateLong('2025-12-28T10:30:00');
+
+      expect(result).toBe('December 28, 2025');
+    });
+  });
+});

--- a/frontend/src/app/shared/utils/date.utils.ts
+++ b/frontend/src/app/shared/utils/date.utils.ts
@@ -1,0 +1,70 @@
+/**
+ * Date utility functions for consistent timezone handling
+ *
+ * Problem: JavaScript's Date constructor interprets ISO date strings (YYYY-MM-DD)
+ * as UTC midnight. When displayed with toLocaleDateString() in timezones west of UTC,
+ * this shows the previous day.
+ *
+ * Solution: Parse dates using the Date constructor with explicit year, month, day
+ * parameters to create dates at midnight in the LOCAL timezone.
+ */
+
+/**
+ * Parse an ISO date string to a Date object in the local timezone.
+ * Handles both date-only (YYYY-MM-DD) and datetime (YYYY-MM-DDTHH:mm:ss) formats.
+ *
+ * @param dateString - ISO date string (e.g., "2025-12-28" or "2025-12-28T10:30:00")
+ * @returns Date object at midnight in local timezone
+ */
+export function parseLocalDate(dateString: string): Date {
+  if (!dateString) {
+    return new Date();
+  }
+
+  // Extract date part (before T if present)
+  const datePart = dateString.split('T')[0];
+  const parts = datePart.split('-');
+
+  if (parts.length !== 3) {
+    // Fallback for unexpected format
+    return new Date(dateString);
+  }
+
+  const year = parseInt(parts[0], 10);
+  const month = parseInt(parts[1], 10) - 1; // JavaScript months are 0-indexed
+  const day = parseInt(parts[2], 10);
+
+  return new Date(year, month, day);
+}
+
+/**
+ * Format a date string for display in a short format.
+ * Uses parseLocalDate to ensure correct timezone handling.
+ *
+ * @param dateString - ISO date string
+ * @returns Formatted string like "Dec 28, 2025"
+ */
+export function formatDateShort(dateString: string): string {
+  const date = parseLocalDate(dateString);
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Format a date string for display in a long format.
+ * Uses parseLocalDate to ensure correct timezone handling.
+ *
+ * @param dateString - ISO date string
+ * @returns Formatted string like "December 28, 2025"
+ */
+export function formatDateLong(dateString: string): string {
+  const date = parseLocalDate(dateString);
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}


### PR DESCRIPTION
## Summary
- Fix expense dates displaying 1 day earlier in list view than actual date
- Add shared date utility with `parseLocalDate` and `formatDateShort` functions
- Add 17 unit tests for date utility covering ISO parsing and edge cases

## Root Cause
JavaScript's `Date` constructor interprets ISO date strings (e.g., `"2025-12-28"`) as UTC midnight. In US timezones (west of UTC), `toLocaleDateString()` converts this to the previous day.

## Changes
| File | Change |
|------|--------|
| `shared/utils/date.utils.ts` | New utility with local timezone parsing |
| `shared/utils/date.utils.spec.ts` | 17 unit tests |
| `expense-list-row.component.ts` | Use `formatDateShort` |
| `expense-row.component.ts` | Use `formatDateShort` |
| `expense-workspace.component.ts` | Use `formatDateShort` |
| `duplicate-warning-dialog.component.ts` | Use `formatDateShort` |

## Test plan
- [x] Unit tests pass (17 new tests)
- [x] E2E tests pass (72 tests)
- [x] Build succeeds
- [ ] Manual verification: expense list shows same date as edit form

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)