### PR TITLE
fix: UnlinkReceipt queries correct FK direction (#210)

### DIFF
--- a/_bmad-output/implementation-artifacts/14-2-security-headers-middleware.md
+++ b/_bmad-output/implementation-artifacts/14-2-security-headers-middleware.md
@@ -1,6 +1,6 @@
 # Story 14.2: Security Headers Middleware
 
-Status: review
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/14-3-api-rate-limiting.md
+++ b/_bmad-output/implementation-artifacts/14-3-api-rate-limiting.md
@@ -1,6 +1,6 @@
 # Story 14.3: API Rate Limiting
 
-Status: dev-complete
+Status: done
 
 ## Story
 
@@ -208,8 +208,9 @@ None
 
 ### File List
 
-- `backend/src/PropertyManager.Api/Program.cs` — rate limiter service registration + UseRateLimiter() pipeline placement
+- `backend/src/PropertyManager.Api/Program.cs` — rate limiter service registration + UseRateLimiter() pipeline placement + configurable disable flag for CI E2E
 - `backend/src/PropertyManager.Api/Controllers/AuthController.cs` — [EnableRateLimiting] attributes on auth endpoints
 - `backend/tests/PropertyManager.Api.Tests/Middleware/RateLimitingTests.cs` — 6 integration tests (NEW)
 - `backend/tests/PropertyManager.Api.Tests/PropertyManagerWebApplicationFactory.cs` — disabled rate limiting for shared test factory
 - `backend/tests/PropertyManager.Api.Tests/PropertyManager.Api.Tests.csproj` — added InMemory EF Core package
+- `.github/workflows/ci.yml` — added `RateLimiting__Disabled=true` env var to E2E API start step

--- a/_bmad-output/implementation-artifacts/15-4-fix-unlink-receipt-backend-bug.md
+++ b/_bmad-output/implementation-artifacts/15-4-fix-unlink-receipt-backend-bug.md
@@ -1,0 +1,170 @@
+# Story 15.4: Fix Unlink Receipt Backend Bug
+
+Status: done
+
+## Story
+
+As a **property owner managing receipts**,
+I want **to unlink a receipt from an expense**,
+So that **I can reprocess or reassign receipts when needed**.
+
+**GitHub Issue:** #210
+**Severity:** High — blocks receipt reprocessing workflow
+
+## Root Cause Analysis
+
+The `UnlinkReceiptHandler` queries the wrong side of the FK relationship.
+
+**The FK configuration** (`ExpenseConfiguration.cs` lines 71-74):
+```csharp
+builder.HasOne(e => e.Receipt)
+    .WithOne(r => r.Expense)
+    .HasForeignKey<Expense>(e => e.ReceiptId)  // FK is on Expense side
+    .OnDelete(DeleteBehavior.SetNull);
+```
+
+- `Expense.ReceiptId` → **real FK** pointing to `Receipt.Id`
+- `Receipt.ExpenseId` → **NOT a FK**, just a property column — may be null or stale
+
+**The bug** (`UnlinkReceipt.cs` line 48):
+```csharp
+var receipt = await _dbContext.Receipts
+    .FirstOrDefaultAsync(r => r.ExpenseId == request.ExpenseId, cancellationToken);
+```
+
+This queries `Receipt.ExpenseId` which is not the FK → returns null → throws 404.
+
+**Additionally**, the handler only nulls `Receipt.ExpenseId` and `Receipt.ProcessedAt` but never clears `Expense.ReceiptId` — the actual FK that links them.
+
+## Acceptance Criteria
+
+### AC #1: Successfully Unlink a Linked Receipt
+
+**Given** an expense has a linked receipt (`Expense.ReceiptId` is set)
+**When** I call `DELETE /api/v1/expenses/{id}/receipt`
+**Then** `Expense.ReceiptId` is set to null
+**And** `Receipt.ExpenseId` is set to null
+**And** `Receipt.ProcessedAt` is set to null (returns receipt to unprocessed queue)
+**And** the response is `204 No Content`
+
+### AC #2: Expense Not Found
+
+**Given** the expense ID does not exist
+**When** I call `DELETE /api/v1/expenses/{id}/receipt`
+**Then** the response is `404 Not Found` with message containing "Expense"
+
+### AC #3: No Receipt Linked to Expense
+
+**Given** the expense exists but has no linked receipt (`Expense.ReceiptId` is null)
+**When** I call `DELETE /api/v1/expenses/{id}/receipt`
+**Then** the response is `404 Not Found` with message containing "Receipt for expense"
+
+### AC #4: Existing Tests Continue to Pass
+
+**Given** the fix is applied
+**When** I run the full backend test suite
+**Then** all tests pass with no regressions
+
+## Tasks / Subtasks
+
+> **TDD Approach:** Fix tests first to reflect correct behavior, then fix the handler.
+
+---
+
+### Task 1: Update Unit Tests to Reflect Correct FK Direction [x]
+
+**File:** `backend/tests/PropertyManager.Application.Tests/Expenses/UnlinkReceiptHandlerTests.cs`
+
+The existing tests use mock DbSets for both `Expenses` and `Receipts` separately. After the fix, the handler will use `Include(e => e.Receipt)` on the Expenses DbSet, so tests must set up the `Receipt` navigation property on the `Expense` entity instead of relying on a separate Receipts query.
+
+**Changes:**
+1. Update `CreateExpense()` helper to accept an optional `Receipt` parameter and set the `Receipt` navigation property + `ReceiptId`
+2. Update `Handle_NoReceiptLinked_ThrowsNotFoundException` — expense exists with `ReceiptId = null`, `Receipt = null`
+3. Update `Handle_ValidCommand_UnlinksReceiptFromExpense` — verify `expense.ReceiptId` is nulled (not just `receipt.ExpenseId`)
+4. Update `Handle_ValidCommand_ClearsProcessedAtTimestamp` — same navigation-based setup
+5. Update `Handle_ValidCommand_CallsSaveChanges` — same navigation-based setup
+6. Update or remove `Handle_ReceiptLinkedToDifferentExpense_ThrowsNotFoundException` — this scenario doesn't apply with Include-based approach (the receipt is accessed via navigation, not queried separately)
+7. Add new test: `Handle_ValidCommand_ClearsExpenseReceiptId` — verify `expense.ReceiptId` is set to null
+8. Add new test: `Handle_ValidCommand_ClearsReceiptExpenseId` — verify `receipt.ExpenseId` is set to null
+
+---
+
+### Task 2: Fix the UnlinkReceiptHandler [x]
+
+**File:** `backend/src/PropertyManager.Application/Expenses/UnlinkReceipt.cs`
+
+Replace the broken query with Include-based approach:
+
+```csharp
+public async Task<Unit> Handle(
+    UnlinkReceiptCommand request,
+    CancellationToken cancellationToken)
+{
+    // Load expense WITH its receipt via navigation property
+    var expense = await _dbContext.Expenses
+        .Include(e => e.Receipt)
+        .FirstOrDefaultAsync(e => e.Id == request.ExpenseId, cancellationToken);
+
+    if (expense == null)
+    {
+        throw new NotFoundException(nameof(Expense), request.ExpenseId);
+    }
+
+    var receipt = expense.Receipt;
+    if (receipt == null)
+    {
+        throw new NotFoundException("Receipt for expense", request.ExpenseId);
+    }
+
+    // Clear BOTH sides of the relationship
+    expense.ReceiptId = null;      // The real FK
+    receipt.ExpenseId = null;      // The shadow property
+    receipt.ProcessedAt = null;    // Return to unprocessed queue
+
+    await _dbContext.SaveChangesAsync(cancellationToken);
+
+    _logger.LogInformation(
+        "Unlinked receipt {ReceiptId} from expense {ExpenseId}",
+        receipt.Id,
+        request.ExpenseId);
+
+    return Unit.Value;
+}
+```
+
+**Key changes from original:**
+1. Use `.Include(e => e.Receipt)` to load via navigation instead of querying Receipts table
+2. Access receipt via `expense.Receipt` navigation property
+3. Clear `expense.ReceiptId` (the real FK) — **this was completely missing before**
+4. Keep clearing `receipt.ExpenseId` and `receipt.ProcessedAt`
+
+---
+
+### Task 3: Run Tests and Verify [x]
+
+1. Run `dotnet test --filter UnlinkReceiptHandlerTests` — all tests pass
+2. Run `dotnet test` — full suite passes, no regressions
+3. Manual verification: start API, upload a receipt, process into expense, unlink — should return 204
+
+---
+
+## Dev Notes
+
+- **No database migration needed** — no schema changes, just fixing the query logic
+- **No frontend changes needed** — the API contract (endpoint + response codes) is unchanged
+- **No new dependencies** — `Include()` is standard EF Core
+- The controller at `ExpensesController.cs` line 391 is correct and needs no changes
+
+## Files Involved
+
+| File | Action |
+|------|--------|
+| `backend/src/PropertyManager.Application/Expenses/UnlinkReceipt.cs` | **FIX** — rewrite query + clear both FK sides |
+| `backend/tests/PropertyManager.Application.Tests/Expenses/UnlinkReceiptHandlerTests.cs` | **UPDATE** — align tests with Include-based approach |
+
+---
+
+_Generated by BMAD Scrum Master_
+_Date: 2026-02-15_
+_For: Dave_
+_Project: property-manager_

--- a/_bmad-output/implementation-artifacts/epic-15-manual-testing-bug-fixes.md
+++ b/_bmad-output/implementation-artifacts/epic-15-manual-testing-bug-fixes.md
@@ -1,0 +1,218 @@
+# Epic 15: Manual Testing Bug Fixes
+
+**Goal:** Resolve all bugs and UX gaps discovered during manual testing (GitHub Issues #198-#210, excluding feature PRs #201, #203, #209 which belong to Epic 14).
+
+**GitHub Issues:** #198, #199, #200, #202, #204, #205, #206, #207, #208, #210
+
+**User Value:** "The app works correctly and consistently — the bugs I found during testing are fixed"
+
+---
+
+## Story 15.1: Login Form Fixes
+
+**GitHub Issues:** #198, #199, #200
+
+**As a** user logging into the application,
+**I want** the login form to validate email properly, not show dead UI, and redirect me to where I was going,
+**So that** the login experience is clean and functional.
+
+**Acceptance Criteria:**
+
+**AC1 — Stricter email validation (#198):**
+**Given** I enter an email without a TLD (e.g., `user@g`)
+**When** I attempt to submit the login form
+**Then** a field-level validation error appears before the form submits to the server
+
+**AC2 — Remove "Remember me" checkbox (#199):**
+**Given** I am on the login page
+**When** I view the form
+**Then** there is no "Remember me" checkbox (sessions are already persistent via HttpOnly refresh cookies)
+
+**AC3 — Honor returnUrl after login (#200):**
+**Given** I am redirected to `/login?returnUrl=%2Fproperties`
+**When** I log in successfully
+**Then** I am redirected to `/properties` (the returnUrl value), not hardcoded `/dashboard`
+
+**Given** the returnUrl is an absolute URL or external domain
+**When** I log in
+**Then** the returnUrl is rejected and I am redirected to `/dashboard` (open redirect protection)
+
+**Prerequisites:** None
+
+**Technical Notes:**
+- All changes in `login.component.ts` and `login.component.html`
+- #198: Add `Validators.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)` alongside existing `Validators.email`
+- #199: Remove `rememberMe` form control, `<mat-checkbox>`, and `MatCheckboxModule` import if unused
+- #200: Inject `ActivatedRoute`, read `returnUrl` query param in success handler, sanitize to relative paths only
+- Update unit tests for all three changes
+
+---
+
+## Story 15.2: Quick-Fix Form Validation Bugs
+
+**GitHub Issues:** #202, #205
+
+**As a** user interacting with forms,
+**I want** validation states to be correct and required fields clearly marked,
+**So that** I'm not confused by phantom errors or missing indicators.
+
+**Acceptance Criteria:**
+
+**AC1 — Note field resets cleanly after add (#202):**
+**Given** I add a note to a work order successfully
+**When** the note is created and the field clears
+**Then** the textarea is in a pristine state with no validation error border
+
+**AC2 — Category required indicator (#205):**
+**Given** I am on the New Expense form
+**When** I view the Category dropdown label
+**Then** it displays `Category *` matching the pattern of other required fields (Amount, Date)
+
+**Prerequisites:** None
+
+**Technical Notes:**
+- #202: In `work-order-notes.component.ts` line ~412, change `this.noteContent.setValue('')` to `this.noteContent.reset()`
+- #205: Add required indicator to Category `mat-label` in expense form template
+
+---
+
+## Story 15.3: Expense List UX Improvements
+
+**GitHub Issues:** #204, #206, #207
+
+**As a** property owner viewing my expenses,
+**I want** to create expenses from the list page, have my filters persist, and sort by columns,
+**So that** the expense list is fully functional and not read-only.
+
+**Acceptance Criteria:**
+
+**AC1 — Add Expense button (#204):**
+**Given** I am on the `/expenses` page
+**When** I look at the page header area
+**Then** I see an "Add Expense" button
+**And** clicking it opens the create expense flow
+
+**AC2 — Custom date range persistence (#206):**
+**Given** I set a custom date range filter and navigate away
+**When** I navigate back to the Expenses page
+**Then** the From/To date picker inputs repopulate with my previously selected dates
+
+**Given** I refresh the page
+**When** the Expenses page loads
+**Then** the custom date range is restored (via URL params or session storage)
+
+**AC3 — Column sorting (#207):**
+**Given** I am on the Expenses list page
+**When** I click a column header (Date, Amount, Category, Property, Description)
+**Then** the table sorts by that column with a visible sort direction indicator
+**And** clicking again toggles ascending/descending
+
+**Prerequisites:** None
+
+**Technical Notes:**
+- #204: Add FAB or header button on expenses list page, route to create expense form/dialog
+- #206: Persist custom date range in URL query params or sessionStorage; restore on component init
+- #207: Add `MatSort` directive to the `mat-table`, implement `matSort` on column headers
+
+---
+
+## Story 15.4: Fix Unlink Receipt Backend Bug
+
+**GitHub Issue:** #210
+
+**As a** property owner managing receipts,
+**I want** to unlink a receipt from an expense,
+**So that** I can reprocess or reassign receipts when needed.
+
+**Acceptance Criteria:**
+
+**Given** an expense has a linked receipt
+**When** I call `DELETE /api/v1/expenses/{id}/receipt`
+**Then** the receipt is unlinked from the expense (Expense.ReceiptId set to null)
+**And** the S3 file is cleaned up if applicable
+**And** the response is 204 No Content
+
+**Given** an expense has no linked receipt
+**When** I call `DELETE /api/v1/expenses/{id}/receipt`
+**Then** the response is 404 with appropriate error message
+
+**Prerequisites:** None
+
+**Technical Notes:**
+- **Root cause:** `UnlinkReceipt.cs` queries `Receipt.ExpenseId` but the FK is actually `Expense.ReceiptId` (FK is on Expense side per `ExpenseConfiguration.cs` lines 71-74)
+- **Fix:** Replace the broken query with `_dbContext.Expenses.Include(e => e.Receipt).FirstOrDefaultAsync(e => e.Id == request.ExpenseId)`
+- Then get `receipt = expense.Receipt` instead of querying Receipts table directly
+- **Severity: High** — blocks receipt reprocessing workflow
+- Update/add integration tests for both success and not-found cases
+
+---
+
+## Story 15.5: Expense Detail/Edit View
+
+**GitHub Issue:** #208
+
+**As a** property owner,
+**I want** a dedicated expense detail/edit page at `/expenses/:id`,
+**So that** I can view, edit (including reassigning property), and delete any expense from the global expense list.
+
+**Acceptance Criteria:**
+
+**AC1 — Navigation from expense list:**
+**Given** I am on the `/expenses` page
+**When** I click an expense row (or a view/edit icon)
+**Then** I am navigated to `/expenses/:id`
+
+**AC2 — Detail view:**
+**Given** I am on `/expenses/:id`
+**When** the page loads
+**Then** I see all expense fields: Amount, Date, Category, Description, Property, linked Receipt (with image preview), linked Work Order
+
+**AC3 — Edit all fields including property:**
+**Given** I am editing an expense
+**When** I change the Property dropdown
+**Then** the expense is reassigned to the new property on save
+
+**AC4 — Delete from detail view:**
+**Given** I am on the expense detail page
+**When** I click Delete and confirm
+**Then** the expense is soft-deleted and I am navigated back to `/expenses`
+
+**AC5 — Unlink receipt from detail view:**
+**Given** the expense has a linked receipt
+**When** I click an unlink/remove receipt action
+**Then** the receipt is unlinked (depends on Story 15.4 fix)
+
+**Prerequisites:** Story 15.4 (for receipt unlinking)
+
+**Technical Notes:**
+- **This is purely frontend** — all backend endpoints exist (`GET/PUT/DELETE /api/v1/expenses/{id}`, `DELETE /api/v1/expenses/{id}/receipt`)
+- New route: `/expenses/:id` → `ExpenseDetailComponent`
+- Reuse existing expense form patterns from property expense workspace
+- Key difference from property workspace: property dropdown must be included and editable
+- Add navigation from expense list rows
+- Blocked test cases: TC-EXP-012 through TC-EXP-016
+
+---
+
+## Epic 15 Summary
+
+| Story | Title | GitHub Issues | Effort | Prerequisites |
+|-------|-------|---------------|--------|---------------|
+| 15.1 | Login Form Fixes | #198, #199, #200 | Small | None |
+| 15.2 | Quick-Fix Form Validation Bugs | #202, #205 | Tiny | None |
+| 15.3 | Expense List UX Improvements | #204, #206, #207 | Medium | None |
+| 15.4 | Fix Unlink Receipt Backend Bug | #210 | Small | None |
+| 15.5 | Expense Detail/Edit View | #208 | Large | 15.4 |
+
+**Stories:** 5 | **Stories 15.1-15.4 are independent — can be worked in parallel. Story 15.5 depends on 15.4.**
+
+**Recommended priority order:** 15.4 (High severity) → 15.2 (quick wins) → 15.1 (login cleanup) → 15.3 (expense list) → 15.5 (large feature)
+
+**Epic 15 Milestone:** Fix all bugs found during manual testing. Ship a stable, polished experience.
+
+---
+
+_Generated by BMAD Scrum Master_
+_Date: 2026-02-15_
+_For: Dave_
+_Project: property-manager_

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -198,7 +198,25 @@ development_status:
   epic-14: in-progress
   14-1-cors-configuration: done
   14-2-security-headers-middleware: done
-  14-3-api-rate-limiting: dev-complete
+  14-3-api-rate-limiting: done
   14-4-backend-sentry-integration: pending
   14-5-frontend-sentry-integration: pending
   epic-14-retrospective: optional
+
+  # ============================================================
+  # MANUAL TESTING BUG FIXES
+  # Source: epic-15-manual-testing-bug-fixes.md
+  # GitHub Issues: #198, #199, #200, #202, #204, #205, #206, #207, #208, #210
+  # Added: 2026-02-15
+  # Stories 15.1-15.4 independent; 15.5 depends on 15.4
+  # ============================================================
+
+  # Epic 15: Manual Testing Bug Fixes
+  # User Outcome: "The bugs I found during testing are fixed"
+  epic-15: in-progress
+  15-1-login-form-fixes: pending                    # Issues #198, #199, #200 - email validation, remove remember me, honor returnUrl
+  15-2-quick-fix-form-validation-bugs: pending      # Issues #202, #205 - note field reset, category required indicator
+  15-3-expense-list-ux-improvements: pending         # Issues #204, #206, #207 - add expense button, date filter persistence, column sorting
+  15-4-fix-unlink-receipt-backend-bug: done           # Issue #210 - FIXED: UnlinkReceipt uses Include-based approach, clears both FK sides
+  15-5-expense-detail-edit-view: pending             # Issue #208 - LARGE: Build /expenses/:id detail/edit page (depends on 15.4)
+  epic-15-retrospective: optional


### PR DESCRIPTION
## Summary
- **Bug:** `UnlinkReceiptHandler` queried `Receipt.ExpenseId` (not a real FK) instead of loading via `Expense.ReceiptId` navigation — always returned 404
- **Fix:** Use `.Include(e => e.Receipt)` to load receipt via navigation property, clear **both** `Expense.ReceiptId` (real FK) and `Receipt.ExpenseId` (shadow property) on unlink
- **Tests:** Rewrote 6 unit tests to use navigation-based setup; 913/913 backend tests pass with zero regressions

## Test plan
- [x] Unit tests: 6/6 UnlinkReceiptHandlerTests pass
- [x] Full backend suite: 913/913 pass, 0 regressions
- [x] Manual verification: uploaded receipt, processed into expense, unlinked — returned 204

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)