### PR TITLE
test: add frontend feature service tests (P2 coverage)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,10 +1,10 @@
 # Test Coverage Gap Work - Handoff Document
 
 ## Status
-- **Branch:** `test/frontend-core-services`
+- **Branch:** `main`
 - **Backend:** ✅ **COMPLETE** - 15/15 controllers tested, 407 API integration tests
-- **Frontend:** 63 test files, 1502 tests
-- **Progress:** P0 ✅ + P1 ✅ (Core Services + Feature Stores complete)
+- **Frontend:** 67 test files, 1565 tests
+- **Progress:** P0 ✅ + P1 ✅ + P2 ✅ (Core Services + Feature Stores + Feature Services complete)
 
 ---
 
@@ -44,15 +44,15 @@ State management stores - high business logic concentration:
 | **P1** | expense-list.store.ts | `frontend/src/app/features/expenses/stores/` | ✅ 54 tests |
 | **P1** | income.store.ts | `frontend/src/app/features/income/stores/` | ✅ 56 tests |
 
-### Medium: Feature Services (No Tests)
+### Medium: Feature Services
 API integration services:
 
-| Priority | File | Location |
-|----------|------|----------|
-| **P2** | work-order.service.ts | `frontend/src/app/features/work-orders/services/` |
-| **P2** | expense.service.ts | `frontend/src/app/features/expenses/services/` |
-| **P2** | income.service.ts | `frontend/src/app/features/income/services/` |
-| **P2** | property.service.ts | `frontend/src/app/features/properties/services/` |
+| Priority | File | Location | Status |
+|----------|------|----------|--------|
+| **P2** | work-order.service.ts | `frontend/src/app/features/work-orders/services/` | ✅ 16 tests |
+| **P2** | expense.service.ts | `frontend/src/app/features/expenses/services/` | ✅ 20 tests |
+| **P2** | income.service.ts | `frontend/src/app/features/income/services/` | ✅ 15 tests |
+| **P2** | property.service.ts | `frontend/src/app/features/properties/services/` | ✅ 12 tests |
 
 ### Lower: Components (No Tests)
 23 components without test files:
@@ -94,10 +94,10 @@ API integration services:
 
 ## Recommended Order
 
-1. **P0 - Core Services** (~2 files, critical foundation)
-2. **P1 - Feature Stores** (~3 files, high business logic)
-3. **P2 - Feature Services** (~4 files, API integration)
-4. **P3 - Auth Components** (~4 files, user-facing critical path)
+1. ~~**P0 - Core Services** (~2 files, critical foundation)~~ ✅ PR #126
+2. ~~**P1 - Feature Stores** (~3 files, high business logic)~~ ✅ PR #126
+3. ~~**P2 - Feature Services** (~4 files, API integration)~~ ✅ PR #127
+4. **P3 - Auth Components** (~4 files, user-facing critical path) ← Next
 5. **P4 - Remaining Components** (~19 files)
 
 ---

--- a/frontend/src/app/features/expenses/services/expense.service.spec.ts
+++ b/frontend/src/app/features/expenses/services/expense.service.spec.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  ExpenseService,
+  CreateExpenseRequest,
+  CreateExpenseResponse,
+  ExpenseCategoriesResponse,
+  ExpenseCategoryDto,
+  ExpenseDto,
+  PagedExpenseListResponse,
+  UpdateExpenseRequest,
+  DuplicateCheckResult,
+  ExpenseFilters,
+  PagedResult,
+  ExpenseListItemDto
+} from './expense.service';
+
+describe('ExpenseService', () => {
+  let service: ExpenseService;
+  let httpMock: HttpTestingController;
+
+  const mockCategory: ExpenseCategoryDto = {
+    id: 'cat-1',
+    name: 'Repairs',
+    scheduleELine: 'Line 14',
+    sortOrder: 1,
+    parentId: undefined
+  };
+
+  const mockExpense: ExpenseDto = {
+    id: 'exp-1',
+    propertyId: 'prop-1',
+    propertyName: 'Test Property',
+    categoryId: 'cat-1',
+    categoryName: 'Repairs',
+    scheduleELine: 'Line 14',
+    amount: 150.50,
+    date: '2024-03-15',
+    description: 'Fixed faucet',
+    receiptId: 'receipt-1',
+    createdAt: '2024-03-15T10:00:00Z'
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ExpenseService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+    service = TestBed.inject(ExpenseService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('createExpense', () => {
+    it('should create an expense and return the ID', () => {
+      const request: CreateExpenseRequest = {
+        propertyId: 'prop-1',
+        amount: 150.50,
+        date: '2024-03-15',
+        categoryId: 'cat-1',
+        description: 'Fixed faucet'
+      };
+      const mockResponse: CreateExpenseResponse = { id: 'new-exp-id' };
+
+      service.createExpense(request).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne('/api/v1/expenses');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(request);
+      req.flush(mockResponse);
+    });
+
+    it('should create an expense without optional description', () => {
+      const request: CreateExpenseRequest = {
+        propertyId: 'prop-1',
+        amount: 100,
+        date: '2024-03-20',
+        categoryId: 'cat-2'
+      };
+      const mockResponse: CreateExpenseResponse = { id: 'exp-no-desc' };
+
+      service.createExpense(request).subscribe(response => {
+        expect(response.id).toBe('exp-no-desc');
+      });
+
+      const req = httpMock.expectOne('/api/v1/expenses');
+      expect(req.request.body.description).toBeUndefined();
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getCategories', () => {
+    it('should get all expense categories', () => {
+      const mockResponse: ExpenseCategoriesResponse = {
+        items: [mockCategory, { ...mockCategory, id: 'cat-2', name: 'Insurance' }],
+        totalCount: 2
+      };
+
+      service.getCategories().subscribe(response => {
+        expect(response.items).toHaveLength(2);
+        expect(response.items[0].name).toBe('Repairs');
+      });
+
+      const req = httpMock.expectOne('/api/v1/expense-categories');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getExpensesByProperty', () => {
+    it('should get expenses for a property with default pagination', () => {
+      const mockResponse: PagedExpenseListResponse = {
+        items: [mockExpense],
+        totalCount: 1,
+        page: 1,
+        pageSize: 25,
+        totalPages: 1,
+        ytdTotal: 150.50
+      };
+
+      service.getExpensesByProperty('prop-1').subscribe(response => {
+        expect(response.items).toHaveLength(1);
+        expect(response.ytdTotal).toBe(150.50);
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/properties/prop-1/expenses');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('page')).toBe('1');
+      expect(req.request.params.get('pageSize')).toBe('25');
+      req.flush(mockResponse);
+    });
+
+    it('should filter expenses by year', () => {
+      const mockResponse: PagedExpenseListResponse = {
+        items: [mockExpense],
+        totalCount: 1,
+        page: 1,
+        pageSize: 25,
+        totalPages: 1,
+        ytdTotal: 150.50
+      };
+
+      service.getExpensesByProperty('prop-1', 2024).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/properties/prop-1/expenses');
+      expect(req.request.params.get('year')).toBe('2024');
+      req.flush(mockResponse);
+    });
+
+    it('should support custom pagination', () => {
+      const mockResponse: PagedExpenseListResponse = {
+        items: [],
+        totalCount: 0,
+        page: 2,
+        pageSize: 10,
+        totalPages: 0,
+        ytdTotal: 0
+      };
+
+      service.getExpensesByProperty('prop-1', undefined, 2, 10).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/properties/prop-1/expenses');
+      expect(req.request.params.get('page')).toBe('2');
+      expect(req.request.params.get('pageSize')).toBe('10');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getExpense', () => {
+    it('should get a single expense by ID', () => {
+      service.getExpense('exp-1').subscribe(response => {
+        expect(response.id).toBe('exp-1');
+        expect(response.amount).toBe(150.50);
+      });
+
+      const req = httpMock.expectOne('/api/v1/expenses/exp-1');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockExpense);
+    });
+  });
+
+  describe('updateExpense', () => {
+    it('should update an expense', () => {
+      const request: UpdateExpenseRequest = {
+        amount: 200,
+        date: '2024-03-16',
+        categoryId: 'cat-2',
+        description: 'Updated description'
+      };
+
+      service.updateExpense('exp-1', request).subscribe();
+
+      const req = httpMock.expectOne('/api/v1/expenses/exp-1');
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(request);
+      req.flush(null);
+    });
+
+    it('should update expense without optional description', () => {
+      const request: UpdateExpenseRequest = {
+        amount: 200,
+        date: '2024-03-16',
+        categoryId: 'cat-2'
+      };
+
+      service.updateExpense('exp-1', request).subscribe();
+
+      const req = httpMock.expectOne('/api/v1/expenses/exp-1');
+      expect(req.request.body.description).toBeUndefined();
+      req.flush(null);
+    });
+  });
+
+  describe('deleteExpense', () => {
+    it('should delete an expense', () => {
+      service.deleteExpense('exp-1').subscribe();
+
+      const req = httpMock.expectOne('/api/v1/expenses/exp-1');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+  });
+
+  describe('checkDuplicateExpense', () => {
+    it('should check for duplicate and return false when no duplicate', () => {
+      const mockResponse: DuplicateCheckResult = {
+        isDuplicate: false
+      };
+
+      service.checkDuplicateExpense('prop-1', 150.50, '2024-03-15').subscribe(response => {
+        expect(response.isDuplicate).toBe(false);
+        expect(response.existingExpense).toBeUndefined();
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/expenses/check-duplicate');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('propertyId')).toBe('prop-1');
+      expect(req.request.params.get('amount')).toBe('150.5');
+      expect(req.request.params.get('date')).toBe('2024-03-15');
+      req.flush(mockResponse);
+    });
+
+    it('should return existing expense when duplicate found', () => {
+      const mockResponse: DuplicateCheckResult = {
+        isDuplicate: true,
+        existingExpense: {
+          id: 'existing-exp',
+          date: '2024-03-15',
+          amount: 150.50,
+          description: 'Same expense'
+        }
+      };
+
+      service.checkDuplicateExpense('prop-1', 150.50, '2024-03-15').subscribe(response => {
+        expect(response.isDuplicate).toBe(true);
+        expect(response.existingExpense?.id).toBe('existing-exp');
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/expenses/check-duplicate');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getExpenses', () => {
+    it('should get all expenses with minimal filters', () => {
+      const filters: ExpenseFilters = {
+        page: 1,
+        pageSize: 25
+      };
+      const mockResponse: PagedResult<ExpenseListItemDto> = {
+        items: [mockExpense as ExpenseListItemDto],
+        totalCount: 1,
+        page: 1,
+        pageSize: 25,
+        totalPages: 1
+      };
+
+      service.getExpenses(filters).subscribe(response => {
+        expect(response.items).toHaveLength(1);
+        expect(response.totalCount).toBe(1);
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/expenses');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('page')).toBe('1');
+      expect(req.request.params.get('pageSize')).toBe('25');
+      req.flush(mockResponse);
+    });
+
+    it('should filter expenses by date range', () => {
+      const filters: ExpenseFilters = {
+        page: 1,
+        pageSize: 25,
+        dateFrom: '2024-01-01',
+        dateTo: '2024-12-31'
+      };
+      const mockResponse: PagedResult<ExpenseListItemDto> = {
+        items: [],
+        totalCount: 0,
+        page: 1,
+        pageSize: 25,
+        totalPages: 0
+      };
+
+      service.getExpenses(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/expenses');
+      expect(req.request.params.get('dateFrom')).toBe('2024-01-01');
+      expect(req.request.params.get('dateTo')).toBe('2024-12-31');
+      req.flush(mockResponse);
+    });
+
+    it('should filter expenses by category IDs', () => {
+      const filters: ExpenseFilters = {
+        page: 1,
+        pageSize: 25,
+        categoryIds: ['cat-1', 'cat-2']
+      };
+      const mockResponse: PagedResult<ExpenseListItemDto> = {
+        items: [],
+        totalCount: 0,
+        page: 1,
+        pageSize: 25,
+        totalPages: 0
+      };
+
+      service.getExpenses(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/expenses');
+      expect(req.request.params.getAll('categoryIds')).toEqual(['cat-1', 'cat-2']);
+      req.flush(mockResponse);
+    });
+
+    it('should filter expenses by search term', () => {
+      const filters: ExpenseFilters = {
+        page: 1,
+        pageSize: 25,
+        search: 'faucet'
+      };
+      const mockResponse: PagedResult<ExpenseListItemDto> = {
+        items: [],
+        totalCount: 0,
+        page: 1,
+        pageSize: 25,
+        totalPages: 0
+      };
+
+      service.getExpenses(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/expenses');
+      expect(req.request.params.get('search')).toBe('faucet');
+      req.flush(mockResponse);
+    });
+
+    it('should filter expenses by year', () => {
+      const filters: ExpenseFilters = {
+        page: 1,
+        pageSize: 25,
+        year: 2024
+      };
+      const mockResponse: PagedResult<ExpenseListItemDto> = {
+        items: [],
+        totalCount: 0,
+        page: 1,
+        pageSize: 25,
+        totalPages: 0
+      };
+
+      service.getExpenses(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/expenses');
+      expect(req.request.params.get('year')).toBe('2024');
+      req.flush(mockResponse);
+    });
+
+    it('should trim search term and ignore whitespace-only search', () => {
+      const filters: ExpenseFilters = {
+        page: 1,
+        pageSize: 25,
+        search: '   '
+      };
+      const mockResponse: PagedResult<ExpenseListItemDto> = {
+        items: [],
+        totalCount: 0,
+        page: 1,
+        pageSize: 25,
+        totalPages: 0
+      };
+
+      service.getExpenses(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/expenses');
+      expect(req.request.params.has('search')).toBe(false);
+      req.flush(mockResponse);
+    });
+
+    it('should not include empty categoryIds array', () => {
+      const filters: ExpenseFilters = {
+        page: 1,
+        pageSize: 25,
+        categoryIds: []
+      };
+      const mockResponse: PagedResult<ExpenseListItemDto> = {
+        items: [],
+        totalCount: 0,
+        page: 1,
+        pageSize: 25,
+        totalPages: 0
+      };
+
+      service.getExpenses(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/expenses');
+      expect(req.request.params.has('categoryIds')).toBe(false);
+      req.flush(mockResponse);
+    });
+  });
+});

--- a/frontend/src/app/features/income/services/income.service.spec.ts
+++ b/frontend/src/app/features/income/services/income.service.spec.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  IncomeService,
+  CreateIncomeRequest,
+  CreateIncomeResponse,
+  IncomeDto,
+  IncomeListResponse,
+  IncomeTotalResponse,
+  IncomeFilterParams,
+  AllIncomeResponse,
+  UpdateIncomeRequest
+} from './income.service';
+
+describe('IncomeService', () => {
+  let service: IncomeService;
+  let httpMock: HttpTestingController;
+
+  const mockIncome: IncomeDto = {
+    id: 'inc-1',
+    propertyId: 'prop-1',
+    propertyName: 'Test Property',
+    amount: 1500.00,
+    date: '2024-03-01',
+    source: 'Rent',
+    description: 'March rent payment',
+    createdAt: '2024-03-01T10:00:00Z'
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        IncomeService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+    service = TestBed.inject(IncomeService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getAllIncome', () => {
+    it('should get all income without filters', () => {
+      const mockResponse: AllIncomeResponse = {
+        items: [mockIncome],
+        totalCount: 1,
+        totalAmount: 1500.00
+      };
+
+      service.getAllIncome().subscribe(response => {
+        expect(response.items).toHaveLength(1);
+        expect(response.totalAmount).toBe(1500.00);
+      });
+
+      const req = httpMock.expectOne('/api/v1/income');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+
+    it('should filter income by date range', () => {
+      const filters: IncomeFilterParams = {
+        dateFrom: '2024-01-01',
+        dateTo: '2024-12-31'
+      };
+      const mockResponse: AllIncomeResponse = {
+        items: [mockIncome],
+        totalCount: 1,
+        totalAmount: 1500.00
+      };
+
+      service.getAllIncome(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/income');
+      expect(req.request.params.get('dateFrom')).toBe('2024-01-01');
+      expect(req.request.params.get('dateTo')).toBe('2024-12-31');
+      req.flush(mockResponse);
+    });
+
+    it('should filter income by property ID', () => {
+      const filters: IncomeFilterParams = {
+        propertyId: 'prop-1'
+      };
+      const mockResponse: AllIncomeResponse = {
+        items: [mockIncome],
+        totalCount: 1,
+        totalAmount: 1500.00
+      };
+
+      service.getAllIncome(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/income');
+      expect(req.request.params.get('propertyId')).toBe('prop-1');
+      req.flush(mockResponse);
+    });
+
+    it('should filter income by year', () => {
+      const filters: IncomeFilterParams = {
+        year: 2024
+      };
+      const mockResponse: AllIncomeResponse = {
+        items: [mockIncome],
+        totalCount: 1,
+        totalAmount: 1500.00
+      };
+
+      service.getAllIncome(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/income');
+      expect(req.request.params.get('year')).toBe('2024');
+      req.flush(mockResponse);
+    });
+
+    it('should combine multiple filters', () => {
+      const filters: IncomeFilterParams = {
+        dateFrom: '2024-01-01',
+        propertyId: 'prop-1',
+        year: 2024
+      };
+      const mockResponse: AllIncomeResponse = {
+        items: [],
+        totalCount: 0,
+        totalAmount: 0
+      };
+
+      service.getAllIncome(filters).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/income');
+      expect(req.request.params.get('dateFrom')).toBe('2024-01-01');
+      expect(req.request.params.get('propertyId')).toBe('prop-1');
+      expect(req.request.params.get('year')).toBe('2024');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('createIncome', () => {
+    it('should create an income entry and return the ID', () => {
+      const request: CreateIncomeRequest = {
+        propertyId: 'prop-1',
+        amount: 1500.00,
+        date: '2024-03-01',
+        source: 'Rent',
+        description: 'March rent payment'
+      };
+      const mockResponse: CreateIncomeResponse = { id: 'new-inc-id' };
+
+      service.createIncome(request).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne('/api/v1/income');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(request);
+      req.flush(mockResponse);
+    });
+
+    it('should create income without optional fields', () => {
+      const request: CreateIncomeRequest = {
+        propertyId: 'prop-1',
+        amount: 1000.00,
+        date: '2024-04-01'
+      };
+      const mockResponse: CreateIncomeResponse = { id: 'minimal-inc' };
+
+      service.createIncome(request).subscribe(response => {
+        expect(response.id).toBe('minimal-inc');
+      });
+
+      const req = httpMock.expectOne('/api/v1/income');
+      expect(req.request.body.source).toBeUndefined();
+      expect(req.request.body.description).toBeUndefined();
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getIncomeByProperty', () => {
+    it('should get income for a property without year filter', () => {
+      const mockResponse: IncomeListResponse = {
+        items: [mockIncome],
+        totalCount: 1,
+        ytdTotal: 1500.00
+      };
+
+      service.getIncomeByProperty('prop-1').subscribe(response => {
+        expect(response.items).toHaveLength(1);
+        expect(response.ytdTotal).toBe(1500.00);
+      });
+
+      const req = httpMock.expectOne('/api/v1/properties/prop-1/income');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.keys()).toHaveLength(0);
+      req.flush(mockResponse);
+    });
+
+    it('should get income for a property filtered by year', () => {
+      const mockResponse: IncomeListResponse = {
+        items: [mockIncome],
+        totalCount: 1,
+        ytdTotal: 1500.00
+      };
+
+      service.getIncomeByProperty('prop-1', 2024).subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/properties/prop-1/income');
+      expect(req.request.params.get('year')).toBe('2024');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getIncomeTotalByProperty', () => {
+    it('should get income total for a property and year', () => {
+      const mockResponse: IncomeTotalResponse = {
+        total: 18000.00,
+        year: 2024
+      };
+
+      service.getIncomeTotalByProperty('prop-1', 2024).subscribe(response => {
+        expect(response.total).toBe(18000.00);
+        expect(response.year).toBe(2024);
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/properties/prop-1/income/total');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('year')).toBe('2024');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getIncomeById', () => {
+    it('should get a single income entry by ID', () => {
+      service.getIncomeById('inc-1').subscribe(response => {
+        expect(response.id).toBe('inc-1');
+        expect(response.amount).toBe(1500.00);
+        expect(response.source).toBe('Rent');
+      });
+
+      const req = httpMock.expectOne('/api/v1/income/inc-1');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockIncome);
+    });
+  });
+
+  describe('updateIncome', () => {
+    it('should update an income entry', () => {
+      const request: UpdateIncomeRequest = {
+        amount: 1600.00,
+        date: '2024-03-05',
+        source: 'Rent + Late Fee',
+        description: 'March rent with late fee'
+      };
+
+      service.updateIncome('inc-1', request).subscribe();
+
+      const req = httpMock.expectOne('/api/v1/income/inc-1');
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(request);
+      req.flush(null);
+    });
+
+    it('should update income with only required fields', () => {
+      const request: UpdateIncomeRequest = {
+        amount: 1500.00,
+        date: '2024-03-01'
+      };
+
+      service.updateIncome('inc-1', request).subscribe();
+
+      const req = httpMock.expectOne('/api/v1/income/inc-1');
+      expect(req.request.body.source).toBeUndefined();
+      expect(req.request.body.description).toBeUndefined();
+      req.flush(null);
+    });
+  });
+
+  describe('deleteIncome', () => {
+    it('should delete an income entry', () => {
+      service.deleteIncome('inc-1').subscribe();
+
+      const req = httpMock.expectOne('/api/v1/income/inc-1');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+  });
+});

--- a/frontend/src/app/features/properties/services/property.service.spec.ts
+++ b/frontend/src/app/features/properties/services/property.service.spec.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  PropertyService,
+  CreatePropertyRequest,
+  CreatePropertyResponse,
+  PropertySummaryDto,
+  GetAllPropertiesResponse,
+  PropertyDetailDto
+} from './property.service';
+
+describe('PropertyService', () => {
+  let service: PropertyService;
+  let httpMock: HttpTestingController;
+
+  const mockPropertySummary: PropertySummaryDto = {
+    id: 'prop-1',
+    name: 'Test Property',
+    street: '123 Main St',
+    city: 'Austin',
+    state: 'TX',
+    zipCode: '78701',
+    expenseTotal: 5000,
+    incomeTotal: 18000,
+    primaryPhotoThumbnailUrl: 'https://example.com/photo.jpg'
+  };
+
+  const mockPropertyDetail: PropertyDetailDto = {
+    id: 'prop-1',
+    name: 'Test Property',
+    street: '123 Main St',
+    city: 'Austin',
+    state: 'TX',
+    zipCode: '78701',
+    expenseTotal: 5000,
+    incomeTotal: 18000,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-03-15T10:00:00Z',
+    recentExpenses: [
+      { id: 'exp-1', description: 'Repairs', amount: 150, date: '2024-03-10' }
+    ],
+    recentIncome: [
+      { id: 'inc-1', description: 'Rent', amount: 1500, date: '2024-03-01' }
+    ],
+    primaryPhotoThumbnailUrl: 'https://example.com/photo.jpg'
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PropertyService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+    service = TestBed.inject(PropertyService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('createProperty', () => {
+    it('should create a property and return the ID', () => {
+      const request: CreatePropertyRequest = {
+        name: 'New Property',
+        street: '456 Oak Ave',
+        city: 'Dallas',
+        state: 'TX',
+        zipCode: '75201'
+      };
+      const mockResponse: CreatePropertyResponse = { id: 'new-prop-id' };
+
+      service.createProperty(request).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne('/api/v1/properties');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(request);
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getProperties', () => {
+    it('should get all properties without year filter', () => {
+      const mockResponse: GetAllPropertiesResponse = {
+        items: [mockPropertySummary],
+        totalCount: 1
+      };
+
+      service.getProperties().subscribe(response => {
+        expect(response.items).toHaveLength(1);
+        expect(response.items[0].name).toBe('Test Property');
+      });
+
+      const req = httpMock.expectOne('/api/v1/properties');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.keys()).toHaveLength(0);
+      req.flush(mockResponse);
+    });
+
+    it('should get properties filtered by year', () => {
+      const mockResponse: GetAllPropertiesResponse = {
+        items: [mockPropertySummary],
+        totalCount: 1
+      };
+
+      service.getProperties(2024).subscribe(response => {
+        expect(response.items).toHaveLength(1);
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/properties');
+      expect(req.request.params.get('year')).toBe('2024');
+      req.flush(mockResponse);
+    });
+
+    it('should handle empty properties list', () => {
+      const mockResponse: GetAllPropertiesResponse = {
+        items: [],
+        totalCount: 0
+      };
+
+      service.getProperties().subscribe(response => {
+        expect(response.items).toHaveLength(0);
+        expect(response.totalCount).toBe(0);
+      });
+
+      const req = httpMock.expectOne('/api/v1/properties');
+      req.flush(mockResponse);
+    });
+
+    it('should handle property without photo', () => {
+      const propertyWithoutPhoto: PropertySummaryDto = {
+        ...mockPropertySummary,
+        primaryPhotoThumbnailUrl: null
+      };
+      const mockResponse: GetAllPropertiesResponse = {
+        items: [propertyWithoutPhoto],
+        totalCount: 1
+      };
+
+      service.getProperties().subscribe(response => {
+        expect(response.items[0].primaryPhotoThumbnailUrl).toBeNull();
+      });
+
+      const req = httpMock.expectOne('/api/v1/properties');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getPropertyById', () => {
+    it('should get a property by ID without year filter', () => {
+      service.getPropertyById('prop-1').subscribe(response => {
+        expect(response.id).toBe('prop-1');
+        expect(response.name).toBe('Test Property');
+        expect(response.recentExpenses).toHaveLength(1);
+        expect(response.recentIncome).toHaveLength(1);
+      });
+
+      const req = httpMock.expectOne('/api/v1/properties/prop-1');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.keys()).toHaveLength(0);
+      req.flush(mockPropertyDetail);
+    });
+
+    it('should get a property by ID filtered by year', () => {
+      service.getPropertyById('prop-1', 2024).subscribe(response => {
+        expect(response.id).toBe('prop-1');
+        expect(response.expenseTotal).toBe(5000);
+        expect(response.incomeTotal).toBe(18000);
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/properties/prop-1');
+      expect(req.request.params.get('year')).toBe('2024');
+      req.flush(mockPropertyDetail);
+    });
+
+    it('should include recent expenses and income in response', () => {
+      service.getPropertyById('prop-1').subscribe(response => {
+        expect(response.recentExpenses[0].description).toBe('Repairs');
+        expect(response.recentExpenses[0].amount).toBe(150);
+        expect(response.recentIncome[0].description).toBe('Rent');
+        expect(response.recentIncome[0].amount).toBe(1500);
+      });
+
+      const req = httpMock.expectOne('/api/v1/properties/prop-1');
+      req.flush(mockPropertyDetail);
+    });
+  });
+
+  describe('updateProperty', () => {
+    it('should update a property', () => {
+      const request: CreatePropertyRequest = {
+        name: 'Updated Property',
+        street: '789 Elm St',
+        city: 'Houston',
+        state: 'TX',
+        zipCode: '77001'
+      };
+
+      service.updateProperty('prop-1', request).subscribe();
+
+      const req = httpMock.expectOne('/api/v1/properties/prop-1');
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(request);
+      req.flush(null);
+    });
+
+    it('should send all property fields in update request', () => {
+      const request: CreatePropertyRequest = {
+        name: 'Updated Name',
+        street: 'New Street',
+        city: 'New City',
+        state: 'CA',
+        zipCode: '90210'
+      };
+
+      service.updateProperty('prop-1', request).subscribe();
+
+      const req = httpMock.expectOne('/api/v1/properties/prop-1');
+      expect(req.request.body.name).toBe('Updated Name');
+      expect(req.request.body.street).toBe('New Street');
+      expect(req.request.body.city).toBe('New City');
+      expect(req.request.body.state).toBe('CA');
+      expect(req.request.body.zipCode).toBe('90210');
+      req.flush(null);
+    });
+  });
+
+  describe('deleteProperty', () => {
+    it('should delete a property', () => {
+      service.deleteProperty('prop-1').subscribe();
+
+      const req = httpMock.expectOne('/api/v1/properties/prop-1');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+  });
+});

--- a/frontend/src/app/features/work-orders/services/work-order.service.spec.ts
+++ b/frontend/src/app/features/work-orders/services/work-order.service.spec.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  WorkOrderService,
+  CreateWorkOrderRequest,
+  CreateWorkOrderResponse,
+  UpdateWorkOrderRequest,
+  WorkOrderDto,
+  GetAllWorkOrdersResponse,
+  GetAllWorkOrderTagsResponse,
+  CreateWorkOrderTagRequest,
+  GetWorkOrdersByPropertyResponse,
+  WorkOrderTagDto
+} from './work-order.service';
+
+describe('WorkOrderService', () => {
+  let service: WorkOrderService;
+  let httpMock: HttpTestingController;
+
+  const mockWorkOrderTag: WorkOrderTagDto = {
+    id: 'tag-1',
+    name: 'Urgent'
+  };
+
+  const mockWorkOrder: WorkOrderDto = {
+    id: 'wo-1',
+    propertyId: 'prop-1',
+    propertyName: 'Test Property',
+    vendorId: 'vendor-1',
+    vendorName: 'Test Vendor',
+    isDiy: false,
+    categoryId: 'cat-1',
+    categoryName: 'Plumbing',
+    status: 'Reported',
+    description: 'Fix leaky faucet',
+    createdAt: '2024-01-15T10:00:00Z',
+    createdByUserId: 'user-1',
+    tags: [mockWorkOrderTag]
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        WorkOrderService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+    service = TestBed.inject(WorkOrderService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('createWorkOrder', () => {
+    it('should create a work order and return the ID', () => {
+      const request: CreateWorkOrderRequest = {
+        propertyId: 'prop-1',
+        description: 'Fix leaky faucet',
+        categoryId: 'cat-1',
+        status: 'Reported',
+        vendorId: 'vendor-1',
+        tagIds: ['tag-1']
+      };
+      const mockResponse: CreateWorkOrderResponse = { id: 'new-wo-id' };
+
+      service.createWorkOrder(request).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne('/api/v1/work-orders');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(request);
+      req.flush(mockResponse);
+    });
+
+    it('should create a DIY work order without vendorId', () => {
+      const request: CreateWorkOrderRequest = {
+        propertyId: 'prop-1',
+        description: 'Paint bedroom'
+      };
+      const mockResponse: CreateWorkOrderResponse = { id: 'diy-wo-id' };
+
+      service.createWorkOrder(request).subscribe(response => {
+        expect(response.id).toBe('diy-wo-id');
+      });
+
+      const req = httpMock.expectOne('/api/v1/work-orders');
+      expect(req.request.body.vendorId).toBeUndefined();
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getWorkOrders', () => {
+    it('should get all work orders without filters', () => {
+      const mockResponse: GetAllWorkOrdersResponse = {
+        items: [mockWorkOrder],
+        totalCount: 1
+      };
+
+      service.getWorkOrders().subscribe(response => {
+        expect(response.items).toHaveLength(1);
+        expect(response.totalCount).toBe(1);
+      });
+
+      const req = httpMock.expectOne('/api/v1/work-orders');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.keys()).toHaveLength(0);
+      req.flush(mockResponse);
+    });
+
+    it('should filter work orders by status', () => {
+      const mockResponse: GetAllWorkOrdersResponse = {
+        items: [mockWorkOrder],
+        totalCount: 1
+      };
+
+      service.getWorkOrders('Reported').subscribe(response => {
+        expect(response.items[0].status).toBe('Reported');
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/work-orders');
+      expect(req.request.params.get('status')).toBe('Reported');
+      req.flush(mockResponse);
+    });
+
+    it('should filter work orders by propertyId', () => {
+      const mockResponse: GetAllWorkOrdersResponse = {
+        items: [mockWorkOrder],
+        totalCount: 1
+      };
+
+      service.getWorkOrders(undefined, 'prop-1').subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/work-orders');
+      expect(req.request.params.get('propertyId')).toBe('prop-1');
+      expect(req.request.params.has('status')).toBe(false);
+      req.flush(mockResponse);
+    });
+
+    it('should filter work orders by both status and propertyId', () => {
+      const mockResponse: GetAllWorkOrdersResponse = {
+        items: [mockWorkOrder],
+        totalCount: 1
+      };
+
+      service.getWorkOrders('Completed', 'prop-2').subscribe();
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/work-orders');
+      expect(req.request.params.get('status')).toBe('Completed');
+      expect(req.request.params.get('propertyId')).toBe('prop-2');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('getWorkOrder', () => {
+    it('should get a single work order by ID', () => {
+      service.getWorkOrder('wo-1').subscribe(response => {
+        expect(response.id).toBe('wo-1');
+        expect(response.description).toBe('Fix leaky faucet');
+      });
+
+      const req = httpMock.expectOne('/api/v1/work-orders/wo-1');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockWorkOrder);
+    });
+  });
+
+  describe('updateWorkOrder', () => {
+    it('should update a work order', () => {
+      const request: UpdateWorkOrderRequest = {
+        description: 'Updated description',
+        categoryId: 'cat-2',
+        status: 'Completed',
+        vendorId: 'vendor-2',
+        tagIds: ['tag-2']
+      };
+
+      service.updateWorkOrder('wo-1', request).subscribe();
+
+      const req = httpMock.expectOne('/api/v1/work-orders/wo-1');
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(request);
+      req.flush(null);
+    });
+
+    it('should update work order with minimal fields', () => {
+      const request: UpdateWorkOrderRequest = {
+        description: 'Minimal update'
+      };
+
+      service.updateWorkOrder('wo-1', request).subscribe();
+
+      const req = httpMock.expectOne('/api/v1/work-orders/wo-1');
+      expect(req.request.body.description).toBe('Minimal update');
+      expect(req.request.body.categoryId).toBeUndefined();
+      req.flush(null);
+    });
+  });
+
+  describe('getWorkOrderTags', () => {
+    it('should get all work order tags', () => {
+      const mockResponse: GetAllWorkOrderTagsResponse = {
+        items: [
+          { id: 'tag-1', name: 'Urgent' },
+          { id: 'tag-2', name: 'Routine' }
+        ],
+        totalCount: 2
+      };
+
+      service.getWorkOrderTags().subscribe(response => {
+        expect(response.items).toHaveLength(2);
+        expect(response.items[0].name).toBe('Urgent');
+      });
+
+      const req = httpMock.expectOne('/api/v1/work-order-tags');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('createWorkOrderTag', () => {
+    it('should create a new work order tag', () => {
+      const request: CreateWorkOrderTagRequest = { name: 'Priority' };
+      const mockResponse = { id: 'new-tag-id' };
+
+      service.createWorkOrderTag(request).subscribe(response => {
+        expect(response.id).toBe('new-tag-id');
+      });
+
+      const req = httpMock.expectOne('/api/v1/work-order-tags');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(request);
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('deleteWorkOrder', () => {
+    it('should delete a work order', () => {
+      service.deleteWorkOrder('wo-1').subscribe();
+
+      const req = httpMock.expectOne('/api/v1/work-orders/wo-1');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+  });
+
+  describe('getWorkOrdersByProperty', () => {
+    it('should get work orders for a specific property', () => {
+      const mockResponse: GetWorkOrdersByPropertyResponse = {
+        items: [mockWorkOrder],
+        totalCount: 1
+      };
+
+      service.getWorkOrdersByProperty('prop-1').subscribe(response => {
+        expect(response.items).toHaveLength(1);
+        expect(response.items[0].propertyId).toBe('prop-1');
+      });
+
+      const req = httpMock.expectOne('/api/v1/properties/prop-1/work-orders');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.keys()).toHaveLength(0);
+      req.flush(mockResponse);
+    });
+
+    it('should get work orders with limit parameter', () => {
+      const mockResponse: GetWorkOrdersByPropertyResponse = {
+        items: [mockWorkOrder],
+        totalCount: 10
+      };
+
+      service.getWorkOrdersByProperty('prop-1', 5).subscribe(response => {
+        expect(response.items).toHaveLength(1);
+        expect(response.totalCount).toBe(10);
+      });
+
+      const req = httpMock.expectOne(r => r.url === '/api/v1/properties/prop-1/work-orders');
+      expect(req.request.params.get('limit')).toBe('5');
+      req.flush(mockResponse);
+    });
+
+    it('should not include limit param when undefined', () => {
+      const mockResponse: GetWorkOrdersByPropertyResponse = {
+        items: [],
+        totalCount: 0
+      };
+
+      service.getWorkOrdersByProperty('prop-1', undefined).subscribe();
+
+      const req = httpMock.expectOne('/api/v1/properties/prop-1/work-orders');
+      expect(req.request.params.has('limit')).toBe(false);
+      req.flush(mockResponse);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for 4 P2 feature services that had no test coverage
- Frontend test count: 63 → 67 files, 1502 → 1565 tests
- Completes P2 priority in test coverage gap work

## Tests Added

| Service | Tests | Coverage |
|---------|-------|----------|
| work-order.service.ts | 16 | CRUD, filters, tags, property work orders |
| expense.service.ts | 20 | CRUD, filters, duplicate check, pagination |
| income.service.ts | 15 | CRUD, filters, totals by property |
| property.service.ts | 12 | CRUD, year filter, detail with summaries |

## Test Plan
- [x] All 1565 frontend tests pass (`ng test --no-watch`)
- [x] New tests use HttpTestingController pattern
- [x] Tests cover all public methods in each service

🤖 Generated with [Claude Code](https://claude.com/claude-code)