### PR TITLE
fix(receipts): Receipt lightbox modal too narrow - controls obscured

### DIFF
--- a/frontend/src/app/features/expenses/components/expense-edit-form/expense-edit-form.component.spec.ts
+++ b/frontend/src/app/features/expenses/components/expense-edit-form/expense-edit-form.component.spec.ts
@@ -276,6 +276,9 @@ describe('ExpenseEditFormComponent', () => {
       expect(mockDialog.open).toHaveBeenCalled();
       const dialogConfig = mockDialog.open.mock.calls[0][1];
       expect(dialogConfig.data.receiptId).toBe('receipt-1');
+      expect(dialogConfig.width).toBe('90vw');
+      expect(dialogConfig.maxWidth).toBe('1400px');
+      expect(dialogConfig.height).toBe('90vh');
       expect(dialogConfig.panelClass).toBe('receipt-lightbox-panel');
     });
   });

--- a/frontend/src/app/features/expenses/components/expense-edit-form/expense-edit-form.component.ts
+++ b/frontend/src/app/features/expenses/components/expense-edit-form/expense-edit-form.component.ts
@@ -505,6 +505,9 @@ export class ExpenseEditFormComponent implements OnInit, OnChanges {
       ReceiptLightboxDialogComponent,
       {
         data: { receiptId },
+        width: '90vw',
+        maxWidth: '1400px',
+        height: '90vh',
         panelClass: 'receipt-lightbox-panel',
       }
     );

--- a/frontend/src/app/features/expenses/components/expense-list-row/expense-list-row.component.spec.ts
+++ b/frontend/src/app/features/expenses/components/expense-list-row/expense-list-row.component.spec.ts
@@ -81,6 +81,9 @@ describe('ExpenseListRowComponent', () => {
         ReceiptLightboxDialogComponent,
         {
           data: { receiptId: 'receipt-789' },
+          width: '90vw',
+          maxWidth: '1400px',
+          height: '90vh',
           panelClass: 'receipt-lightbox-panel',
         }
       );

--- a/frontend/src/app/features/expenses/components/expense-list-row/expense-list-row.component.ts
+++ b/frontend/src/app/features/expenses/components/expense-list-row/expense-list-row.component.ts
@@ -244,6 +244,9 @@ export class ExpenseListRowComponent {
       ReceiptLightboxDialogComponent,
       {
         data: { receiptId },
+        width: '90vw',
+        maxWidth: '1400px',
+        height: '90vh',
         panelClass: 'receipt-lightbox-panel',
       }
     );

--- a/frontend/src/app/features/expenses/components/expense-row/expense-row.component.spec.ts
+++ b/frontend/src/app/features/expenses/components/expense-row/expense-row.component.spec.ts
@@ -156,6 +156,9 @@ describe('ExpenseRowComponent', () => {
         ReceiptLightboxDialogComponent,
         {
           data: { receiptId: 'receipt-999' },
+          width: '90vw',
+          maxWidth: '1400px',
+          height: '90vh',
           panelClass: 'receipt-lightbox-panel',
         }
       );

--- a/frontend/src/app/features/expenses/components/expense-row/expense-row.component.ts
+++ b/frontend/src/app/features/expenses/components/expense-row/expense-row.component.ts
@@ -243,6 +243,9 @@ export class ExpenseRowComponent {
       ReceiptLightboxDialogComponent,
       {
         data: { receiptId },
+        width: '90vw',
+        maxWidth: '1400px',
+        height: '90vh',
         panelClass: 'receipt-lightbox-panel',
       }
     );

--- a/frontend/src/app/features/receipts/components/receipt-lightbox-dialog/receipt-lightbox-dialog.component.ts
+++ b/frontend/src/app/features/receipts/components/receipt-lightbox-dialog/receipt-lightbox-dialog.component.ts
@@ -73,7 +73,8 @@ export interface ReceiptLightboxDialogData {
   styles: [
     `
       .lightbox-container {
-        width: 75vw;
+        width: 90vw;
+        max-width: 1400px;
         height: 90vh;
         display: flex;
         flex-direction: column;
@@ -96,6 +97,7 @@ export interface ReceiptLightboxDialogData {
       .lightbox-content {
         flex: 1;
         min-height: 0;
+        overflow: hidden;
         display: flex;
         width: 100%;
       }
@@ -119,6 +121,8 @@ export interface ReceiptLightboxDialogData {
 
       app-receipt-image-viewer {
         display: block;
+        flex: 1;
+        min-width: 0;
         width: 100%;
         height: 100%;
       }


### PR DESCRIPTION
## Summary

- Fixes receipt lightbox modal being too narrow with controls obscured
- Adds proper `MatDialogConfig` dimensions (`width: 90vw`, `maxWidth: 1400px`, `height: 90vh`) to all dialog.open() calls
- Updates CSS in receipt-lightbox-dialog component for proper overflow handling

## Root Cause

The `dialog.open()` calls only had `panelClass` but no size configuration, so Angular Material used its default narrow sizing. The CSS inside the component was being overridden by the dialog container.

## Changes

| File | Change |
|------|--------|
| `expense-list-row.component.ts` | Added width/maxWidth/height to dialog config |
| `expense-row.component.ts` | Added width/maxWidth/height to dialog config |
| `expense-edit-form.component.ts` | Added width/maxWidth/height to dialog config |
| `receipt-lightbox-dialog.component.ts` | CSS improvements for overflow handling |
| 3 spec files | Updated test assertions |

## Test plan

- [x] Verified with Playwright MCP at 1440px viewport
- [x] All 6 toolbar controls visible (zoom in/out, rotate left/right, reset, close)
- [x] No horizontal scrollbar
- [x] Image contained within modal
- [x] Unit tests updated and passing

Fixes #83

🤖 Generated with [Claude Code](https://claude.ai/code)