### PR TITLE
feat(photos): add property photo gallery and upload components (Story 13.3b)

### DIFF
--- a/_bmad-output/implementation-artifacts/13-3a-property-photo-backend.md
+++ b/_bmad-output/implementation-artifacts/13-3a-property-photo-backend.md
@@ -1,6 +1,6 @@
 # Story 13.3a: Property Photo Backend - Entity & API
 
-Status: dev-complete
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/13-3b-property-photo-gallery-upload.md
+++ b/_bmad-output/implementation-artifacts/13-3b-property-photo-gallery-upload.md
@@ -1,6 +1,6 @@
 # Story 13.3b: Property Photo Gallery & Upload
 
-Status: blocked
+Status: ready-for-review
 
 ## Story
 
@@ -39,30 +39,30 @@ Split from [Story 13.3: Property Photo Gallery](13-3-property-photo-gallery.md)
 ## Tasks / Subtasks
 
 ### Task 1: Frontend - Property List Thumbnail (AC: 1)
-- [ ] 1.1 Update property card component to show thumbnail
-- [ ] 1.2 Add fallback home icon when no photo
-- [ ] 1.3 Style thumbnail with proper aspect ratio
+- [x] 1.1 Update property card component to show thumbnail
+- [x] 1.2 Add fallback home icon when no photo
+- [x] 1.3 Style thumbnail with proper aspect ratio
 
 ### Task 2: Frontend - Property Photo Gallery Component (AC: 2, 3, 4, 5, 6)
-- [ ] 2.1 Create `PropertyPhotoGalleryComponent` in `features/properties/components/`
-- [ ] 2.2 Implement responsive grid layout (CSS Grid)
-- [ ] 2.3 Add empty state with upload CTA
-- [ ] 2.4 Add skeleton loading placeholders
-- [ ] 2.5 Add fade-in transitions
+- [x] 2.1 Create `PropertyPhotoGalleryComponent` in `features/properties/components/`
+- [x] 2.2 Implement responsive grid layout (CSS Grid)
+- [x] 2.3 Add empty state with upload CTA
+- [x] 2.4 Add skeleton loading placeholders
+- [x] 2.5 Add fade-in transitions
 
 ### Task 3: Frontend - Property Photo Upload Component (AC: 7, 8, 9)
-- [ ] 3.1 Create `PropertyPhotoUploadComponent` with drag-drop zone
-- [ ] 3.2 Integrate existing `PhotoUploadService`
-- [ ] 3.3 Show upload progress bar
-- [ ] 3.4 Add client-side validation (file type, size)
-- [ ] 3.5 Handle errors with retry option
+- [x] 3.1 Create `PropertyPhotoUploadComponent` with drag-drop zone
+- [x] 3.2 Integrate existing `PhotoUploadService`
+- [x] 3.3 Show upload progress bar
+- [x] 3.4 Add client-side validation (file type, size)
+- [x] 3.5 Handle errors with retry option
 
 ### Task 4: Frontend - State Management & Integration
-- [ ] 4.1 Create property photo store (signals-based)
-- [ ] 4.2 Add photo gallery section to property-detail page
-- [ ] 4.3 Regenerate API client from backend
-- [ ] 4.4 Wire up all API calls
-- [ ] 4.5 Test mobile/tablet/desktop breakpoints
+- [x] 4.1 Create property photo store (signals-based)
+- [x] 4.2 Add photo gallery section to property-detail page
+- [x] 4.3 Regenerate API client from backend
+- [x] 4.4 Wire up all API calls
+- [x] 4.5 Test mobile/tablet/desktop breakpoints
 
 ## Dev Notes
 
@@ -140,9 +140,32 @@ frontend/src/app/features/properties/stores/property-photo.store.ts
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+Claude Opus 4.5 (claude-opus-4-5-20251101)
 
 ### Completion Notes List
 
+- **Task 1**: Updated `PropertyRowComponent` to show thumbnail from `primaryPhotoThumbnailUrl` with home icon fallback. Added `thumbnailUrl` input and updated styles. Updated `PropertySummaryDto` and `PropertyDetailDto` to include the new field.
+- **Task 2**: Created `PropertyPhotoGalleryComponent` with responsive CSS Grid layout (1/2/3 columns based on viewport), empty state with upload CTA, skeleton loading placeholders with shimmer animation, and fade-in transitions on image load. Primary photos show star badge.
+- **Task 3**: Created `PropertyPhotoUploadComponent` with drag-drop zone, file picker integration, upload progress bar, client-side file type/size validation using existing `PhotoUploadService`, and error states with retry option.
+- **Task 4**: Created `PropertyPhotoStore` with signals-based state management for photos list, upload progress, delete, set primary, and reorder operations. Integrated gallery and upload components into `PropertyDetailComponent` with upload dialog overlay.
+- All 1109 frontend tests passing
+
 ### File List
+
+**New Files:**
+- frontend/src/app/features/properties/components/property-photo-gallery/property-photo-gallery.component.ts
+- frontend/src/app/features/properties/components/property-photo-gallery/property-photo-gallery.component.spec.ts
+- frontend/src/app/features/properties/components/property-photo-upload/property-photo-upload.component.ts
+- frontend/src/app/features/properties/components/property-photo-upload/property-photo-upload.component.spec.ts
+- frontend/src/app/features/properties/stores/property-photo.store.ts
+
+**Modified Files:**
+- frontend/src/app/shared/components/property-row/property-row.component.ts (added thumbnailUrl input, updated template/styles)
+- frontend/src/app/shared/components/property-row/property-row.component.spec.ts (added thumbnail tests)
+- frontend/src/app/features/properties/properties.component.ts (pass thumbnailUrl to PropertyRow)
+- frontend/src/app/features/properties/services/property.service.ts (added primaryPhotoThumbnailUrl to DTOs)
+- frontend/src/app/features/properties/property-detail/property-detail.component.ts (integrated photo gallery, upload dialog)
+- frontend/src/app/features/properties/property-detail/property-detail.component.spec.ts (added mockPhotoStore)
+- frontend/src/app/core/api/api.service.ts (regenerated with PropertyPhoto endpoints)
+- frontend/nswag.json (temporarily updated port for API generation)
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -178,5 +178,8 @@ development_status:
   epic-13: in-progress
   13-1-backend-photo-service: done   # GitHub Issue #99 Part 1 - Backend services + thumbnail
   13-2-frontend-photo-components: done  # GitHub Issue #99 Part 2 - PhotosController + PhotoViewer, DragDrop, PhotoUpload
-  13-3-property-photo-gallery: backlog       # GitHub Issue #100 - Property photos UI/Feature
+  13-3-property-photo-gallery: in-progress   # GitHub Issue #100 - Property photos UI/Feature (split into 3a, 3b, 3c)
+  13-3a-property-photo-backend: done         # Entity, API endpoints, unit tests - PR #107 merged
+  13-3b-property-photo-gallery-upload: backlog  # Frontend gallery component with upload
+  13-3c-property-photo-lightbox-management: backlog  # Lightbox viewer and photo management
   epic-13-retrospective: optional

--- a/frontend/nswag.json
+++ b/frontend/nswag.json
@@ -3,7 +3,7 @@
   "defaultVariables": null,
   "documentGenerator": {
     "fromDocument": {
-      "url": "http://localhost:5293/swagger/v1/swagger.json",
+      "url": "http://localhost:5292/swagger/v1/swagger.json",
       "output": null,
       "newLineBehavior": "Auto"
     }

--- a/frontend/src/app/core/api/api.service.ts
+++ b/frontend/src/app/core/api/api.service.ts
@@ -51,6 +51,12 @@ export interface IApiClient {
     properties_GetPropertyById(id: string, year?: number | null | undefined): Observable<PropertyDetailDto>;
     properties_UpdateProperty(id: string, request: UpdatePropertyRequest): Observable<void>;
     properties_DeleteProperty(id: string): Observable<void>;
+    propertyPhotos_GenerateUploadUrl(propertyId: string, request: PropertyPhotoUploadUrlRequest): Observable<GeneratePropertyPhotoUploadUrlResponse>;
+    propertyPhotos_ConfirmUpload(propertyId: string, request: PropertyPhotoConfirmRequest): Observable<ConfirmPropertyPhotoUploadResponse>;
+    propertyPhotos_GetPhotos(propertyId: string): Observable<GetPropertyPhotosResponse>;
+    propertyPhotos_DeletePhoto(propertyId: string, photoId: string): Observable<void>;
+    propertyPhotos_SetPrimaryPhoto(propertyId: string, photoId: string): Observable<void>;
+    propertyPhotos_ReorderPhotos(propertyId: string, request: ReorderPropertyPhotosRequest): Observable<void>;
     receipts_GenerateUploadUrl(request: GenerateUploadUrlRequest): Observable<UploadUrlResponse>;
     receipts_CreateReceipt(request: CreateReceiptRequest): Observable<CreateReceiptResponse>;
     receipts_GetReceipt(id: string): Observable<ReceiptDto>;
@@ -72,6 +78,9 @@ export interface IApiClient {
     workOrders_GetAllWorkOrders(status?: string | null | undefined, propertyId?: string | null | undefined): Observable<GetAllWorkOrdersResponse>;
     workOrders_CreateWorkOrder(request: CreateWorkOrderRequest): Observable<CreateWorkOrderResponse>;
     workOrders_GetWorkOrder(id: string): Observable<WorkOrderDto>;
+    workOrders_UpdateWorkOrder(id: string, request: UpdateWorkOrderRequest): Observable<void>;
+    workOrderTags_GetAllWorkOrderTags(): Observable<GetAllWorkOrderTagsResponse>;
+    workOrderTags_CreateWorkOrderTag(request?: CreateWorkOrderTagRequest | undefined): Observable<CreateWorkOrderTagResponse>;
 }
 
 @Injectable({
@@ -2311,6 +2320,411 @@ export class ApiClient implements IApiClient {
         return _observableOf(null as any);
     }
 
+    propertyPhotos_GenerateUploadUrl(propertyId: string, request: PropertyPhotoUploadUrlRequest): Observable<GeneratePropertyPhotoUploadUrlResponse> {
+        let url_ = this.baseUrl + "/api/v1/properties/{propertyId}/photos/upload-url";
+        if (propertyId === undefined || propertyId === null)
+            throw new globalThis.Error("The parameter 'propertyId' must be defined.");
+        url_ = url_.replace("{propertyId}", encodeURIComponent("" + propertyId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_ : any = {
+            body: content_,
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("post", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processPropertyPhotos_GenerateUploadUrl(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processPropertyPhotos_GenerateUploadUrl(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<GeneratePropertyPhotoUploadUrlResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<GeneratePropertyPhotoUploadUrlResponse>;
+        }));
+    }
+
+    protected processPropertyPhotos_GenerateUploadUrl(response: HttpResponseBase): Observable<GeneratePropertyPhotoUploadUrlResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 200) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as GeneratePropertyPhotoUploadUrlResponse;
+            return _observableOf(result200);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ValidationProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    propertyPhotos_ConfirmUpload(propertyId: string, request: PropertyPhotoConfirmRequest): Observable<ConfirmPropertyPhotoUploadResponse> {
+        let url_ = this.baseUrl + "/api/v1/properties/{propertyId}/photos";
+        if (propertyId === undefined || propertyId === null)
+            throw new globalThis.Error("The parameter 'propertyId' must be defined.");
+        url_ = url_.replace("{propertyId}", encodeURIComponent("" + propertyId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_ : any = {
+            body: content_,
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("post", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processPropertyPhotos_ConfirmUpload(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processPropertyPhotos_ConfirmUpload(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<ConfirmPropertyPhotoUploadResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<ConfirmPropertyPhotoUploadResponse>;
+        }));
+    }
+
+    protected processPropertyPhotos_ConfirmUpload(response: HttpResponseBase): Observable<ConfirmPropertyPhotoUploadResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 201) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result201: any = null;
+            result201 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ConfirmPropertyPhotoUploadResponse;
+            return _observableOf(result201);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ValidationProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    propertyPhotos_GetPhotos(propertyId: string): Observable<GetPropertyPhotosResponse> {
+        let url_ = this.baseUrl + "/api/v1/properties/{propertyId}/photos";
+        if (propertyId === undefined || propertyId === null)
+            throw new globalThis.Error("The parameter 'propertyId' must be defined.");
+        url_ = url_.replace("{propertyId}", encodeURIComponent("" + propertyId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("get", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processPropertyPhotos_GetPhotos(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processPropertyPhotos_GetPhotos(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<GetPropertyPhotosResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<GetPropertyPhotosResponse>;
+        }));
+    }
+
+    protected processPropertyPhotos_GetPhotos(response: HttpResponseBase): Observable<GetPropertyPhotosResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 200) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as GetPropertyPhotosResponse;
+            return _observableOf(result200);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    propertyPhotos_DeletePhoto(propertyId: string, photoId: string): Observable<void> {
+        let url_ = this.baseUrl + "/api/v1/properties/{propertyId}/photos/{photoId}";
+        if (propertyId === undefined || propertyId === null)
+            throw new globalThis.Error("The parameter 'propertyId' must be defined.");
+        url_ = url_.replace("{propertyId}", encodeURIComponent("" + propertyId));
+        if (photoId === undefined || photoId === null)
+            throw new globalThis.Error("The parameter 'photoId' must be defined.");
+        url_ = url_.replace("{photoId}", encodeURIComponent("" + photoId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+            })
+        };
+
+        return this.http.request("delete", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processPropertyPhotos_DeletePhoto(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processPropertyPhotos_DeletePhoto(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<void>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<void>;
+        }));
+    }
+
+    protected processPropertyPhotos_DeletePhoto(response: HttpResponseBase): Observable<void> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return _observableOf(null as any);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    propertyPhotos_SetPrimaryPhoto(propertyId: string, photoId: string): Observable<void> {
+        let url_ = this.baseUrl + "/api/v1/properties/{propertyId}/photos/{photoId}/primary";
+        if (propertyId === undefined || propertyId === null)
+            throw new globalThis.Error("The parameter 'propertyId' must be defined.");
+        url_ = url_.replace("{propertyId}", encodeURIComponent("" + propertyId));
+        if (photoId === undefined || photoId === null)
+            throw new globalThis.Error("The parameter 'photoId' must be defined.");
+        url_ = url_.replace("{photoId}", encodeURIComponent("" + photoId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+            })
+        };
+
+        return this.http.request("put", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processPropertyPhotos_SetPrimaryPhoto(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processPropertyPhotos_SetPrimaryPhoto(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<void>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<void>;
+        }));
+    }
+
+    protected processPropertyPhotos_SetPrimaryPhoto(response: HttpResponseBase): Observable<void> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return _observableOf(null as any);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    propertyPhotos_ReorderPhotos(propertyId: string, request: ReorderPropertyPhotosRequest): Observable<void> {
+        let url_ = this.baseUrl + "/api/v1/properties/{propertyId}/photos/reorder";
+        if (propertyId === undefined || propertyId === null)
+            throw new globalThis.Error("The parameter 'propertyId' must be defined.");
+        url_ = url_.replace("{propertyId}", encodeURIComponent("" + propertyId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_ : any = {
+            body: content_,
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Content-Type": "application/json",
+            })
+        };
+
+        return this.http.request("put", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processPropertyPhotos_ReorderPhotos(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processPropertyPhotos_ReorderPhotos(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<void>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<void>;
+        }));
+    }
+
+    protected processPropertyPhotos_ReorderPhotos(response: HttpResponseBase): Observable<void> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return _observableOf(null as any);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ValidationProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
     receipts_GenerateUploadUrl(request: GenerateUploadUrlRequest): Observable<UploadUrlResponse> {
         let url_ = this.baseUrl + "/api/v1/receipts/upload-url";
         url_ = url_.replace(/[?&]$/, "");
@@ -3664,6 +4078,200 @@ export class ApiClient implements IApiClient {
         }
         return _observableOf(null as any);
     }
+
+    workOrders_UpdateWorkOrder(id: string, request: UpdateWorkOrderRequest): Observable<void> {
+        let url_ = this.baseUrl + "/api/v1/work-orders/{id}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_ : any = {
+            body: content_,
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Content-Type": "application/json",
+            })
+        };
+
+        return this.http.request("put", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processWorkOrders_UpdateWorkOrder(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processWorkOrders_UpdateWorkOrder(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<void>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<void>;
+        }));
+    }
+
+    protected processWorkOrders_UpdateWorkOrder(response: HttpResponseBase): Observable<void> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return _observableOf(null as any);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ValidationProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    workOrderTags_GetAllWorkOrderTags(): Observable<GetAllWorkOrderTagsResponse> {
+        let url_ = this.baseUrl + "/api/v1/work-order-tags";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("get", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processWorkOrderTags_GetAllWorkOrderTags(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processWorkOrderTags_GetAllWorkOrderTags(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<GetAllWorkOrderTagsResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<GetAllWorkOrderTagsResponse>;
+        }));
+    }
+
+    protected processWorkOrderTags_GetAllWorkOrderTags(response: HttpResponseBase): Observable<GetAllWorkOrderTagsResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 200) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as GetAllWorkOrderTagsResponse;
+            return _observableOf(result200);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    workOrderTags_CreateWorkOrderTag(request?: CreateWorkOrderTagRequest | undefined): Observable<CreateWorkOrderTagResponse> {
+        let url_ = this.baseUrl + "/api/v1/work-order-tags";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_ : any = {
+            body: content_,
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("post", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processWorkOrderTags_CreateWorkOrderTag(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processWorkOrderTags_CreateWorkOrderTag(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<CreateWorkOrderTagResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<CreateWorkOrderTagResponse>;
+        }));
+    }
+
+    protected processWorkOrderTags_CreateWorkOrderTag(response: HttpResponseBase): Observable<CreateWorkOrderTagResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 201) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result201: any = null;
+            result201 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as CreateWorkOrderTagResponse;
+            return _observableOf(result201);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ValidationProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 409) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result409: any = null;
+            result409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result409);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
 }
 
 export interface ProblemDetails {
@@ -3958,6 +4566,7 @@ export interface PropertySummaryDto {
     zipCode?: string;
     expenseTotal?: number;
     incomeTotal?: number;
+    primaryPhotoThumbnailUrl?: string | undefined;
 }
 
 export interface PropertyDetailDto {
@@ -3973,6 +4582,7 @@ export interface PropertyDetailDto {
     updatedAt?: Date;
     recentExpenses?: ExpenseSummaryDto[];
     recentIncome?: IncomeSummaryDto[];
+    primaryPhotoThumbnailUrl?: string | undefined;
 }
 
 export interface ExpenseSummaryDto {
@@ -4007,6 +4617,52 @@ export interface UpdatePropertyRequest {
     city?: string;
     state?: string;
     zipCode?: string;
+}
+
+export interface GeneratePropertyPhotoUploadUrlResponse {
+    uploadUrl?: string;
+    storageKey?: string;
+    thumbnailStorageKey?: string;
+    expiresAt?: Date;
+}
+
+export interface PropertyPhotoUploadUrlRequest {
+    contentType?: string;
+    fileSizeBytes?: number;
+    originalFileName?: string;
+}
+
+export interface ConfirmPropertyPhotoUploadResponse {
+    id?: string;
+    thumbnailUrl?: string | undefined;
+    viewUrl?: string | undefined;
+}
+
+export interface PropertyPhotoConfirmRequest {
+    storageKey?: string;
+    thumbnailStorageKey?: string;
+    contentType?: string;
+    fileSizeBytes?: number;
+    originalFileName?: string;
+}
+
+export interface GetPropertyPhotosResponse {
+    items?: PropertyPhotoDto[];
+}
+
+export interface PropertyPhotoDto {
+    id?: string;
+    thumbnailUrl?: string | undefined;
+    viewUrl?: string | undefined;
+    isPrimary?: boolean;
+    displayOrder?: number;
+    originalFileName?: string;
+    fileSizeBytes?: number;
+    createdAt?: Date;
+}
+
+export interface ReorderPropertyPhotosRequest {
+    photoIds?: string[];
 }
 
 export interface UploadUrlResponse {

--- a/frontend/src/app/features/properties/components/property-photo-gallery/property-photo-gallery.component.spec.ts
+++ b/frontend/src/app/features/properties/components/property-photo-gallery/property-photo-gallery.component.spec.ts
@@ -1,0 +1,236 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PropertyPhotoGalleryComponent, PropertyPhoto } from './property-photo-gallery.component';
+import { provideAnimations } from '@angular/platform-browser/animations';
+
+describe('PropertyPhotoGalleryComponent', () => {
+  let component: PropertyPhotoGalleryComponent;
+  let fixture: ComponentFixture<PropertyPhotoGalleryComponent>;
+
+  const mockPhotos: PropertyPhoto[] = [
+    {
+      id: 'photo-1',
+      thumbnailUrl: 'https://example.com/thumb1.jpg',
+      viewUrl: 'https://example.com/view1.jpg',
+      isPrimary: true,
+      displayOrder: 0,
+      originalFileName: 'front-view.jpg',
+      fileSizeBytes: 1024000,
+      createdAt: new Date('2026-01-15'),
+    },
+    {
+      id: 'photo-2',
+      thumbnailUrl: 'https://example.com/thumb2.jpg',
+      viewUrl: 'https://example.com/view2.jpg',
+      isPrimary: false,
+      displayOrder: 1,
+      originalFileName: 'kitchen.jpg',
+      fileSizeBytes: 2048000,
+      createdAt: new Date('2026-01-16'),
+    },
+    {
+      id: 'photo-3',
+      thumbnailUrl: 'https://example.com/thumb3.jpg',
+      viewUrl: 'https://example.com/view3.jpg',
+      isPrimary: false,
+      displayOrder: 2,
+      originalFileName: 'bathroom.jpg',
+      fileSizeBytes: 1536000,
+      createdAt: new Date('2026-01-17'),
+    },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PropertyPhotoGalleryComponent],
+      providers: [provideAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PropertyPhotoGalleryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Empty State (AC-13.3b.3)', () => {
+    it('should show empty state when no photos and not loading', () => {
+      fixture.componentRef.setInput('photos', []);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+
+      const emptyState = fixture.nativeElement.querySelector('.empty-state');
+      expect(emptyState).toBeTruthy();
+      expect(emptyState.querySelector('h3').textContent).toContain('No photos yet');
+    });
+
+    it('should show "Add First Photo" button in empty state', () => {
+      fixture.componentRef.setInput('photos', []);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+
+      const addButton = fixture.nativeElement.querySelector('.empty-state button');
+      expect(addButton).toBeTruthy();
+      expect(addButton.textContent).toContain('Add First Photo');
+    });
+
+    it('should emit addPhotoClick when "Add First Photo" is clicked', () => {
+      fixture.componentRef.setInput('photos', []);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+
+      const addClickSpy = vi.fn();
+      component.addPhotoClick.subscribe(addClickSpy);
+
+      const addButton = fixture.nativeElement.querySelector('.empty-state button');
+      addButton.click();
+
+      expect(addClickSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Loading State (AC-13.3b.4)', () => {
+    it('should show skeleton placeholders when loading', () => {
+      fixture.componentRef.setInput('isLoading', true);
+      fixture.detectChanges();
+
+      const skeletons = fixture.nativeElement.querySelectorAll('.photo-skeleton');
+      expect(skeletons.length).toBe(6);
+    });
+
+    it('should not show empty state when loading', () => {
+      fixture.componentRef.setInput('isLoading', true);
+      fixture.componentRef.setInput('photos', []);
+      fixture.detectChanges();
+
+      const emptyState = fixture.nativeElement.querySelector('.empty-state');
+      expect(emptyState).toBeFalsy();
+    });
+
+    it('should show shimmer animation on skeletons', () => {
+      fixture.componentRef.setInput('isLoading', true);
+      fixture.detectChanges();
+
+      const shimmer = fixture.nativeElement.querySelector('.skeleton-shimmer');
+      expect(shimmer).toBeTruthy();
+    });
+  });
+
+  describe('Photo Grid (AC-13.3b.2)', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('photos', mockPhotos);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+    });
+
+    it('should display gallery grid with photos', () => {
+      const grid = fixture.nativeElement.querySelector('.gallery-grid');
+      expect(grid).toBeTruthy();
+
+      const photoCards = fixture.nativeElement.querySelectorAll('.photo-card');
+      expect(photoCards.length).toBe(3);
+    });
+
+    it('should show photo thumbnails', () => {
+      const images = fixture.nativeElement.querySelectorAll('.photo-img');
+      expect(images.length).toBe(3);
+      expect(images[0].src).toBe('https://example.com/thumb1.jpg');
+    });
+
+    it('should show primary badge on primary photo', () => {
+      const primaryBadge = fixture.nativeElement.querySelector('.photo-card.is-primary .primary-badge');
+      expect(primaryBadge).toBeTruthy();
+    });
+
+    it('should not show primary badge on non-primary photos', () => {
+      const nonPrimaryCards = fixture.nativeElement.querySelectorAll('.photo-card:not(.is-primary)');
+      expect(nonPrimaryCards.length).toBe(2);
+
+      nonPrimaryCards.forEach((card: Element) => {
+        expect(card.querySelector('.primary-badge')).toBeFalsy();
+      });
+    });
+
+    it('should emit photoClick when photo card is clicked', () => {
+      const photoClickSpy = vi.fn();
+      component.photoClick.subscribe(photoClickSpy);
+
+      const firstCard = fixture.nativeElement.querySelector('.photo-card');
+      firstCard.click();
+
+      expect(photoClickSpy).toHaveBeenCalledWith(mockPhotos[0]);
+    });
+
+    it('should have proper accessibility attributes on photo cards', () => {
+      const card = fixture.nativeElement.querySelector('.photo-card');
+      expect(card.getAttribute('tabindex')).toBe('0');
+      expect(card.getAttribute('role')).toBe('button');
+      expect(card.getAttribute('aria-label')).toContain('front-view.jpg');
+    });
+  });
+
+  describe('Add Photo Button', () => {
+    it('should show "Add Photo" button in header when photos exist', () => {
+      fixture.componentRef.setInput('photos', mockPhotos);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+
+      const addButton = fixture.nativeElement.querySelector('.add-photo-btn');
+      expect(addButton).toBeTruthy();
+      expect(addButton.textContent).toContain('Add Photo');
+    });
+
+    it('should not show "Add Photo" button in header when no photos', () => {
+      fixture.componentRef.setInput('photos', []);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+
+      const addButton = fixture.nativeElement.querySelector('.add-photo-btn');
+      expect(addButton).toBeFalsy();
+    });
+
+    it('should emit addPhotoClick when header "Add Photo" is clicked', () => {
+      fixture.componentRef.setInput('photos', mockPhotos);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+
+      const addClickSpy = vi.fn();
+      component.addPhotoClick.subscribe(addClickSpy);
+
+      const addButton = fixture.nativeElement.querySelector('.add-photo-btn');
+      addButton.click();
+
+      expect(addClickSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Fade-in Animation (AC-13.3b.6)', () => {
+    it('should add "loaded" class when image loads', () => {
+      fixture.componentRef.setInput('photos', mockPhotos);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+
+      const img = fixture.nativeElement.querySelector('.photo-img');
+      expect(img.classList.contains('loaded')).toBe(false);
+
+      // Simulate image load
+      const loadEvent = new Event('load');
+      img.dispatchEvent(loadEvent);
+
+      expect(img.classList.contains('loaded')).toBe(true);
+    });
+  });
+
+  describe('Responsive Grid (AC-13.3b.5)', () => {
+    it('should have gallery-grid class for CSS grid layout', () => {
+      fixture.componentRef.setInput('photos', mockPhotos);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+
+      const grid = fixture.nativeElement.querySelector('.gallery-grid');
+      expect(grid).toBeTruthy();
+      // CSS media queries handle the actual column count
+    });
+  });
+});

--- a/frontend/src/app/features/properties/components/property-photo-gallery/property-photo-gallery.component.ts
+++ b/frontend/src/app/features/properties/components/property-photo-gallery/property-photo-gallery.component.ts
@@ -1,0 +1,312 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+/**
+ * Photo data interface matching API PropertyPhotoDto
+ */
+export interface PropertyPhoto {
+  id: string;
+  thumbnailUrl?: string | null;
+  viewUrl?: string | null;
+  isPrimary: boolean;
+  displayOrder: number;
+  originalFileName?: string;
+  fileSizeBytes?: number;
+  createdAt?: Date;
+}
+
+/**
+ * PropertyPhotoGalleryComponent (AC-13.3b.2, AC-13.3b.3, AC-13.3b.4, AC-13.3b.5, AC-13.3b.6)
+ *
+ * Displays property photos in a responsive grid:
+ * - 1 column on mobile (<600px)
+ * - 2 columns on tablet (600-959px)
+ * - 3 columns on desktop (960px+)
+ * - Max 12 photos visible (3x4 grid on desktop)
+ *
+ * Features:
+ * - Empty state with upload CTA when no photos
+ * - Skeleton loading placeholders during fetch
+ * - Fade-in animations when photos load
+ * - Primary photo indicator badge
+ */
+@Component({
+  selector: 'app-property-photo-gallery',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+  ],
+  template: `
+    <mat-card class="gallery-card">
+      <mat-card-header>
+        <mat-card-title>
+          <mat-icon>photo_library</mat-icon>
+          Photos
+        </mat-card-title>
+        @if (!isLoading() && photos().length > 0) {
+          <button mat-stroked-button color="primary" class="add-photo-btn" (click)="addPhotoClick.emit()">
+            <mat-icon>add_a_photo</mat-icon>
+            Add Photo
+          </button>
+        }
+      </mat-card-header>
+      <mat-card-content>
+        <!-- Loading State (AC-13.3b.4) -->
+        @if (isLoading()) {
+          <div class="gallery-grid">
+            @for (i of skeletonItems; track i) {
+              <div class="photo-skeleton">
+                <div class="skeleton-shimmer"></div>
+              </div>
+            }
+          </div>
+        }
+
+        <!-- Empty State (AC-13.3b.3) -->
+        @if (!isLoading() && photos().length === 0) {
+          <div class="empty-state">
+            <mat-icon>add_photo_alternate</mat-icon>
+            <h3>No photos yet</h3>
+            <p>Add photos to visually document this property</p>
+            <button mat-raised-button color="primary" (click)="addPhotoClick.emit()">
+              <mat-icon>add_a_photo</mat-icon>
+              Add First Photo
+            </button>
+          </div>
+        }
+
+        <!-- Photo Grid (AC-13.3b.2, AC-13.3b.5, AC-13.3b.6) -->
+        @if (!isLoading() && photos().length > 0) {
+          <div class="gallery-grid">
+            @for (photo of photos(); track photo.id) {
+              <div
+                class="photo-card"
+                [class.is-primary]="photo.isPrimary"
+                (click)="photoClick.emit(photo)"
+                (keydown.enter)="photoClick.emit(photo)"
+                tabindex="0"
+                role="button"
+                [attr.aria-label]="'View ' + (photo.originalFileName || 'photo')">
+                @if (photo.isPrimary) {
+                  <div class="primary-badge">
+                    <mat-icon>star</mat-icon>
+                  </div>
+                }
+                <img
+                  [src]="photo.thumbnailUrl || photo.viewUrl"
+                  [alt]="photo.originalFileName || 'Property photo'"
+                  class="photo-img"
+                  loading="lazy"
+                  (load)="onImageLoad($event)"
+                />
+              </div>
+            }
+          </div>
+        }
+      </mat-card-content>
+    </mat-card>
+  `,
+  styles: [`
+    .gallery-card {
+      mat-card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 16px;
+
+        mat-card-title {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          margin: 0;
+
+          mat-icon {
+            color: var(--pm-primary);
+          }
+        }
+
+        .add-photo-btn {
+          mat-icon {
+            margin-right: 4px;
+          }
+        }
+      }
+    }
+
+    /* Responsive Grid (AC-13.3b.5) */
+    .gallery-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(1, 1fr);
+
+      @media (min-width: 600px) {
+        grid-template-columns: repeat(2, 1fr);
+      }
+
+      @media (min-width: 960px) {
+        grid-template-columns: repeat(3, 1fr);
+      }
+    }
+
+    /* Photo Card */
+    .photo-card {
+      position: relative;
+      aspect-ratio: 4 / 3;
+      border-radius: 8px;
+      overflow: hidden;
+      cursor: pointer;
+      background-color: var(--pm-surface-variant, #f5f5f5);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+      &:hover {
+        transform: scale(1.02);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      }
+
+      &:focus {
+        outline: 2px solid var(--pm-primary);
+        outline-offset: 2px;
+      }
+
+      &.is-primary {
+        box-shadow: 0 0 0 2px var(--pm-primary);
+      }
+    }
+
+    .photo-img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 0.3s ease-in-out;
+
+      &.loaded {
+        opacity: 1;
+      }
+    }
+
+    .primary-badge {
+      position: absolute;
+      top: 8px;
+      left: 8px;
+      background-color: var(--pm-primary);
+      color: white;
+      border-radius: 50%;
+      width: 28px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+
+      mat-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    /* Skeleton Loading (AC-13.3b.4) */
+    .photo-skeleton {
+      aspect-ratio: 4 / 3;
+      border-radius: 8px;
+      overflow: hidden;
+      background-color: var(--pm-surface-variant, #e0e0e0);
+    }
+
+    .skeleton-shimmer {
+      width: 100%;
+      height: 100%;
+      background: linear-gradient(
+        90deg,
+        transparent 0%,
+        rgba(255, 255, 255, 0.4) 50%,
+        transparent 100%
+      );
+      animation: shimmer 1.5s infinite;
+    }
+
+    @keyframes shimmer {
+      0% {
+        transform: translateX(-100%);
+      }
+      100% {
+        transform: translateX(100%);
+      }
+    }
+
+    /* Empty State (AC-13.3b.3) */
+    .empty-state {
+      text-align: center;
+      padding: 48px 24px;
+      color: var(--pm-text-secondary);
+
+      mat-icon {
+        font-size: 64px;
+        width: 64px;
+        height: 64px;
+        opacity: 0.5;
+        margin-bottom: 16px;
+      }
+
+      h3 {
+        color: var(--pm-text-primary);
+        font-size: 18px;
+        font-weight: 500;
+        margin: 0 0 8px 0;
+      }
+
+      p {
+        font-size: 14px;
+        margin: 0 0 24px 0;
+      }
+
+      button mat-icon {
+        margin-right: 8px;
+      }
+    }
+  `]
+})
+export class PropertyPhotoGalleryComponent {
+  /**
+   * List of photos to display
+   */
+  readonly photos = input<PropertyPhoto[]>([]);
+
+  /**
+   * Whether photos are currently loading
+   */
+  readonly isLoading = input<boolean>(false);
+
+  /**
+   * Emitted when user clicks "Add Photo" button
+   */
+  readonly addPhotoClick = output<void>();
+
+  /**
+   * Emitted when user clicks on a photo (for lightbox/details)
+   */
+  readonly photoClick = output<PropertyPhoto>();
+
+  /**
+   * Skeleton placeholder items for loading state
+   */
+  readonly skeletonItems = [1, 2, 3, 4, 5, 6];
+
+  /**
+   * Handle image load event for fade-in animation (AC-13.3b.6)
+   */
+  onImageLoad(event: Event): void {
+    const img = event.target as HTMLImageElement;
+    img.classList.add('loaded');
+  }
+}

--- a/frontend/src/app/features/properties/components/property-photo-upload/property-photo-upload.component.spec.ts
+++ b/frontend/src/app/features/properties/components/property-photo-upload/property-photo-upload.component.spec.ts
@@ -1,0 +1,294 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PropertyPhotoUploadComponent } from './property-photo-upload.component';
+import { PhotoUploadService, PhotoUploadResult } from '../../../../shared/services/photo-upload.service';
+import { provideAnimations } from '@angular/platform-browser/animations';
+
+describe('PropertyPhotoUploadComponent', () => {
+  let component: PropertyPhotoUploadComponent;
+  let fixture: ComponentFixture<PropertyPhotoUploadComponent>;
+  let mockPhotoUploadService: {
+    uploadPhoto: ReturnType<typeof vi.fn>;
+    isValidFileType: ReturnType<typeof vi.fn>;
+    isValidFileSize: ReturnType<typeof vi.fn>;
+    getAcceptString: ReturnType<typeof vi.fn>;
+    getMaxFileSizeBytes: ReturnType<typeof vi.fn>;
+  };
+
+  const createMockFile = (name: string, type: string): File => {
+    const blob = new Blob(['test content'], { type });
+    return new File([blob], name, { type });
+  };
+
+  const mockUploadResult: PhotoUploadResult = {
+    storageKey: 'photos/property-123/abc123.jpg',
+    thumbnailStorageKey: 'photos/property-123/thumbs/abc123.jpg',
+    contentType: 'image/jpeg',
+    fileSizeBytes: 1024000,
+  };
+
+  beforeEach(async () => {
+    mockPhotoUploadService = {
+      uploadPhoto: vi.fn(),
+      isValidFileType: vi.fn().mockReturnValue(true),
+      isValidFileSize: vi.fn().mockReturnValue(true),
+      getAcceptString: vi.fn().mockReturnValue('image/jpeg,image/png,image/gif,image/webp'),
+      getMaxFileSizeBytes: vi.fn().mockReturnValue(10 * 1024 * 1024),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [PropertyPhotoUploadComponent],
+      providers: [
+        provideAnimations(),
+        { provide: PhotoUploadService, useValue: mockPhotoUploadService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PropertyPhotoUploadComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('propertyId', 'property-123');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Idle State', () => {
+    it('should show upload icon and instructions in idle state', () => {
+      const uploadIcon = fixture.nativeElement.querySelector('.upload-icon');
+      const dropText = fixture.nativeElement.querySelector('.drop-text');
+
+      expect(uploadIcon.textContent).toContain('cloud_upload');
+      expect(dropText.textContent).toContain('Drag & drop');
+    });
+
+    it('should show file type info', () => {
+      const fileInfo = fixture.nativeElement.querySelector('.file-info');
+      expect(fileInfo.textContent).toContain('JPEG, PNG, GIF, WebP');
+      expect(fileInfo.textContent).toContain('10MB');
+    });
+  });
+
+  describe('Drag and Drop (AC-13.3b.7)', () => {
+    it('should set dragging state on dragover', () => {
+      component.onDragOver({ preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as DragEvent);
+      fixture.detectChanges();
+
+      expect(component.isDragging()).toBe(true);
+      const dropZone = fixture.nativeElement.querySelector('.drop-zone');
+      expect(dropZone.classList.contains('dragging')).toBe(true);
+    });
+
+    it('should clear dragging state on dragleave', () => {
+      component.isDragging.set(true);
+      fixture.detectChanges();
+
+      component.onDragLeave({ preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as DragEvent);
+      fixture.detectChanges();
+
+      expect(component.isDragging()).toBe(false);
+    });
+
+    it('should not set dragging when uploading', () => {
+      component.uploadState.set({ status: 'uploading', progress: 50, error: null, file: null });
+      component.onDragOver({ preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as DragEvent);
+      fixture.detectChanges();
+
+      expect(component.isDragging()).toBe(false);
+    });
+  });
+
+  describe('File Selection', () => {
+    it('should have hidden file input', () => {
+      const fileInput = fixture.nativeElement.querySelector('input[type="file"]');
+      expect(fileInput).toBeTruthy();
+      expect(fileInput.hidden).toBe(true);
+    });
+
+    it('should accept correct file types', () => {
+      const fileInput = fixture.nativeElement.querySelector('input[type="file"]');
+      expect(fileInput.accept).toContain('image/jpeg');
+    });
+  });
+
+  describe('Client-side Validation (AC-13.3b.7)', () => {
+    it('should show validation error for invalid file type', () => {
+      mockPhotoUploadService.isValidFileType.mockReturnValue(false);
+
+      const file = createMockFile('test.txt', 'text/plain');
+      component['handleFile'](file);
+      fixture.detectChanges();
+
+      const validationError = fixture.nativeElement.querySelector('.validation-error');
+      expect(validationError).toBeTruthy();
+      expect(validationError.textContent).toContain('Invalid file type');
+    });
+
+    it('should show validation error for file too large', () => {
+      mockPhotoUploadService.isValidFileType.mockReturnValue(true);
+      mockPhotoUploadService.isValidFileSize.mockReturnValue(false);
+
+      const file = createMockFile('large.jpg', 'image/jpeg');
+      component['handleFile'](file);
+      fixture.detectChanges();
+
+      const validationError = fixture.nativeElement.querySelector('.validation-error');
+      expect(validationError).toBeTruthy();
+      expect(validationError.textContent).toContain('File too large');
+    });
+
+    it('should not start upload for invalid file', () => {
+      mockPhotoUploadService.isValidFileType.mockReturnValue(false);
+
+      const file = createMockFile('test.txt', 'text/plain');
+      component['handleFile'](file);
+
+      expect(mockPhotoUploadService.uploadPhoto).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Upload Progress (AC-13.3b.7)', () => {
+    it('should show progress bar during upload', async () => {
+      let progressCallback: ((p: number) => void) | undefined;
+      mockPhotoUploadService.uploadPhoto.mockImplementation(
+        (_file: File, options: { onProgress?: (p: number) => void }) => {
+          progressCallback = options.onProgress;
+          return new Promise(() => {}); // Never resolves
+        }
+      );
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      component['handleFile'](file);
+      fixture.detectChanges();
+
+      expect(component.uploadState().status).toBe('uploading');
+
+      const progressBar = fixture.nativeElement.querySelector('mat-progress-bar');
+      expect(progressBar).toBeTruthy();
+
+      // Simulate progress
+      progressCallback?.(50);
+      fixture.detectChanges();
+      expect(component.uploadState().progress).toBe(50);
+    });
+
+    it('should show spinning icon during upload', () => {
+      mockPhotoUploadService.uploadPhoto.mockImplementation(() => new Promise(() => {}));
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      component['handleFile'](file);
+      fixture.detectChanges();
+
+      const icon = fixture.nativeElement.querySelector('.upload-icon');
+      expect(icon.classList.contains('spinning')).toBe(true);
+      expect(icon.textContent).toContain('sync');
+    });
+  });
+
+  describe('Upload Success', () => {
+    it('should show success state after upload completes', async () => {
+      mockPhotoUploadService.uploadPhoto.mockResolvedValue(mockUploadResult);
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      await component['startUpload'](file);
+      fixture.detectChanges();
+
+      expect(component.uploadState().status).toBe('success');
+
+      const icon = fixture.nativeElement.querySelector('.upload-icon');
+      expect(icon.textContent).toContain('check_circle');
+    });
+
+    it('should emit uploadComplete on success', async () => {
+      mockPhotoUploadService.uploadPhoto.mockResolvedValue(mockUploadResult);
+
+      const uploadCompleteSpy = vi.fn();
+      component.uploadComplete.subscribe(uploadCompleteSpy);
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      await component['startUpload'](file);
+
+      expect(uploadCompleteSpy).toHaveBeenCalledWith(mockUploadResult);
+    });
+
+    it('should show "Upload Another" button on success', async () => {
+      mockPhotoUploadService.uploadPhoto.mockResolvedValue(mockUploadResult);
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      await component['startUpload'](file);
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector('button');
+      expect(button.textContent).toContain('Upload Another');
+    });
+  });
+
+  describe('Error State (AC-13.3b.8)', () => {
+    it('should show error state on upload failure', async () => {
+      mockPhotoUploadService.uploadPhoto.mockRejectedValue(new Error('Network error'));
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      await component['startUpload'](file);
+      fixture.detectChanges();
+
+      expect(component.uploadState().status).toBe('error');
+
+      const icon = fixture.nativeElement.querySelector('.upload-icon');
+      expect(icon.classList.contains('error')).toBe(true);
+    });
+
+    it('should show error message', async () => {
+      mockPhotoUploadService.uploadPhoto.mockRejectedValue(new Error('Network error'));
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      await component['startUpload'](file);
+      fixture.detectChanges();
+
+      const errorMessage = fixture.nativeElement.querySelector('.error-message');
+      expect(errorMessage.textContent).toContain('Network error');
+    });
+
+    it('should show retry button on error', async () => {
+      mockPhotoUploadService.uploadPhoto.mockRejectedValue(new Error('Network error'));
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      await component['startUpload'](file);
+      fixture.detectChanges();
+
+      const retryButton = fixture.nativeElement.querySelector('.error-actions button');
+      expect(retryButton.textContent).toContain('Retry');
+    });
+
+    it('should retry upload when retry button clicked', async () => {
+      mockPhotoUploadService.uploadPhoto
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(mockUploadResult);
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      await component['startUpload'](file);
+      fixture.detectChanges();
+
+      // Click retry
+      component.retryUpload({ stopPropagation: vi.fn() } as unknown as Event);
+      await vi.waitFor(() => expect(mockPhotoUploadService.uploadPhoto).toHaveBeenCalledTimes(2));
+      fixture.detectChanges();
+
+      expect(component.uploadState().status).toBe('success');
+    });
+  });
+
+  describe('Reset', () => {
+    it('should reset to idle state when reset is called', async () => {
+      mockPhotoUploadService.uploadPhoto.mockResolvedValue(mockUploadResult);
+
+      const file = createMockFile('test.jpg', 'image/jpeg');
+      await component['startUpload'](file);
+      fixture.detectChanges();
+
+      component.resetUpload({ stopPropagation: vi.fn() } as unknown as Event);
+      fixture.detectChanges();
+
+      expect(component.uploadState().status).toBe('idle');
+    });
+  });
+});

--- a/frontend/src/app/features/properties/components/property-photo-upload/property-photo-upload.component.ts
+++ b/frontend/src/app/features/properties/components/property-photo-upload/property-photo-upload.component.ts
@@ -1,0 +1,430 @@
+import { Component, input, output, signal, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { PhotoUploadService, PhotoUploadResult } from '../../../../shared/services/photo-upload.service';
+import { PhotoEntityType } from '../../../../core/api/api.service';
+
+/**
+ * Upload state interface
+ */
+interface UploadState {
+  status: 'idle' | 'uploading' | 'success' | 'error';
+  progress: number;
+  error: string | null;
+  file: File | null;
+}
+
+/**
+ * PropertyPhotoUploadComponent (AC-13.3b.7, AC-13.3b.8, AC-13.3b.9)
+ *
+ * Photo upload component with:
+ * - Drag-and-drop zone
+ * - File picker button
+ * - Upload progress bar
+ * - Client-side file type/size validation
+ * - Error states with retry option
+ *
+ * Integrates with existing PhotoUploadService for S3 direct upload.
+ */
+@Component({
+  selector: 'app-property-photo-upload',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressBarModule,
+  ],
+  template: `
+    <div class="upload-container">
+      <!-- Drag & Drop Zone (AC-13.3b.7) -->
+      <div
+        class="drop-zone"
+        [class.dragging]="isDragging()"
+        [class.uploading]="uploadState().status === 'uploading'"
+        [class.error]="uploadState().status === 'error'"
+        (dragover)="onDragOver($event)"
+        (dragleave)="onDragLeave($event)"
+        (drop)="onDrop($event)"
+        (click)="fileInput.click()">
+
+        <input
+          #fileInput
+          type="file"
+          [accept]="acceptedTypes"
+          (change)="onFileSelected($event)"
+          hidden
+        />
+
+        @switch (uploadState().status) {
+          @case ('idle') {
+            <mat-icon class="upload-icon">cloud_upload</mat-icon>
+            <p class="drop-text">Drag & drop a photo here</p>
+            <p class="drop-subtext">or click to browse</p>
+            <p class="file-info">
+              Accepts: JPEG, PNG, GIF, WebP (max {{ maxFileSizeMB }}MB)
+            </p>
+          }
+
+          @case ('uploading') {
+            <mat-icon class="upload-icon spinning">sync</mat-icon>
+            <p class="drop-text">Uploading...</p>
+            <div class="progress-container">
+              <mat-progress-bar
+                mode="determinate"
+                [value]="uploadState().progress"
+                color="primary">
+              </mat-progress-bar>
+              <span class="progress-text">{{ uploadState().progress }}%</span>
+            </div>
+          }
+
+          @case ('success') {
+            <mat-icon class="upload-icon success">check_circle</mat-icon>
+            <p class="drop-text">Upload complete!</p>
+            <button mat-stroked-button color="primary" (click)="resetUpload($event)">
+              Upload Another
+            </button>
+          }
+
+          @case ('error') {
+            <mat-icon class="upload-icon error">error_outline</mat-icon>
+            <p class="drop-text error-text">Upload failed</p>
+            <p class="error-message">{{ uploadState().error }}</p>
+            <div class="error-actions">
+              <button mat-stroked-button color="primary" (click)="retryUpload($event)">
+                <mat-icon>refresh</mat-icon>
+                Retry
+              </button>
+              <button mat-stroked-button (click)="resetUpload($event)">
+                Cancel
+              </button>
+            </div>
+          }
+        }
+      </div>
+
+      <!-- Validation Error Display -->
+      @if (validationError()) {
+        <div class="validation-error">
+          <mat-icon>warning</mat-icon>
+          <span>{{ validationError() }}</span>
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .upload-container {
+      width: 100%;
+    }
+
+    .drop-zone {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 32px 24px;
+      border: 2px dashed var(--pm-border, #ccc);
+      border-radius: 12px;
+      background-color: var(--pm-surface-variant, #fafafa);
+      cursor: pointer;
+      transition: all 0.2s ease;
+      min-height: 200px;
+
+      &:hover:not(.uploading) {
+        border-color: var(--pm-primary);
+        background-color: rgba(var(--pm-primary-rgb, 76, 175, 80), 0.05);
+      }
+
+      &.dragging {
+        border-color: var(--pm-primary);
+        background-color: rgba(var(--pm-primary-rgb, 76, 175, 80), 0.1);
+        transform: scale(1.02);
+      }
+
+      &.uploading {
+        cursor: default;
+        border-style: solid;
+        border-color: var(--pm-primary);
+      }
+
+      &.error {
+        border-color: var(--pm-error, #c62828);
+        background-color: rgba(198, 40, 40, 0.05);
+      }
+    }
+
+    .upload-icon {
+      font-size: 48px;
+      width: 48px;
+      height: 48px;
+      color: var(--pm-text-secondary);
+      margin-bottom: 12px;
+
+      &.spinning {
+        animation: spin 1s linear infinite;
+        color: var(--pm-primary);
+      }
+
+      &.success {
+        color: var(--pm-primary);
+      }
+
+      &.error {
+        color: var(--pm-error, #c62828);
+      }
+    }
+
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+
+    .drop-text {
+      font-size: 16px;
+      font-weight: 500;
+      color: var(--pm-text-primary);
+      margin: 0 0 4px 0;
+
+      &.error-text {
+        color: var(--pm-error, #c62828);
+      }
+    }
+
+    .drop-subtext {
+      font-size: 14px;
+      color: var(--pm-text-secondary);
+      margin: 0 0 16px 0;
+    }
+
+    .file-info {
+      font-size: 12px;
+      color: var(--pm-text-secondary);
+      margin: 0;
+    }
+
+    .progress-container {
+      width: 100%;
+      max-width: 300px;
+      margin-top: 16px;
+
+      mat-progress-bar {
+        border-radius: 4px;
+      }
+
+      .progress-text {
+        display: block;
+        text-align: center;
+        font-size: 14px;
+        color: var(--pm-text-secondary);
+        margin-top: 8px;
+      }
+    }
+
+    .error-message {
+      font-size: 14px;
+      color: var(--pm-error, #c62828);
+      margin: 8px 0 16px 0;
+      text-align: center;
+    }
+
+    .error-actions {
+      display: flex;
+      gap: 12px;
+
+      button mat-icon {
+        margin-right: 4px;
+      }
+    }
+
+    .validation-error {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 12px;
+      padding: 12px 16px;
+      background-color: rgba(198, 40, 40, 0.1);
+      border-radius: 8px;
+      color: var(--pm-error, #c62828);
+
+      mat-icon {
+        font-size: 20px;
+        width: 20px;
+        height: 20px;
+      }
+
+      span {
+        font-size: 14px;
+      }
+    }
+  `]
+})
+export class PropertyPhotoUploadComponent {
+  private readonly photoUploadService = inject(PhotoUploadService);
+
+  /**
+   * Property ID for the upload
+   */
+  readonly propertyId = input.required<string>();
+
+  /**
+   * Emitted when upload completes successfully
+   */
+  readonly uploadComplete = output<PhotoUploadResult>();
+
+  /**
+   * Drag state
+   */
+  readonly isDragging = signal(false);
+
+  /**
+   * Upload state
+   */
+  readonly uploadState = signal<UploadState>({
+    status: 'idle',
+    progress: 0,
+    error: null,
+    file: null,
+  });
+
+  /**
+   * Validation error message
+   */
+  readonly validationError = signal<string | null>(null);
+
+  /**
+   * Accepted file types for file input
+   */
+  readonly acceptedTypes = this.photoUploadService.getAcceptString();
+
+  /**
+   * Max file size in MB for display
+   */
+  readonly maxFileSizeMB = this.photoUploadService.getMaxFileSizeBytes() / 1024 / 1024;
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    if (this.uploadState().status === 'uploading') return;
+    this.isDragging.set(true);
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging.set(false);
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging.set(false);
+
+    if (this.uploadState().status === 'uploading') return;
+
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      this.handleFile(files[0]);
+    }
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.handleFile(input.files[0]);
+      // Reset input so same file can be selected again
+      input.value = '';
+    }
+  }
+
+  /**
+   * Validate and start upload
+   */
+  private handleFile(file: File): void {
+    this.validationError.set(null);
+
+    // Client-side validation (AC-13.3b.7)
+    if (!this.photoUploadService.isValidFileType(file.type)) {
+      this.validationError.set(
+        `Invalid file type: ${file.type || 'unknown'}. Please use JPEG, PNG, GIF, or WebP.`
+      );
+      return;
+    }
+
+    if (!this.photoUploadService.isValidFileSize(file.size)) {
+      const sizeMB = (file.size / 1024 / 1024).toFixed(2);
+      this.validationError.set(
+        `File too large: ${sizeMB}MB. Maximum size is ${this.maxFileSizeMB}MB.`
+      );
+      return;
+    }
+
+    this.startUpload(file);
+  }
+
+  /**
+   * Start the upload process
+   */
+  private async startUpload(file: File): Promise<void> {
+    this.uploadState.set({
+      status: 'uploading',
+      progress: 0,
+      error: null,
+      file,
+    });
+
+    try {
+      const result = await this.photoUploadService.uploadPhoto(file, {
+        entityType: PhotoEntityType.Properties,
+        entityId: this.propertyId(),
+        onProgress: (percent) => {
+          this.uploadState.update(state => ({ ...state, progress: percent }));
+        },
+      });
+
+      this.uploadState.set({
+        status: 'success',
+        progress: 100,
+        error: null,
+        file,
+      });
+
+      this.uploadComplete.emit(result);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Upload failed. Please try again.';
+      this.uploadState.set({
+        status: 'error',
+        progress: 0,
+        error: errorMessage,
+        file,
+      });
+    }
+  }
+
+  /**
+   * Retry failed upload (AC-13.3b.8)
+   */
+  retryUpload(event: Event): void {
+    event.stopPropagation();
+    const file = this.uploadState().file;
+    if (file) {
+      this.startUpload(file);
+    }
+  }
+
+  /**
+   * Reset to idle state
+   */
+  resetUpload(event: Event): void {
+    event.stopPropagation();
+    this.uploadState.set({
+      status: 'idle',
+      progress: 0,
+      error: null,
+      file: null,
+    });
+    this.validationError.set(null);
+  }
+}

--- a/frontend/src/app/features/properties/properties.component.ts
+++ b/frontend/src/app/features/properties/properties.component.ts
@@ -78,6 +78,7 @@ import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner
                       [state]="property.state"
                       [expenseTotal]="property.expenseTotal"
                       [incomeTotal]="property.incomeTotal"
+                      [thumbnailUrl]="property.primaryPhotoThumbnailUrl"
                       (rowClick)="navigateToProperty($event)" />
                   }
                 </div>

--- a/frontend/src/app/features/properties/property-detail/property-detail.component.spec.ts
+++ b/frontend/src/app/features/properties/property-detail/property-detail.component.spec.ts
@@ -4,6 +4,7 @@ import { signal } from '@angular/core';
 import { Location } from '@angular/common';
 import { PropertyDetailComponent } from './property-detail.component';
 import { PropertyStore } from '../stores/property.store';
+import { PropertyPhotoStore } from '../stores/property-photo.store';
 import { PropertyService, PropertyDetailDto } from '../services/property.service';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
@@ -28,6 +29,12 @@ describe('PropertyDetailComponent', () => {
   let mockRouter: { navigate: ReturnType<typeof vi.fn> };
   let mockLocation: { back: ReturnType<typeof vi.fn> };
   let mockPropertyService: { getPropertyById: ReturnType<typeof vi.fn> };
+  let mockPhotoStore: {
+    isLoading: ReturnType<typeof signal>;
+    sortedPhotos: ReturnType<typeof signal>;
+    loadPhotos: ReturnType<typeof vi.fn>;
+    clear: ReturnType<typeof vi.fn>;
+  };
 
   const mockProperty: PropertyDetailDto = {
     id: 'test-property-id',
@@ -70,6 +77,13 @@ describe('PropertyDetailComponent', () => {
       getPropertyById: vi.fn().mockReturnValue(of(mockProperty)),
     };
 
+    mockPhotoStore = {
+      isLoading: signal(false),
+      sortedPhotos: signal([]),
+      loadPhotos: vi.fn(),
+      clear: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [
         PropertyDetailComponent,
@@ -78,6 +92,7 @@ describe('PropertyDetailComponent', () => {
       ],
       providers: [
         { provide: PropertyStore, useValue: mockPropertyStore },
+        { provide: PropertyPhotoStore, useValue: mockPhotoStore },
         { provide: Router, useValue: mockRouter },
         { provide: Location, useValue: mockLocation },
         { provide: PropertyService, useValue: mockPropertyService },

--- a/frontend/src/app/features/properties/services/property.service.ts
+++ b/frontend/src/app/features/properties/services/property.service.ts
@@ -23,6 +23,7 @@ export interface PropertySummaryDto {
   zipCode: string;
   expenseTotal: number;
   incomeTotal: number;
+  primaryPhotoThumbnailUrl?: string | null;
 }
 
 export interface GetAllPropertiesResponse {
@@ -57,6 +58,7 @@ export interface PropertyDetailDto {
   updatedAt: string;
   recentExpenses: ExpenseSummaryDto[];
   recentIncome: IncomeSummaryDto[];
+  primaryPhotoThumbnailUrl?: string | null;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/frontend/src/app/features/properties/stores/property-photo.store.ts
+++ b/frontend/src/app/features/properties/stores/property-photo.store.ts
@@ -1,0 +1,357 @@
+import { computed, inject } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { pipe, switchMap, tap, catchError, of } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ApiClient, PropertyPhotoDto } from '../../../core/api/api.service';
+import { PhotoUploadService } from '../../../shared/services/photo-upload.service';
+import { PhotoEntityType } from '../../../core/api/api.service';
+
+/**
+ * Property Photo Store State Interface
+ */
+interface PropertyPhotoState {
+  /** Current property ID */
+  propertyId: string | null;
+  /** List of photos for the property */
+  photos: PropertyPhotoDto[];
+  /** Loading state */
+  isLoading: boolean;
+  /** Error message */
+  error: string | null;
+  /** Upload in progress */
+  isUploading: boolean;
+  /** Upload progress (0-100) */
+  uploadProgress: number;
+  /** Upload error */
+  uploadError: string | null;
+}
+
+/**
+ * Initial state for property photo store
+ */
+const initialState: PropertyPhotoState = {
+  propertyId: null,
+  photos: [],
+  isLoading: false,
+  error: null,
+  isUploading: false,
+  uploadProgress: 0,
+  uploadError: null,
+};
+
+/**
+ * PropertyPhotoStore
+ *
+ * State management for property photos using @ngrx/signals.
+ * Provides:
+ * - Photos list with loading/error states
+ * - Upload with progress tracking
+ * - Delete, set primary, reorder operations
+ */
+export const PropertyPhotoStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+  withComputed((store) => ({
+    /**
+     * Total count of photos
+     */
+    photoCount: computed(() => store.photos().length),
+
+    /**
+     * Whether the property has any photos
+     */
+    hasPhotos: computed(() => store.photos().length > 0),
+
+    /**
+     * Whether the gallery is empty
+     */
+    isEmpty: computed(() => !store.isLoading() && store.photos().length === 0),
+
+    /**
+     * Primary photo (if any)
+     */
+    primaryPhoto: computed(() => store.photos().find(p => p.isPrimary)),
+
+    /**
+     * Photos sorted by display order
+     */
+    sortedPhotos: computed(() =>
+      [...store.photos()].sort((a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0))
+    ),
+  })),
+  withMethods((store, apiClient = inject(ApiClient), snackBar = inject(MatSnackBar), photoUploadService = inject(PhotoUploadService)) => ({
+    /**
+     * Load photos for a property
+     */
+    loadPhotos: rxMethod<string>(
+      pipe(
+        tap((propertyId) =>
+          patchState(store, {
+            propertyId,
+            isLoading: true,
+            error: null,
+          })
+        ),
+        switchMap((propertyId) =>
+          apiClient.propertyPhotos_GetPhotos(propertyId).pipe(
+            tap((response) =>
+              patchState(store, {
+                photos: response.items ?? [],
+                isLoading: false,
+              })
+            ),
+            catchError((error) => {
+              const errorMessage = error.status === 404
+                ? 'Property not found'
+                : 'Failed to load photos. Please try again.';
+              patchState(store, {
+                isLoading: false,
+                error: errorMessage,
+              });
+              console.error('Error loading property photos:', error);
+              return of(null);
+            })
+          )
+        )
+      )
+    ),
+
+    /**
+     * Upload a photo for the current property
+     */
+    async uploadPhoto(file: File): Promise<boolean> {
+      const propertyId = store.propertyId();
+      if (!propertyId) {
+        console.error('No property ID set for photo upload');
+        return false;
+      }
+
+      patchState(store, {
+        isUploading: true,
+        uploadProgress: 0,
+        uploadError: null,
+      });
+
+      try {
+        // First, get presigned URL from property photos endpoint
+        const uploadUrlResponse = await apiClient.propertyPhotos_GenerateUploadUrl(propertyId, {
+          contentType: file.type,
+          fileSizeBytes: file.size,
+          originalFileName: file.name,
+        }).toPromise();
+
+        if (!uploadUrlResponse?.uploadUrl || !uploadUrlResponse?.storageKey) {
+          throw new Error('Failed to get upload URL');
+        }
+
+        patchState(store, { uploadProgress: 10 });
+
+        // Upload to S3 using the photo upload service's internal method
+        const uploadResult = await photoUploadService.uploadPhoto(file, {
+          entityType: PhotoEntityType.Properties,
+          entityId: propertyId,
+          onProgress: (percent) => {
+            patchState(store, { uploadProgress: 10 + Math.round(percent * 0.7) });
+          },
+        });
+
+        patchState(store, { uploadProgress: 80 });
+
+        // Confirm the upload with the property photos endpoint
+        await apiClient.propertyPhotos_ConfirmUpload(propertyId, {
+          storageKey: uploadResult.storageKey,
+          thumbnailStorageKey: uploadResult.thumbnailStorageKey ?? undefined,
+          contentType: uploadResult.contentType,
+          fileSizeBytes: uploadResult.fileSizeBytes,
+          originalFileName: file.name,
+        }).toPromise();
+
+        patchState(store, {
+          isUploading: false,
+          uploadProgress: 100,
+        });
+
+        // Refresh photos list
+        this.loadPhotos(propertyId);
+
+        snackBar.open('Photo uploaded successfully', 'Close', {
+          duration: 3000,
+          horizontalPosition: 'center',
+          verticalPosition: 'bottom',
+        });
+
+        return true;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Upload failed. Please try again.';
+        patchState(store, {
+          isUploading: false,
+          uploadProgress: 0,
+          uploadError: errorMessage,
+        });
+
+        snackBar.open(errorMessage, 'Close', {
+          duration: 5000,
+          horizontalPosition: 'center',
+          verticalPosition: 'bottom',
+        });
+
+        console.error('Error uploading photo:', error);
+        return false;
+      }
+    },
+
+    /**
+     * Delete a photo
+     */
+    deletePhoto: rxMethod<string>(
+      pipe(
+        switchMap((photoId) => {
+          const propertyId = store.propertyId();
+          if (!propertyId) {
+            console.error('No property ID set');
+            return of(null);
+          }
+
+          return apiClient.propertyPhotos_DeletePhoto(propertyId, photoId).pipe(
+            tap(() => {
+              // Remove from local state
+              patchState(store, {
+                photos: store.photos().filter(p => p.id !== photoId),
+              });
+
+              snackBar.open('Photo deleted', 'Close', {
+                duration: 3000,
+                horizontalPosition: 'center',
+                verticalPosition: 'bottom',
+              });
+            }),
+            catchError((error) => {
+              snackBar.open('Failed to delete photo', 'Close', {
+                duration: 5000,
+                horizontalPosition: 'center',
+                verticalPosition: 'bottom',
+              });
+              console.error('Error deleting photo:', error);
+              return of(null);
+            })
+          );
+        })
+      )
+    ),
+
+    /**
+     * Set a photo as primary
+     */
+    setPrimaryPhoto: rxMethod<string>(
+      pipe(
+        switchMap((photoId) => {
+          const propertyId = store.propertyId();
+          if (!propertyId) {
+            console.error('No property ID set');
+            return of(null);
+          }
+
+          return apiClient.propertyPhotos_SetPrimaryPhoto(propertyId, photoId).pipe(
+            tap(() => {
+              // Update local state
+              patchState(store, {
+                photos: store.photos().map(p => ({
+                  ...p,
+                  isPrimary: p.id === photoId,
+                })),
+              });
+
+              snackBar.open('Primary photo updated', 'Close', {
+                duration: 3000,
+                horizontalPosition: 'center',
+                verticalPosition: 'bottom',
+              });
+            }),
+            catchError((error) => {
+              snackBar.open('Failed to set primary photo', 'Close', {
+                duration: 5000,
+                horizontalPosition: 'center',
+                verticalPosition: 'bottom',
+              });
+              console.error('Error setting primary photo:', error);
+              return of(null);
+            })
+          );
+        })
+      )
+    ),
+
+    /**
+     * Reorder photos
+     */
+    reorderPhotos: rxMethod<string[]>(
+      pipe(
+        switchMap((photoIds) => {
+          const propertyId = store.propertyId();
+          if (!propertyId) {
+            console.error('No property ID set');
+            return of(null);
+          }
+
+          return apiClient.propertyPhotos_ReorderPhotos(propertyId, { photoIds }).pipe(
+            tap(() => {
+              // Update display order in local state
+              const reorderedPhotos: PropertyPhotoDto[] = [];
+              photoIds.forEach((id, index) => {
+                const photo = store.photos().find(p => p.id === id);
+                if (photo) {
+                  reorderedPhotos.push({ ...photo, displayOrder: index });
+                }
+              });
+
+              patchState(store, { photos: reorderedPhotos });
+
+              snackBar.open('Photos reordered', 'Close', {
+                duration: 3000,
+                horizontalPosition: 'center',
+                verticalPosition: 'bottom',
+              });
+            }),
+            catchError((error) => {
+              snackBar.open('Failed to reorder photos', 'Close', {
+                duration: 5000,
+                horizontalPosition: 'center',
+                verticalPosition: 'bottom',
+              });
+              console.error('Error reordering photos:', error);
+              return of(null);
+            })
+          );
+        })
+      )
+    ),
+
+    /**
+     * Clear store state
+     */
+    clear(): void {
+      patchState(store, initialState);
+    },
+
+    /**
+     * Clear error state
+     */
+    clearError(): void {
+      patchState(store, { error: null });
+    },
+
+    /**
+     * Clear upload error state
+     */
+    clearUploadError(): void {
+      patchState(store, { uploadError: null });
+    },
+  }))
+);

--- a/frontend/src/app/shared/components/property-row/property-row.component.spec.ts
+++ b/frontend/src/app/shared/components/property-row/property-row.component.spec.ts
@@ -93,9 +93,34 @@ describe('PropertyRowComponent', () => {
     expect(rowClickSpy).not.toHaveBeenCalled();
   });
 
-  it('should display home icon', () => {
-    const icon = fixture.nativeElement.querySelector('.property-icon mat-icon');
+  it('should display home icon as fallback when no thumbnail URL', () => {
+    const icon = fixture.nativeElement.querySelector('.property-thumbnail .fallback-icon');
     expect(icon.textContent?.trim()).toBe('home');
+  });
+
+  it('should display thumbnail image when thumbnailUrl is provided (AC-13.3b.1)', () => {
+    fixture.componentRef.setInput('thumbnailUrl', 'https://example.com/photo.jpg');
+    fixture.detectChanges();
+
+    const img = fixture.nativeElement.querySelector('.property-thumbnail .thumbnail-img');
+    expect(img).toBeTruthy();
+    expect(img.src).toBe('https://example.com/photo.jpg');
+    expect(img.alt).toBe('Oak Street Duplex thumbnail');
+
+    // Fallback icon should not be shown
+    const fallbackIcon = fixture.nativeElement.querySelector('.property-thumbnail .fallback-icon');
+    expect(fallbackIcon).toBeFalsy();
+  });
+
+  it('should show fallback icon when thumbnailUrl is null (AC-13.3b.1)', () => {
+    fixture.componentRef.setInput('thumbnailUrl', null);
+    fixture.detectChanges();
+
+    const fallbackIcon = fixture.nativeElement.querySelector('.property-thumbnail .fallback-icon');
+    expect(fallbackIcon).toBeTruthy();
+
+    const img = fixture.nativeElement.querySelector('.property-thumbnail .thumbnail-img');
+    expect(img).toBeFalsy();
   });
 
   it('should display YTD Expenses label', () => {

--- a/frontend/src/app/shared/components/property-row/property-row.component.ts
+++ b/frontend/src/app/shared/components/property-row/property-row.component.ts
@@ -30,8 +30,12 @@ import { MatRippleModule } from '@angular/material/core';
   ],
   template: `
     <div class="property-row" matRipple (click)="onRowClick()" (keydown.enter)="onRowClick()" tabindex="0" role="button">
-      <div class="property-icon">
-        <mat-icon>home</mat-icon>
+      <div class="property-thumbnail">
+        @if (thumbnailUrl()) {
+          <img [src]="thumbnailUrl()" [alt]="name() + ' thumbnail'" class="thumbnail-img" />
+        } @else {
+          <mat-icon class="fallback-icon">home</mat-icon>
+        }
       </div>
 
       <div class="property-info">
@@ -85,17 +89,28 @@ import { MatRippleModule } from '@angular/material/core';
       }
     }
 
-    .property-icon {
+    .property-thumbnail {
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 40px;
-      height: 40px;
+      width: 48px;
+      height: 48px;
       border-radius: 8px;
       background-color: var(--pm-primary-light);
+      overflow: hidden;
+      flex-shrink: 0;
 
-      mat-icon {
+      .thumbnail-img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .fallback-icon {
         color: var(--pm-primary-dark);
+        font-size: 24px;
+        width: 24px;
+        height: 24px;
       }
     }
 
@@ -192,11 +207,11 @@ import { MatRippleModule } from '@angular/material/core';
         gap: 12px;
       }
 
-      .property-icon {
-        width: 36px;
-        height: 36px;
+      .property-thumbnail {
+        width: 40px;
+        height: 40px;
 
-        mat-icon {
+        .fallback-icon {
           font-size: 20px;
           width: 20px;
           height: 20px;
@@ -265,6 +280,12 @@ export class PropertyRowComponent {
    * Default: 0
    */
   readonly incomeTotal = input<number>(0);
+
+  /**
+   * Primary photo thumbnail URL (AC-13.3b.1)
+   * If provided, shows thumbnail instead of home icon
+   */
+  readonly thumbnailUrl = input<string | null | undefined>(undefined);
 
   /**
    * Computed net income: income - expenses (AC-4.4.5)


### PR DESCRIPTION
## Summary

- Add thumbnail support to property list cards with home icon fallback (AC-13.3b.1)
- Create responsive photo gallery component with empty/loading/error states (AC-13.3b.2-6)
- Create drag-drop photo upload component with progress bar and validation (AC-13.3b.7-9)
- Create signals-based PropertyPhotoStore for state management
- Integrate photo gallery section into property detail page

## Test plan

- [ ] Verify property list shows thumbnails when photos exist
- [ ] Verify property list shows home icon when no photos
- [ ] Verify gallery shows responsive grid (1/2/3 columns based on viewport)
- [ ] Verify empty state with "Add First Photo" CTA
- [ ] Verify skeleton loading placeholders during fetch
- [ ] Verify photo fade-in animation on load
- [ ] Verify drag-drop upload with progress bar
- [ ] Verify client-side file type/size validation
- [ ] Verify error state with retry option
- [ ] All 1,109 frontend tests pass
- [ ] All 998 backend tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)