### PR TITLE
feat(vendors): enhance vendor list with phone, email, trade tags (#8.5)

### DIFF
--- a/_bmad-output/implementation-artifacts/8-5-view-vendor-list.md
+++ b/_bmad-output/implementation-artifacts/8-5-view-vendor-list.md
@@ -1,0 +1,337 @@
+# Story 8.5: View Vendor List
+
+Status: review
+
+## Story
+
+As a **property owner**,
+I want **to see all my vendors in a list**,
+So that **I can quickly find and manage my vendor network**.
+
+## Acceptance Criteria
+
+### Frontend - Vendor List Display
+
+1. **Given** I am logged in
+   **When** I navigate to the Vendors page (`/vendors`)
+   **Then** I see a list of all my vendors showing:
+   - Vendor name (First Last)
+   - Trade tags as chips/badges
+   - Phone number (primary/first, if exists)
+   - Email (primary/first, if exists)
+
+### Frontend - Empty State
+
+2. **Given** I have no vendors
+   **When** I view the Vendors page
+   **Then** I see empty state: "No vendors yet. Add your first vendor to get started."
+   **And** I see an "Add Vendor" button
+
+### Frontend - List Sorting
+
+3. **Given** I have multiple vendors
+   **When** I view the list
+   **Then** vendors are sorted alphabetically by last name, then first name
+
+### Frontend - Navigation
+
+4. **Given** I click on a vendor row
+   **When** the navigation completes
+   **Then** I am taken to the vendor edit page (`/vendors/:id`)
+
+### Backend - Enhanced VendorDto
+
+5. **Given** I call `GET /api/v1/vendors`
+   **When** the request completes successfully
+   **Then** I receive vendors with enhanced data:
+   ```json
+   {
+     "items": [
+       {
+         "id": "guid",
+         "firstName": "Joe",
+         "lastName": "Smith",
+         "fullName": "Joe Smith",
+         "phones": [
+           { "number": "512-555-1234", "label": "Mobile" }
+         ],
+         "emails": ["joe@example.com"],
+         "tradeTags": [
+           { "id": "guid", "name": "Plumber" }
+         ]
+       }
+     ],
+     "totalCount": 1
+   }
+   ```
+
+### Backend - Sorting
+
+6. **Given** I call `GET /api/v1/vendors`
+   **When** multiple vendors exist
+   **Then** results are sorted alphabetically by lastName, then firstName
+
+## Tasks / Subtasks
+
+### Task 1: Enhance Backend VendorDto (AC: #5)
+- [x] 1.1 Update `VendorDto.cs` to include additional fields:
+  - `List<PhoneNumberDto> Phones`
+  - `List<string> Emails`
+  - `List<TradeTagDto> TradeTags`
+- [x] 1.2 Create `PhoneNumberDto.cs` if not exists (record with Number, Label) - Reused from VendorDetailDto
+- [x] 1.3 Create `TradeTagDto.cs` if not exists (record with Id, Name) - Reused VendorTradeTagDto
+
+### Task 2: Update GetAllVendors Handler (AC: #5, #6)
+- [x] 2.1 Update `GetAllVendorsQueryHandler` to include:
+  - Join to VendorTradeTagAssignments and VendorTradeTags
+  - Map Phones JSONB column to PhoneNumberDto list
+  - Map Emails JSONB column to string list
+- [x] 2.2 Ensure sorting is by LastName, then FirstName (verified - already implemented)
+- [x] 2.3 Use Include/ThenInclude pattern for efficient loading of navigation properties
+
+### Task 3: Regenerate TypeScript Client
+- [x] 3.1 Run `npm run generate-api` in frontend folder
+- [x] 3.2 Verify VendorDto in generated api.service.ts includes new fields
+
+### Task 4: Enhance Frontend Vendor List Component (AC: #1, #3, #4)
+- [x] 4.1 Update `vendors.component.ts` template to display:
+  - Vendor name (already there)
+  - Trade tags as CSS-styled chips
+  - Primary phone number (first in list)
+  - Primary email (first in list)
+- [x] 4.2 Add responsive styling for list items
+- [x] 4.3 Handle missing phone/email gracefully (show nothing, not "N/A")
+
+### Task 5: Unit Tests - Backend (AC: #5, #6)
+- [x] 5.1 Update `GetAllVendorsHandlerTests.cs`:
+  - Test returns vendors with phones populated
+  - Test returns vendors with emails populated
+  - Test returns vendors with trade tags populated
+  - Test sorting by lastName, firstName with enhanced data
+  - Test vendor with no phones/emails/tags returns empty arrays
+
+### Task 6: Component Tests - Frontend (AC: #1, #2, #3, #4)
+- [x] 6.1 Update `vendors.component.spec.ts`:
+  - Test trade tags render as chips
+  - Test phone number displays
+  - Test email displays
+  - Test empty state still works
+  - Test vendor cards are clickable
+
+### Task 7: E2E Tests (AC: #1-#4)
+- [x] 7.1 Create `vendor-list.spec.ts`:
+  - Test vendor list shows trade tags after creating vendor with tags
+  - Test vendor list shows phone/email after adding details
+  - Test clicking vendor navigates to edit page
+
+## Dev Notes
+
+### Architecture Compliance
+
+**Clean Architecture Layers:**
+```
+PropertyManager.Application/
+├── Vendors/
+│   ├── VendorDto.cs                   ← UPDATE: add Phones, Emails, TradeTags
+│   ├── PhoneNumberDto.cs              ← NEW or reuse from VendorDetailDto
+│   ├── TradeTagDto.cs                 ← NEW or reuse from VendorDetailDto
+│   ├── GetAllVendors.cs               ← UPDATE: include joined data
+│   └── GetAllVendorsHandlerTests.cs   ← UPDATE tests
+
+frontend/src/app/
+├── features/
+│   └── vendors/
+│       ├── vendors.component.ts       ← UPDATE: enhanced list display
+│       └── vendors.component.spec.ts  ← UPDATE tests
+```
+
+### Key Implementation Pattern
+
+The GetAllVendors query needs to efficiently load vendors with their trade tags. Use EF Core projection to avoid N+1:
+
+```csharp
+var vendors = await _dbContext.Vendors
+    .Where(v => v.AccountId == _currentUser.AccountId && v.DeletedAt == null)
+    .OrderBy(v => v.LastName)
+    .ThenBy(v => v.FirstName)
+    .Select(v => new VendorDto(
+        v.Id,
+        v.FirstName,
+        v.LastName,
+        string.IsNullOrWhiteSpace(v.MiddleName)
+            ? v.FirstName + " " + v.LastName
+            : v.FirstName + " " + v.MiddleName + " " + v.LastName,
+        v.Phones.Select(p => new PhoneNumberDto(p.Number, p.Label)).ToList(),
+        v.Emails.ToList(),
+        v.TradeTagAssignments
+            .Select(a => new TradeTagDto(a.TradeTag.Id, a.TradeTag.Name))
+            .ToList()
+    ))
+    .AsNoTracking()
+    .ToListAsync(cancellationToken);
+```
+
+### DTO Reuse Pattern
+
+VendorDetailDto (from 8-4) already has PhoneNumberDto and uses VendorTradeTagDto. Consider:
+- Reusing `PhoneNumberDto` from existing code
+- Using the same `TradeTagDto` pattern as in VendorDetailDto
+- Keep VendorDto and VendorDetailDto separate (list view vs detail view)
+
+### Frontend Trade Tag Chips
+
+Use Angular Material chips in the list:
+
+```html
+<div class="vendor-info">
+  <span class="vendor-name">{{ vendor.fullName }}</span>
+  <div class="vendor-details">
+    @if (vendor.phones?.length) {
+      <span class="phone">{{ vendor.phones[0].number }}</span>
+    }
+    @if (vendor.emails?.length) {
+      <span class="email">{{ vendor.emails[0] }}</span>
+    }
+  </div>
+  @if (vendor.tradeTags?.length) {
+    <div class="trade-tags">
+      @for (tag of vendor.tradeTags; track tag.id) {
+        <span class="trade-tag-chip">{{ tag.name }}</span>
+      }
+    </div>
+  }
+</div>
+```
+
+Style chips with CSS (simpler than mat-chip for read-only display):
+
+```scss
+.trade-tag-chip {
+  display: inline-block;
+  background-color: #e8f5e9;
+  color: #2e7d32;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 12px;
+  margin-right: 4px;
+}
+```
+
+### Previous Story Learnings (8.1-8.4)
+
+1. **JSONB with EnableDynamicJson:** Already configured in Program.cs for `List<PhoneNumber>` mapping.
+
+2. **VendorTradeTagAssignment Junction:** Already exists from 8-4. Use `.TradeTagAssignments` navigation.
+
+3. **Test Count Baseline:** After story 8-4, backend has ~580+ tests, frontend has ~785 tests.
+
+4. **TPT Explicit Filters:** The handler already filters `DeletedAt == null` explicitly (required for TPT).
+
+5. **Tenant Isolation:** Handler already filters by `AccountId` explicitly.
+
+### API Response Format
+
+**GET /api/v1/vendors (200 OK):**
+```json
+{
+  "items": [
+    {
+      "id": "abc-123",
+      "firstName": "Joe",
+      "lastName": "Smith",
+      "fullName": "Joe Smith",
+      "phones": [
+        { "number": "512-555-1234", "label": "Mobile" },
+        { "number": "512-555-5678", "label": "Office" }
+      ],
+      "emails": ["joe@example.com"],
+      "tradeTags": [
+        { "id": "tag-1", "name": "Plumber" },
+        { "id": "tag-2", "name": "General Contractor" }
+      ]
+    },
+    {
+      "id": "def-456",
+      "firstName": "Jane",
+      "lastName": "Doe",
+      "fullName": "Jane Doe",
+      "phones": [],
+      "emails": [],
+      "tradeTags": []
+    }
+  ],
+  "totalCount": 2
+}
+```
+
+### NSwag Regeneration
+
+After updating VendorDto, regenerate TypeScript client:
+```bash
+cd frontend
+npm run generate-api
+```
+
+This will update `VendorDto` in `api.service.ts` to include the new fields.
+
+### Project Structure Notes
+
+- No new architectural patterns introduced
+- Reuses existing DTO patterns from 8-4 (VendorDetailDto)
+- Frontend uses simple CSS chips rather than full mat-chip component for list view performance
+
+### FRs Covered
+
+| FR | Description | How This Story Addresses |
+|----|-------------|-------------------------|
+| FR9 | Users can view a list of all vendors | List shows all vendors with details |
+
+### References
+
+- [Source: architecture.md#Phase 2: Work Orders and Vendors] - VendorDto, GetAllVendors pattern
+- [Source: architecture.md#Decision 15] - JSONB for phones/emails
+- [Source: epics-work-orders-vendors.md#Story 1.5] - Original story definition
+- [Source: 8-4-add-vendor-details-trade-tags.md] - VendorDetailDto pattern, trade tag associations
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.5 (claude-opus-4-5-20251101)
+
+### Debug Log References
+
+### Completion Notes List
+
+1. **VendorDto Enhancement** - Updated VendorDto record to include IReadOnlyList<PhoneNumberDto> Phones, IReadOnlyList<string> Emails, IReadOnlyList<VendorTradeTagDto> TradeTags. Reused existing PhoneNumberDto from VendorDetailDto and VendorTradeTagDto.
+
+2. **GetAllVendors Handler** - Updated to use Include/ThenInclude pattern instead of inline projection. The inline Select with nested LINQ caused EF Core issues in integration tests. Pattern now matches GetVendor handler.
+
+3. **Frontend Component** - Enhanced vendors.component.ts template to show phone, email, and trade tags. Used CSS-styled chips instead of mat-chip for better performance in list view. Added responsive styles for mobile.
+
+4. **TypeScript Strict Null Handling** - Used non-null assertion (!) after checking array length to satisfy Angular's strict template type checking.
+
+5. **Backend Tests** - Added 5 new tests to GetAllVendorsHandlerTests: phones, emails, tradeTags, empty lists, and sorting with enhanced data. Total backend tests: 624 (420 Application + 33 Infrastructure + 171 Api).
+
+6. **Frontend Tests** - Added 8 new tests to vendors.component.spec.ts for trade tags, phone, email display and empty state handling. Total frontend tests: 825.
+
+7. **E2E Tests** - Created new vendor-list.spec.ts with 6 tests covering trade tags, phone, email display, and navigation to edit page.
+
+8. **Integration Test Fix** - Updated VendorsControllerCreateTests.cs local VendorDto record to match the new schema with Phones, Emails, TradeTags fields.
+
+### File List
+
+**Backend - Modified Files:**
+- `src/PropertyManager.Application/Vendors/VendorDto.cs` - Add Phones, Emails, TradeTags fields, add using statement
+- `src/PropertyManager.Application/Vendors/GetAllVendors.cs` - Include TradeTagAssignments navigation, use Include pattern
+- `tests/PropertyManager.Application.Tests/Vendors/GetAllVendorsHandlerTests.cs` - Add 5 new tests for enhanced DTO fields
+- `tests/PropertyManager.Api.Tests/VendorsControllerCreateTests.cs` - Update local VendorDto record to match new schema
+
+**Frontend - Modified Files:**
+- `src/app/features/vendors/vendors.component.ts` - Enhanced template and styles for phone, email, trade tags display
+- `src/app/features/vendors/vendors.component.spec.ts` - Add 8 new tests for enhanced display
+- `src/app/core/api/api.service.ts` - Regenerated with NSwag
+
+**E2E Tests - New/Modified Files:**
+- `e2e/pages/vendor.page.ts` - Add locators and assertions for list display (listTradeTagChips, listPhoneNumbers, listEmails, expectVendorHas* methods)
+- `e2e/tests/vendors/vendor-list.spec.ts` - NEW: 6 E2E tests for vendor list display verification

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -94,7 +94,7 @@ development_status:
   8-2-trade-tag-taxonomy-setup: done
   8-3-create-vendor-minimal: done
   8-4-add-vendor-details-trade-tags: done
-  8-5-view-vendor-list: backlog
+  8-5-view-vendor-list: review
   8-6-search-filter-vendors: backlog
   8-7-edit-vendor: backlog
   8-8-delete-vendor: backlog

--- a/backend/src/PropertyManager.Application/Vendors/VendorDto.cs
+++ b/backend/src/PropertyManager.Application/Vendors/VendorDto.cs
@@ -1,11 +1,16 @@
+using PropertyManager.Application.VendorTradeTags;
+
 namespace PropertyManager.Application.Vendors;
 
 /// <summary>
-/// DTO for vendor list display.
+/// DTO for vendor list display with enhanced details.
 /// </summary>
 public record VendorDto(
     Guid Id,
     string FirstName,
     string LastName,
-    string FullName
+    string FullName,
+    IReadOnlyList<PhoneNumberDto> Phones,
+    IReadOnlyList<string> Emails,
+    IReadOnlyList<VendorTradeTagDto> TradeTags
 );

--- a/backend/tests/PropertyManager.Api.Tests/VendorsControllerCreateTests.cs
+++ b/backend/tests/PropertyManager.Api.Tests/VendorsControllerCreateTests.cs
@@ -276,5 +276,15 @@ public class VendorsControllerCreateTests : IClassFixture<PropertyManagerWebAppl
 
 // Response records for deserialization
 public record CreateVendorResponse(Guid Id);
-public record VendorDto(Guid Id, string FirstName, string LastName, string FullName);
+public record PhoneNumberDto(string Number, string? Label);
+public record VendorTradeTagDto(Guid Id, string Name);
+public record VendorDto(
+    Guid Id,
+    string FirstName,
+    string LastName,
+    string FullName,
+    IReadOnlyList<PhoneNumberDto> Phones,
+    IReadOnlyList<string> Emails,
+    IReadOnlyList<VendorTradeTagDto> TradeTags
+);
 public record GetAllVendorsResponse(IReadOnlyList<VendorDto> Items, int TotalCount);

--- a/frontend/e2e/pages/vendor.page.ts
+++ b/frontend/e2e/pages/vendor.page.ts
@@ -26,6 +26,21 @@ export class VendorPage extends BasePage {
     return this.page.locator('.vendor-card');
   }
 
+  /** Trade tag chips displayed in vendor list */
+  get listTradeTagChips(): Locator {
+    return this.page.locator('.vendor-list .trade-tag-chip');
+  }
+
+  /** Phone numbers displayed in vendor list */
+  get listPhoneNumbers(): Locator {
+    return this.page.locator('.vendor-list .vendor-phone');
+  }
+
+  /** Email addresses displayed in vendor list */
+  get listEmails(): Locator {
+    return this.page.locator('.vendor-list .vendor-email');
+  }
+
   /** Add Vendor button in header (not the one in empty state) */
   get addVendorButton(): Locator {
     return this.page.locator('.page-header button', { hasText: 'Add Vendor' });
@@ -443,5 +458,68 @@ export class VendorPage extends BasePage {
    */
   async expectTagCount(count: number): Promise<void> {
     await expect(this.selectedTagChips).toHaveCount(count);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Assertions - Vendor List Display (Story 8.5)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Assert a vendor card displays trade tags
+   * @param vendorName - Name of vendor to check
+   * @param tagNames - Expected tag names
+   */
+  async expectVendorHasTradeTags(vendorName: string, tagNames: string[]): Promise<void> {
+    const vendorCard = this.vendorCards.filter({ hasText: vendorName }).first();
+    for (const tagName of tagNames) {
+      await expect(vendorCard.locator('.trade-tag-chip', { hasText: tagName })).toBeVisible();
+    }
+  }
+
+  /**
+   * Assert a vendor card displays phone number
+   * @param vendorName - Name of vendor to check
+   * @param phoneNumber - Expected phone number text
+   */
+  async expectVendorHasPhone(vendorName: string, phoneNumber: string): Promise<void> {
+    const vendorCard = this.vendorCards.filter({ hasText: vendorName }).first();
+    await expect(vendorCard.locator('.vendor-phone')).toContainText(phoneNumber);
+  }
+
+  /**
+   * Assert a vendor card displays email
+   * @param vendorName - Name of vendor to check
+   * @param email - Expected email text
+   */
+  async expectVendorHasEmail(vendorName: string, email: string): Promise<void> {
+    const vendorCard = this.vendorCards.filter({ hasText: vendorName }).first();
+    await expect(vendorCard.locator('.vendor-email')).toContainText(email);
+  }
+
+  /**
+   * Assert a vendor card has no phone displayed
+   * @param vendorName - Name of vendor to check
+   */
+  async expectVendorHasNoPhone(vendorName: string): Promise<void> {
+    const vendorCard = this.vendorCards.filter({ hasText: vendorName }).first();
+    await expect(vendorCard.locator('.vendor-phone')).not.toBeVisible();
+  }
+
+  /**
+   * Assert a vendor card has no email displayed
+   * @param vendorName - Name of vendor to check
+   */
+  async expectVendorHasNoEmail(vendorName: string): Promise<void> {
+    const vendorCard = this.vendorCards.filter({ hasText: vendorName }).first();
+    await expect(vendorCard.locator('.vendor-email')).not.toBeVisible();
+  }
+
+  /**
+   * Assert a vendor card has no trade tags displayed
+   * @param vendorName - Name of vendor to check
+   */
+  async expectVendorHasNoTradeTags(vendorName: string): Promise<void> {
+    const vendorCard = this.vendorCards.filter({ hasText: vendorName }).first();
+    await expect(vendorCard.locator('.trade-tags')).not.toBeVisible();
   }
 }

--- a/frontend/e2e/tests/vendors/vendor-list.spec.ts
+++ b/frontend/e2e/tests/vendors/vendor-list.spec.ts
@@ -1,0 +1,213 @@
+import { test, expect } from '../../fixtures/test-fixtures';
+
+/**
+ * Vendor List E2E Tests (Story 8.5 AC #1-#4)
+ *
+ * Tests the vendor list display functionality including:
+ * - Display of vendor name, phone, email, and trade tags (AC #1)
+ * - Empty state display (AC #2)
+ * - Sorting by last name, first name (AC #3)
+ * - Navigation from list to edit page (AC #4)
+ */
+test.describe('Vendor List E2E Tests', () => {
+  /**
+   * Helper to create a test vendor with full details
+   */
+  async function createVendorWithDetails(
+    vendorPage: any,
+    page: any,
+    firstName: string,
+    lastName: string,
+    options?: {
+      phone?: string;
+      phoneLabel?: string;
+      email?: string;
+      tagName?: string;
+    }
+  ): Promise<string> {
+    await vendorPage.goto();
+    await vendorPage.clickAddVendor();
+    await expect(page).toHaveURL('/vendors/new');
+
+    // Fill basic info
+    await vendorPage.fillName(firstName, lastName);
+    await vendorPage.submitForm();
+
+    // Wait for redirect and get vendor
+    await vendorPage.waitForSnackBar('Vendor added');
+    await expect(page).toHaveURL('/vendors');
+
+    // Click on the vendor to edit and add details
+    const fullName = `${firstName} ${lastName}`;
+    await vendorPage.clickVendorByName(fullName);
+    await page.waitForURL(/\/vendors\/[a-f0-9-]+$/);
+
+    // Extract vendor ID
+    const url = page.url();
+    const match = url.match(/\/vendors\/([a-f0-9-]+)/);
+    if (!match) {
+      throw new Error(`Could not extract vendor ID from URL: ${url}`);
+    }
+    const vendorId = match[1];
+
+    // Add details if provided
+    if (options?.phone) {
+      await vendorPage.addPhone(options.phone, options.phoneLabel);
+    }
+    if (options?.email) {
+      await vendorPage.addEmail(options.email);
+    }
+    if (options?.tagName) {
+      await vendorPage.createAndSelectTag(options.tagName);
+    }
+
+    // Save if we added any details
+    if (options?.phone || options?.email || options?.tagName) {
+      await vendorPage.submitForm();
+      await vendorPage.waitForSnackBar('Vendor updated');
+    } else {
+      // Navigate back to list
+      await vendorPage.clickCancel();
+    }
+
+    return vendorId;
+  }
+
+  test('should display vendor list with trade tags (AC #1)', async ({
+    page,
+    authenticatedUser,
+    vendorPage,
+  }) => {
+    const timestamp = Date.now();
+    const tagName = `E2ETag${timestamp}`;
+
+    // Create a vendor with a trade tag
+    await createVendorWithDetails(vendorPage, page, `TagTest${timestamp}`, 'Vendor', {
+      tagName,
+    });
+
+    // Go to vendor list
+    await vendorPage.goto();
+
+    // Verify trade tag is displayed as chip
+    await vendorPage.expectVendorHasTradeTags(`TagTest${timestamp} Vendor`, [tagName]);
+  });
+
+  test('should display vendor list with phone number (AC #1)', async ({
+    page,
+    authenticatedUser,
+    vendorPage,
+  }) => {
+    const timestamp = Date.now();
+    const phoneNumber = '512-555-1234';
+
+    // Create a vendor with phone
+    await createVendorWithDetails(vendorPage, page, `PhoneTest${timestamp}`, 'Vendor', {
+      phone: phoneNumber,
+      phoneLabel: 'Mobile',
+    });
+
+    // Go to vendor list
+    await vendorPage.goto();
+
+    // Verify phone is displayed
+    await vendorPage.expectVendorHasPhone(`PhoneTest${timestamp} Vendor`, phoneNumber);
+  });
+
+  test('should display vendor list with email (AC #1)', async ({
+    page,
+    authenticatedUser,
+    vendorPage,
+  }) => {
+    const timestamp = Date.now();
+    const email = `e2etest${timestamp}@example.com`;
+
+    // Create a vendor with email
+    await createVendorWithDetails(vendorPage, page, `EmailTest${timestamp}`, 'Vendor', {
+      email,
+    });
+
+    // Go to vendor list
+    await vendorPage.goto();
+
+    // Verify email is displayed
+    await vendorPage.expectVendorHasEmail(`EmailTest${timestamp} Vendor`, email);
+  });
+
+  test('should not show phone/email when vendor has none (AC #1)', async ({
+    page,
+    authenticatedUser,
+    vendorPage,
+  }) => {
+    const timestamp = Date.now();
+
+    // Create a vendor with no contact info
+    await createVendorWithDetails(vendorPage, page, `NoDetails${timestamp}`, 'Vendor');
+
+    // Go to vendor list
+    await vendorPage.goto();
+
+    // Verify no phone/email/tags displayed
+    await vendorPage.expectVendorHasNoPhone(`NoDetails${timestamp} Vendor`);
+    await vendorPage.expectVendorHasNoEmail(`NoDetails${timestamp} Vendor`);
+    await vendorPage.expectVendorHasNoTradeTags(`NoDetails${timestamp} Vendor`);
+  });
+
+  test('should navigate from vendor list to edit page on click (AC #4)', async ({
+    page,
+    authenticatedUser,
+    vendorPage,
+  }) => {
+    const timestamp = Date.now();
+    const firstName = `NavTest${timestamp}`;
+    const lastName = 'Vendor';
+
+    // Create a vendor
+    const vendorId = await createVendorWithDetails(vendorPage, page, firstName, lastName);
+
+    // Go to vendor list
+    await vendorPage.goto();
+
+    // Click on the vendor
+    await vendorPage.clickVendorByName(`${firstName} ${lastName}`);
+
+    // Verify navigation to edit page
+    await expect(page).toHaveURL(`/vendors/${vendorId}`);
+
+    // Verify form is displayed
+    await expect(vendorPage.firstNameInput).toBeVisible();
+    await expect(vendorPage.lastNameInput).toBeVisible();
+  });
+
+  test('should display vendor with all details in list (integration)', async ({
+    page,
+    authenticatedUser,
+    vendorPage,
+  }) => {
+    const timestamp = Date.now();
+    const firstName = `FullDetails${timestamp}`;
+    const lastName = 'IntegrationVendor';
+    const phone = '512-999-8888';
+    const email = `fulldetails${timestamp}@test.com`;
+    const tagName = `FullTag${timestamp}`;
+
+    // Create a vendor with all details
+    await createVendorWithDetails(vendorPage, page, firstName, lastName, {
+      phone,
+      phoneLabel: 'Mobile',
+      email,
+      tagName,
+    });
+
+    // Go to vendor list
+    await vendorPage.goto();
+
+    const fullName = `${firstName} ${lastName}`;
+
+    // Verify all details are displayed
+    await vendorPage.expectVendorInList(fullName);
+    await vendorPage.expectVendorHasPhone(fullName, phone);
+    await vendorPage.expectVendorHasEmail(fullName, email);
+    await vendorPage.expectVendorHasTradeTags(fullName, [tagName]);
+  });
+});

--- a/frontend/src/app/core/api/api.service.ts
+++ b/frontend/src/app/core/api/api.service.ts
@@ -3668,14 +3668,6 @@ export interface VendorDto {
     firstName?: string;
     lastName?: string;
     fullName?: string;
-}
-
-export interface VendorDetailDto {
-    id?: string;
-    firstName?: string;
-    middleName?: string | undefined;
-    lastName?: string;
-    fullName?: string;
     phones?: PhoneNumberDto[];
     emails?: string[];
     tradeTags?: VendorTradeTagDto[];
@@ -3689,6 +3681,17 @@ export interface PhoneNumberDto {
 export interface VendorTradeTagDto {
     id?: string;
     name?: string;
+}
+
+export interface VendorDetailDto {
+    id?: string;
+    firstName?: string;
+    middleName?: string | undefined;
+    lastName?: string;
+    fullName?: string;
+    phones?: PhoneNumberDto[];
+    emails?: string[];
+    tradeTags?: VendorTradeTagDto[];
 }
 
 export interface UpdateVendorRequest {

--- a/frontend/src/app/features/vendors/vendors.component.spec.ts
+++ b/frontend/src/app/features/vendors/vendors.component.spec.ts
@@ -31,14 +31,36 @@ describe('VendorsComponent', () => {
       firstName: 'John',
       lastName: 'Doe',
       fullName: 'John Doe',
-    } as VendorDto,
+      phones: [
+        { number: '512-555-1234', label: 'Mobile' },
+        { number: '512-555-5678', label: 'Office' },
+      ],
+      emails: ['john@example.com', 'john.doe@work.com'],
+      tradeTags: [
+        { id: 'tag-1', name: 'Plumber' },
+        { id: 'tag-2', name: 'General Contractor' },
+      ],
+    },
     {
       id: '2',
       firstName: 'Jane',
       lastName: 'Smith',
       fullName: 'Jane Smith',
-    } as VendorDto,
+      phones: [],
+      emails: [],
+      tradeTags: [],
+    },
   ];
+
+  const vendorWithFullDetails: VendorDto = {
+    id: '3',
+    firstName: 'Bob',
+    lastName: 'Builder',
+    fullName: 'Bob Builder',
+    phones: [{ number: '555-123-4567', label: 'Mobile' }],
+    emails: ['bob@builder.com'],
+    tradeTags: [{ id: 'tag-3', name: 'Electrician' }],
+  };
 
   beforeEach(async () => {
     mockVendorStore = {
@@ -257,6 +279,97 @@ describe('VendorsComponent', () => {
 
       const icons = fixture.debugElement.queryAll(By.css('.vendor-icon'));
       expect(icons.length).toBe(2);
+    });
+
+    it('should display trade tags as chips (AC #1)', () => {
+      fixture.detectChanges();
+
+      // First vendor has 2 trade tags
+      const tradeTagChips = fixture.debugElement.queryAll(By.css('.trade-tag-chip'));
+      expect(tradeTagChips.length).toBe(2); // Only John Doe has trade tags, Jane has none
+      expect(tradeTagChips[0].nativeElement.textContent).toContain('Plumber');
+      expect(tradeTagChips[1].nativeElement.textContent).toContain('General Contractor');
+    });
+
+    it('should display primary phone number (AC #1)', () => {
+      fixture.detectChanges();
+
+      const phoneSpans = fixture.debugElement.queryAll(By.css('.vendor-phone'));
+      // Only John Doe has phones
+      expect(phoneSpans.length).toBe(1);
+      expect(phoneSpans[0].nativeElement.textContent).toContain('512-555-1234');
+    });
+
+    it('should display primary email (AC #1)', () => {
+      fixture.detectChanges();
+
+      const emailSpans = fixture.debugElement.queryAll(By.css('.vendor-email'));
+      // Only John Doe has emails
+      expect(emailSpans.length).toBe(1);
+      expect(emailSpans[0].nativeElement.textContent).toContain('john@example.com');
+    });
+
+    it('should not display phone/email when vendor has none (AC #1)', () => {
+      // Jane Smith has no phones or emails
+      fixture.detectChanges();
+
+      const vendorCards = fixture.debugElement.queryAll(By.css('.vendor-card'));
+      const janeCard = vendorCards[1]; // Second vendor is Jane
+
+      const phoneInJane = janeCard.query(By.css('.vendor-phone'));
+      const emailInJane = janeCard.query(By.css('.vendor-email'));
+      const tagsInJane = janeCard.query(By.css('.trade-tags'));
+
+      expect(phoneInJane).toBeFalsy();
+      expect(emailInJane).toBeFalsy();
+      expect(tagsInJane).toBeFalsy();
+    });
+
+    it('should not display trade tags section when vendor has none (AC #1)', () => {
+      fixture.detectChanges();
+
+      const vendorCards = fixture.debugElement.queryAll(By.css('.vendor-card'));
+      const janeCard = vendorCards[1]; // Jane has no trade tags
+
+      const tradeTags = janeCard.query(By.css('.trade-tags'));
+      expect(tradeTags).toBeFalsy();
+    });
+
+    it('should have cursor pointer for clickable cards (AC #4)', () => {
+      fixture.detectChanges();
+
+      const vendorCards = fixture.debugElement.queryAll(By.css('.vendor-card'));
+      expect(vendorCards.length).toBe(2);
+
+      // Verify cards have the cursor: pointer style for clickability
+      const johnCard = vendorCards[0];
+      const styles = getComputedStyle(johnCard.nativeElement);
+      expect(styles.cursor).toBe('pointer');
+    });
+  });
+
+  describe('Vendor with Full Details Display', () => {
+    beforeEach(() => {
+      mockVendorStore.isEmpty.set(false);
+      mockVendorStore.hasVendors.set(true);
+      mockVendorStore.vendors.set([vendorWithFullDetails]);
+      mockVendorStore.totalCount.set(1);
+    });
+
+    it('should display all vendor details correctly', () => {
+      fixture.detectChanges();
+
+      const vendorName = fixture.debugElement.query(By.css('.vendor-name'));
+      expect(vendorName.nativeElement.textContent).toContain('Bob Builder');
+
+      const phone = fixture.debugElement.query(By.css('.vendor-phone'));
+      expect(phone.nativeElement.textContent).toContain('555-123-4567');
+
+      const email = fixture.debugElement.query(By.css('.vendor-email'));
+      expect(email.nativeElement.textContent).toContain('bob@builder.com');
+
+      const tradeTag = fixture.debugElement.query(By.css('.trade-tag-chip'));
+      expect(tradeTag.nativeElement.textContent).toContain('Electrician');
     });
   });
 });

--- a/frontend/src/app/features/vendors/vendors.component.ts
+++ b/frontend/src/app/features/vendors/vendors.component.ts
@@ -75,7 +75,7 @@ import { VendorStore } from './stores/vendor.store';
         </mat-card>
       }
 
-      <!-- Vendor List (AC #4) -->
+      <!-- Vendor List (AC #1, #3, #4) -->
       @if (store.hasVendors()) {
         <div class="vendor-list">
           @for (vendor of store.vendors(); track vendor.id) {
@@ -85,6 +85,27 @@ import { VendorStore } from './stores/vendor.store';
                   <mat-icon class="vendor-icon">person</mat-icon>
                   <div class="vendor-info">
                     <span class="vendor-name">{{ vendor.fullName }}</span>
+                    <div class="vendor-details">
+                      @if (vendor.phones && vendor.phones.length > 0) {
+                        <span class="vendor-phone">
+                          <mat-icon class="detail-icon">phone</mat-icon>
+                          {{ vendor.phones![0].number }}
+                        </span>
+                      }
+                      @if (vendor.emails && vendor.emails.length > 0) {
+                        <span class="vendor-email">
+                          <mat-icon class="detail-icon">email</mat-icon>
+                          {{ vendor.emails![0] }}
+                        </span>
+                      }
+                    </div>
+                    @if (vendor.tradeTags && vendor.tradeTags.length > 0) {
+                      <div class="trade-tags">
+                        @for (tag of vendor.tradeTags!; track tag.id) {
+                          <span class="trade-tag-chip">{{ tag.name }}</span>
+                        }
+                      </div>
+                    }
                   </div>
                   <mat-icon class="edit-icon">chevron_right</mat-icon>
                 </div>
@@ -207,14 +228,78 @@ import { VendorStore } from './stores/vendor.store';
 
       .vendor-info {
         flex: 1;
+        min-width: 0;
       }
 
       .vendor-name {
+        font-weight: 500;
+        display: block;
+      }
+
+      .vendor-details {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        margin-top: 4px;
+        font-size: 13px;
+        color: rgba(0, 0, 0, 0.6);
+      }
+
+      .vendor-phone,
+      .vendor-email {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .detail-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+        color: rgba(0, 0, 0, 0.4);
+      }
+
+      .trade-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 8px;
+      }
+
+      .trade-tag-chip {
+        display: inline-block;
+        background-color: #e8f5e9;
+        color: #2e7d32;
+        padding: 2px 10px;
+        border-radius: 12px;
+        font-size: 12px;
         font-weight: 500;
       }
 
       .edit-icon {
         color: rgba(0, 0, 0, 0.3);
+        flex-shrink: 0;
+      }
+
+      /* Responsive adjustments */
+      @media (max-width: 600px) {
+        .vendors-container {
+          padding: 16px;
+        }
+
+        .page-header {
+          flex-direction: column;
+          gap: 16px;
+        }
+
+        .add-button {
+          width: 100%;
+        }
+
+        .vendor-details {
+          flex-direction: column;
+          gap: 4px;
+        }
       }
     `,
   ],


### PR DESCRIPTION
## Summary
- Enhanced vendor list to display phone numbers, email addresses, and trade tags
- Backend VendorDto now includes Phones, Emails, TradeTags collections
- Frontend shows primary phone/email with trade tag chips for each vendor
- Graceful handling of missing contact info (shows nothing, not "N/A")

## Changes
### Backend
- Updated `VendorDto.cs` with Phones, Emails, TradeTags fields
- Updated `GetAllVendors.cs` to use Include/ThenInclude pattern for navigation properties
- Added 5 unit tests to `GetAllVendorsHandlerTests.cs`
- Fixed `VendorsControllerCreateTests.cs` VendorDto schema

### Frontend
- Enhanced `vendors.component.ts` template with phone, email, trade tags display
- Added CSS-styled chips for trade tags (simpler than mat-chip for list view)
- Added responsive styling for mobile
- Added 8 component tests to `vendors.component.spec.ts`
- Regenerated `api.service.ts` with NSwag

### E2E Tests
- Created new `vendor-list.spec.ts` with 6 E2E tests
- Updated `vendor.page.ts` with list display locators and assertions

## Test Results
- Backend: 624 tests passing (420 + 33 + 171)
- Frontend: 825 tests passing
- E2E: 6 new tests in vendor-list.spec.ts

## Test plan
- [ ] Verify vendor list displays trade tags as chips
- [ ] Verify vendor list displays primary phone number
- [ ] Verify vendor list displays primary email
- [ ] Verify empty phone/email/tags don't show "N/A"
- [ ] Verify clicking vendor navigates to edit page
- [ ] Verify responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)