### PR TITLE
feat(work-orders): add status badges and created date to dashboard (#9-6)

### DIFF
--- a/_bmad-output/implementation-artifacts/9-6-work-order-dashboard.md
+++ b/_bmad-output/implementation-artifacts/9-6-work-order-dashboard.md
@@ -1,0 +1,269 @@
+# Story 9.6: Work Order Dashboard
+
+Status: review
+
+## Story
+
+As a **property owner**,
+I want **to see all my work orders in one place with status badges and dates**,
+So that **I can track what's happening across all my properties at a glance**.
+
+## Acceptance Criteria
+
+### Frontend - Work Order List Display
+
+1. **Given** I am logged in
+   **When** I navigate to Work Orders (`/work-orders`)
+   **Then** I see a list of all my work orders showing:
+   - Status (as colored badge: Reported=amber/yellow, Assigned=blue, Completed=green)
+   - Property name
+   - Description (truncated if long)
+   - Assigned to (vendor name or "Self (DIY)")
+   - Category (if set)
+   - Created date (formatted, e.g., "Jan 20, 2026")
+   - Tags (as small chips)
+
+### Frontend - Empty State
+
+2. **Given** I have no work orders
+   **When** I view the Work Orders page
+   **Then** I see empty state: "No work orders yet. Create your first work order to track maintenance tasks."
+   **And** I see a "Create Work Order" button
+
+### Frontend - Sorting
+
+3. **Given** I have multiple work orders
+   **When** I view the list
+   **Then** work orders are sorted by created date (newest first)
+   **And** I can click any card to go to its detail page
+
+### Frontend - New Work Order Navigation
+
+4. **Given** I click "New Work Order" button
+   **When** the form opens
+   **Then** I can create a new work order (routes to /work-orders/new)
+
+## Tasks / Subtasks
+
+### Task 1: Add Status Badge Component (AC: #1)
+
+- [x] 1.1 Create status badge styles using Angular Material theming:
+  - Reported: amber/warning color
+  - Assigned: blue/primary color
+  - Completed: green/success color
+- [x] 1.2 Update mat-card-subtitle to use colored badge styling
+- [x] 1.3 Add CSS classes for each status: `.status-reported`, `.status-assigned`, `.status-completed`
+
+### Task 2: Add Created Date Display (AC: #1)
+
+- [x] 2.1 Add created date to work order card display
+- [x] 2.2 Format date using Angular DatePipe (e.g., "Jan 20, 2026" or "mediumDate")
+- [x] 2.3 Position date appropriately in card layout
+
+### Task 3: Verify Sorting by Created Date (AC: #3)
+
+- [x] 3.1 Verify backend API returns work orders sorted by createdAt DESC
+- [x] 3.2 If not sorted by backend, add frontend sorting in store or component (N/A - backend sorts correctly)
+- [x] 3.3 Confirm newest work orders appear first
+
+### Task 4: Testing
+
+- [x] 4.1 Update unit tests for WorkOrdersComponent:
+  - Status badge renders with correct class for each status
+  - Created date displays formatted correctly
+  - Work orders sorted newest first
+- [x] 4.2 Manual verification:
+  - [x] Navigate to /work-orders
+  - [x] Verify Reported status shows amber/yellow badge
+  - [x] Verify Assigned status shows blue badge
+  - [x] Verify Completed status shows green badge (code implemented, no Completed data to verify visually)
+  - [x] Verify created date displays on each card
+  - [x] Verify newest work orders appear at top
+  - [x] Verify empty state when no work orders (existing implementation verified in unit tests)
+  - [x] Verify "New Work Order" navigates to creation form
+
+## Dev Notes
+
+### Architecture Compliance
+
+**Frontend Structure:**
+```
+frontend/src/app/features/work-orders/
+├── work-orders.component.ts           ← MODIFIED (add status badges, created date)
+├── work-orders.component.spec.ts      ← MODIFIED (update tests)
+```
+
+**No backend changes required** - WorkOrderDto already includes `createdAt` and `status`.
+
+### Current Implementation Analysis
+
+The work-orders.component.ts currently displays:
+- Property name (mat-card-title)
+- Status as plain text (mat-card-subtitle)
+- Description (truncated with CSS)
+- Assignee (vendor name or "DIY")
+- Category (if set)
+- Tags (as chips)
+
+**Gaps to address:**
+1. Status needs colored badge styling instead of plain text
+2. Created date not displayed
+3. Sorting verification needed
+
+### Status Badge Implementation Pattern
+
+```typescript
+// Add to template - replace plain status text with badge
+<span class="status-badge" [ngClass]="'status-' + workOrder.status.toLowerCase()">
+  {{ workOrder.status }}
+</span>
+
+// Add to styles
+.status-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.status-reported {
+  background-color: var(--mat-sys-warning-container, #fef3c7);
+  color: var(--mat-sys-on-warning-container, #92400e);
+}
+
+.status-assigned {
+  background-color: var(--mat-sys-primary-container, #dbeafe);
+  color: var(--mat-sys-on-primary-container, #1e40af);
+}
+
+.status-completed {
+  background-color: var(--mat-sys-tertiary-container, #d1fae5);
+  color: var(--mat-sys-on-tertiary-container, #065f46);
+}
+```
+
+### Created Date Display Pattern
+
+```typescript
+// Add DatePipe to imports
+import { DatePipe } from '@angular/common';
+
+// In template - add after status badge
+<span class="created-date">
+  <mat-icon class="date-icon">calendar_today</mat-icon>
+  {{ workOrder.createdAt | date:'mediumDate' }}
+</span>
+
+// Styles
+.created-date {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85em;
+  color: var(--mat-sys-outline);
+  margin-top: 8px;
+}
+
+.date-icon {
+  font-size: 16px;
+  height: 16px;
+  width: 16px;
+}
+```
+
+### Sorting Verification
+
+Check WorkOrderStore.loadWorkOrders() and backend API behavior:
+- Backend GetWorkOrdersQuery should order by CreatedAt DESC
+- If not, add sorting in the store after loading:
+```typescript
+// In store, after loading
+const sorted = [...workOrders].sort(
+  (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+);
+```
+
+### Previous Story Intelligence
+
+From 9-5 implementation:
+- WorkOrderStore uses @ngrx/signals pattern
+- WorkOrderDto includes: id, propertyId, propertyName, vendorId, vendorName, isDiy, categoryId, categoryName, status, description, createdAt, createdByUserId, tags
+- Component uses CommonModule, RouterLink, MatCardModule, MatButtonModule, MatIconModule, MatProgressSpinnerModule, MatChipsModule
+
+### WorkOrderDto Structure Reference
+
+```typescript
+interface WorkOrderDto {
+  id: string;
+  propertyId: string;
+  propertyName: string;
+  vendorId?: string;
+  vendorName?: string;
+  isDiy: boolean;
+  categoryId?: string;
+  categoryName?: string;
+  status: string;  // 'Reported' | 'Assigned' | 'Completed'
+  description: string;
+  createdAt: string;  // ISO date string
+  createdByUserId: string;
+  tags: WorkOrderTagDto[];
+}
+```
+
+### FRs Covered
+
+| FR | Description | How This Story Addresses |
+|----|-------------|-------------------------|
+| FR22 | Users can view all work orders in a dashboard view | Enhanced dashboard with status badges and dates |
+
+### Testing Requirements
+
+**Unit Tests (frontend):**
+- Status badge renders correct CSS class per status
+- Created date displays with correct format
+- Work orders appear in correct order (newest first)
+- Empty state renders when no work orders
+
+**Manual Verification:**
+- [x] Navigate to /work-orders with existing work orders
+- [x] Verify "Reported" work orders show amber/yellow badge
+- [x] Verify "Assigned" work orders show blue badge
+- [x] Verify "Completed" work orders show green badge (code implemented)
+- [x] Verify created date shows on each card
+- [x] Verify newest work orders at top of list
+- [x] Navigate to /work-orders with no work orders (tested via unit tests)
+- [x] Verify empty state message and button (tested via unit tests)
+- [x] Click "New Work Order" - verify navigation to /work-orders/new
+
+### References
+
+- [Source: epics-work-orders-vendors.md#Story 2.6] - Original story definition
+- [Source: architecture.md#Phase 2] - Frontend structure patterns
+- [Source: work-orders.component.ts] - Current implementation to enhance
+- [Source: 9-5-inline-vendor-creation.md] - Previous story patterns
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.5 (claude-opus-4-5-20251101)
+
+### Debug Log References
+
+N/A
+
+### Completion Notes List
+
+- Implemented status badge component with colored styling (amber/Reported, blue/Assigned, green/Completed)
+- Added created date display with calendar icon using Angular DatePipe (mediumDate format)
+- Verified backend API already sorts by createdAt DESC (GetAllWorkOrders.cs:69)
+- Added 8 new unit tests covering status badges, created date, and sorting
+- All 1151 frontend tests passing
+- Manual verification completed via Playwright MCP
+
+### File List
+
+- `frontend/src/app/features/work-orders/work-orders.component.ts` - MODIFIED (status badges, created date display, CSS styles)
+- `frontend/src/app/features/work-orders/work-orders.component.spec.ts` - MODIFIED (added 8 new tests for Story 9-6)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -125,8 +125,8 @@ development_status:
   9-2-create-work-order: done
   9-3-add-work-order-tags: done
   9-4-assign-work-order-vendor-or-diy: done
-  9-5-inline-vendor-creation: backlog
-  9-6-work-order-dashboard: backlog
+  9-5-inline-vendor-creation: done
+  9-6-work-order-dashboard: review
   9-7-filter-work-orders: backlog
   9-8-work-order-detail-page: backlog
   9-9-edit-work-order: backlog

--- a/frontend/src/app/features/work-orders/work-orders.component.spec.ts
+++ b/frontend/src/app/features/work-orders/work-orders.component.spec.ts
@@ -31,6 +31,7 @@ describe('WorkOrdersComponent', () => {
       vendorName: null,
       categoryName: 'Plumbing',
       tags: [],
+      createdAt: '2026-01-20T10:00:00Z',
     },
     {
       id: 'wo-2',
@@ -43,18 +44,20 @@ describe('WorkOrdersComponent', () => {
       vendorName: 'John Plumber',
       categoryName: null,
       tags: [{ id: 'tag-1', name: 'Urgent' }],
+      createdAt: '2026-01-19T10:00:00Z',
     },
     {
       id: 'wo-3',
       propertyId: 'prop-2',
       propertyName: 'Other Property',
       description: 'Paint the walls',
-      status: 'Assigned',
+      status: 'Completed',
       isDiy: false,
       vendorId: 'vendor-2',
       vendorName: null, // Vendor was deleted but FK preserved
       categoryName: 'Painting',
       tags: [],
+      createdAt: '2026-01-18T10:00:00Z',
     },
   ];
 
@@ -154,6 +157,92 @@ describe('WorkOrdersComponent', () => {
       const emptyState = fixture.debugElement.query(By.css('.empty-state'));
       expect(emptyState).toBeTruthy();
       expect(emptyState.nativeElement.textContent).toContain('No work orders yet');
+    });
+  });
+
+  describe('Status Badge Display (Story 9-6 AC #1)', () => {
+    it('should render status as badge with status-reported class for Reported status', () => {
+      const cards = fixture.debugElement.queryAll(By.css('.work-order-card'));
+      const reportedCard = cards[0]; // First work order has Reported status
+
+      const statusBadge = reportedCard.query(By.css('.status-badge'));
+      expect(statusBadge).toBeTruthy();
+      expect(statusBadge.nativeElement.classList).toContain('status-reported');
+      expect(statusBadge.nativeElement.textContent.trim()).toBe('Reported');
+    });
+
+    it('should render status as badge with status-assigned class for Assigned status', () => {
+      const cards = fixture.debugElement.queryAll(By.css('.work-order-card'));
+      const assignedCard = cards[1]; // Second work order has Assigned status
+
+      const statusBadge = assignedCard.query(By.css('.status-badge'));
+      expect(statusBadge).toBeTruthy();
+      expect(statusBadge.nativeElement.classList).toContain('status-assigned');
+      expect(statusBadge.nativeElement.textContent.trim()).toBe('Assigned');
+    });
+
+    it('should render status as badge with status-completed class for Completed status', () => {
+      const cards = fixture.debugElement.queryAll(By.css('.work-order-card'));
+      const completedCard = cards[2]; // Third work order has Completed status
+
+      const statusBadge = completedCard.query(By.css('.status-badge'));
+      expect(statusBadge).toBeTruthy();
+      expect(statusBadge.nativeElement.classList).toContain('status-completed');
+      expect(statusBadge.nativeElement.textContent.trim()).toBe('Completed');
+    });
+
+    it('should show status badge for each work order card', () => {
+      const statusBadges = fixture.debugElement.queryAll(By.css('.status-badge'));
+      expect(statusBadges.length).toBe(3);
+    });
+  });
+
+  describe('Created Date Display (Story 9-6 AC #1)', () => {
+    it('should display created date on work order card', () => {
+      const cards = fixture.debugElement.queryAll(By.css('.work-order-card'));
+      const firstCard = cards[0];
+
+      const createdDate = firstCard.query(By.css('.created-date'));
+      expect(createdDate).toBeTruthy();
+      // Check that date is formatted (mediumDate format: Jan 20, 2026)
+      expect(createdDate.nativeElement.textContent).toContain('Jan 20, 2026');
+    });
+
+    it('should show calendar icon with created date', () => {
+      const cards = fixture.debugElement.queryAll(By.css('.work-order-card'));
+      const firstCard = cards[0];
+
+      const dateIcon = firstCard.query(By.css('.created-date mat-icon'));
+      expect(dateIcon).toBeTruthy();
+      expect(dateIcon.nativeElement.textContent.trim()).toBe('calendar_today');
+    });
+
+    it('should display created date for all work order cards', () => {
+      const createdDates = fixture.debugElement.queryAll(By.css('.created-date'));
+      expect(createdDates.length).toBe(3);
+    });
+  });
+
+  describe('Work Order Sorting (Story 9-6 AC #3)', () => {
+    it('should display work orders in order from store (sorted by createdAt DESC)', () => {
+      // The store is responsible for sorting, component just displays in order
+      // Mock data is already in newest-first order (wo-1: Jan 20, wo-2: Jan 19, wo-3: Jan 18)
+      const cards = fixture.debugElement.queryAll(By.css('.work-order-card'));
+
+      // Verify order matches store order
+      const firstCardTitle = cards[0].query(By.css('mat-card-title'));
+      const secondCardTitle = cards[1].query(By.css('mat-card-title'));
+      const thirdCardTitle = cards[2].query(By.css('mat-card-title'));
+
+      expect(firstCardTitle.nativeElement.textContent.trim()).toBe('Test Property');
+      expect(secondCardTitle.nativeElement.textContent.trim()).toBe('Test Property');
+      expect(thirdCardTitle.nativeElement.textContent.trim()).toBe('Other Property');
+
+      // Verify dates are in descending order
+      const createdDates = fixture.debugElement.queryAll(By.css('.created-date'));
+      expect(createdDates[0].nativeElement.textContent).toContain('Jan 20, 2026');
+      expect(createdDates[1].nativeElement.textContent).toContain('Jan 19, 2026');
+      expect(createdDates[2].nativeElement.textContent).toContain('Jan 18, 2026');
     });
   });
 });

--- a/frontend/src/app/features/work-orders/work-orders.component.ts
+++ b/frontend/src/app/features/work-orders/work-orders.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
@@ -19,6 +19,7 @@ import { WorkOrderStore } from './stores/work-order.store';
   standalone: true,
   imports: [
     CommonModule,
+    DatePipe,
     RouterLink,
     MatCardModule,
     MatButtonModule,
@@ -58,7 +59,11 @@ import { WorkOrderStore } from './stores/work-order.store';
             <mat-card class="work-order-card" [routerLink]="['/work-orders', workOrder.id]">
               <mat-card-header>
                 <mat-card-title>{{ workOrder.propertyName }}</mat-card-title>
-                <mat-card-subtitle>{{ workOrder.status }}</mat-card-subtitle>
+                <mat-card-subtitle>
+                  <span class="status-badge" [ngClass]="'status-' + workOrder.status.toLowerCase()">
+                    {{ workOrder.status }}
+                  </span>
+                </mat-card-subtitle>
               </mat-card-header>
               <mat-card-content>
                 <p class="description">{{ workOrder.description }}</p>
@@ -76,6 +81,10 @@ import { WorkOrderStore } from './stores/work-order.store';
                     }
                   </mat-chip-set>
                 }
+                <span class="created-date">
+                  <mat-icon class="date-icon">calendar_today</mat-icon>
+                  {{ workOrder.createdAt | date:'mediumDate' }}
+                </span>
               </mat-card-content>
             </mat-card>
           }
@@ -175,6 +184,45 @@ import { WorkOrderStore } from './stores/work-order.store';
 
       .work-order-tags mat-chip {
         font-size: 0.8em;
+      }
+
+      .status-badge {
+        display: inline-block;
+        padding: 4px 12px;
+        border-radius: 16px;
+        font-size: 0.75rem;
+        font-weight: 500;
+        text-transform: uppercase;
+      }
+
+      .status-reported {
+        background-color: var(--mat-sys-warning-container, #fef3c7);
+        color: var(--mat-sys-on-warning-container, #92400e);
+      }
+
+      .status-assigned {
+        background-color: var(--mat-sys-primary-container, #dbeafe);
+        color: var(--mat-sys-on-primary-container, #1e40af);
+      }
+
+      .status-completed {
+        background-color: var(--mat-sys-tertiary-container, #d1fae5);
+        color: var(--mat-sys-on-tertiary-container, #065f46);
+      }
+
+      .created-date {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        font-size: 0.85em;
+        color: var(--mat-sys-outline);
+        margin-top: 8px;
+      }
+
+      .date-icon {
+        font-size: 16px;
+        height: 16px;
+        width: 16px;
       }
     `,
   ],


### PR DESCRIPTION
## Summary

- Add colored status badges to work order cards (Reported=amber, Assigned=blue, Completed=green)
- Display created date with calendar icon on each work order card
- Verified backend API already sorts by createdAt DESC

## Changes

**Frontend:**
- `work-orders.component.ts` - Added status badge styling and created date display
- `work-orders.component.spec.ts` - Added 8 new unit tests

## Acceptance Criteria

- [x] AC #1: Status badges with colored styling
- [x] AC #1: Created date displayed (formatted as "Jan 20, 2026")
- [x] AC #3: Work orders sorted by created date (newest first)
- [x] AC #4: New Work Order button navigates to creation form

## Test Plan

- [x] All 1151 frontend tests passing
- [x] Manual verification via Playwright MCP
- [x] Verified Reported status shows amber/yellow badge
- [x] Verified Assigned status shows blue badge
- [x] Verified created date displays on each card
- [x] Verified card click navigates to detail page
- [x] Verified "New Work Order" navigates to /work-orders/new

🤖 Generated with [Claude Code](https://claude.com/claude-code)