### PR TITLE
chore: enforce documentation-first dev via Ref MCP + dependency updates

### DIFF
--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -1,7 +1,7 @@
 ---
 project_name: 'property-manager'
 user_name: 'Dave'
-date: '2026-02-15'
+date: '2026-02-23'
 sections_completed: ['technology_stack', 'language_specific_rules', 'framework_specific_rules', 'testing_rules', 'code_quality_style', 'development_workflow', 'critical_dont_miss']
 status: 'complete'
 rule_count: 65
@@ -22,23 +22,26 @@ _This file contains critical rules and patterns that AI agents must follow when 
 |---|---|---|
 | .NET | 10 | LTS, `net10.0` TFM |
 | ASP.NET Core | 10 | Web API with JWT Bearer auth |
-| EF Core | 10.0.2 | PostgreSQL via Npgsql 10.0.0 |
-| Angular | 21.x | ^21.1.3 in package.json |
+| EF Core | 10.0.3 | PostgreSQL via Npgsql 10.0.0 |
+| Angular | 21.x | ^21.1.5 in package.json |
 | @ngrx/signals | 21.0.1 | Signal-based state management |
-| Angular Material | 21.1.3 | UI component library |
+| Angular Material | 21.1.5 | UI component library |
 | TypeScript | 5.9.2 | Strict mode enabled |
 
 ### Key Dependencies
 
 | Dependency | Version | Purpose |
 |---|---|---|
-| MediatR | via FluentValidation.AspNetCore 11.3.1 | CQRS command/query handling |
-| FluentValidation | 11.3.1 | Request validation |
+| MediatR | 14.0.0 | CQRS command/query handling |
+| FluentValidation | 12.1.1 (Application), 11.3.1 AspNetCore (Api) | Request validation |
 | Serilog | 10.0 | Structured JSON logging |
 | NSwag | 14.6.3 | TypeScript API client generation |
-| QuestPDF | 2025.12.4 | PDF report generation |
+| QuestPDF | 2026.2.1 | PDF report generation |
 | SixLabors.ImageSharp | 3.1.12 | Image/thumbnail processing |
-| AWSSDK.S3 | 4.0.18.3 | Receipt/photo storage |
+| AWSSDK.S3 | 4.0.18.6 | Receipt/photo storage |
+| PDFtoImage | 5.2.0 | PDF-to-image conversion for thumbnails |
+| Microsoft.IdentityModel.Tokens | 8.16.0 | JWT token handling |
+| System.IdentityModel.Tokens.Jwt | 8.16.0 | JWT token parsing |
 | @microsoft/signalr | 10.0 | Real-time notifications |
 | Vitest | 4.0.18 | Frontend unit tests (max 3 threads) |
 | Playwright | 1.58.2 | E2E tests |
@@ -174,7 +177,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 
 **Git/Repository:**
 - Monorepo: `backend/` and `frontend/` in single repo
-- Main branch: `main`
+- Main branch: `main` — **protected, no direct pushes**. All changes require a feature branch + PR.
 - Feature branches: `feature/{issue-number}-{description}`
 - PRs merge to `main`
 
@@ -216,6 +219,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - Do NOT add `using System;` or other implicit usings in C# files
 
 **Critical Patterns to Follow:**
+- MANDATORY: Documentation-first development. Do upfront research via `mcp__Ref__ref_search_documentation` at story start for key technologies involved, then during implementation use Ref MCP and WebSearch when encountering unfamiliar APIs, errors, or unexpected behavior — research docs BEFORE retrying. Do NOT re-fetch docs already in context. Applies to Angular, .NET, EF Core, ngrx/signals, Angular Material, Playwright, and all project dependencies.
 - Always check `DeletedAt == null` when querying soft-deletable entities (in addition to global filters)
 - Always throw `NotFoundException(nameof(Entity), id)` when entity not found — middleware maps to 404
 - Always use `_dbContext.SaveChangesAsync(cancellationToken)` — pass the token through
@@ -250,4 +254,4 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - Review quarterly for outdated rules
 - Remove rules that become obvious over time
 
-Last Updated: 2026-02-15
+Last Updated: 2026-02-23

--- a/_bmad/bmm/agents/dev.md
+++ b/_bmad/bmm/agents/dev.md
@@ -51,6 +51,7 @@ You must fully embody this agent's persona and follow all activation instruction
             <r> Stay in character until exit selected</r>
       <r> Display Menu items as the item dictates and in the order given.</r>
       <r> Load files ONLY when executing a user chosen workflow or a command requires it, EXCEPTION: agent activation step 2 config.yaml</r>
+      <r>MANDATORY: Research before guessing. Story-level technology research happens upfront (workflow Step 2) — do NOT re-fetch docs already in context. During implementation, use mcp__Ref__ref_search_documentation and WebSearch when: (1) encountering an API or pattern not covered by upfront research, (2) hitting errors or unexpected behavior — research docs BEFORE retrying, (3) unsure about method signatures, config options, or component APIs. Documentation-first, not guess-and-retry.</r>
     </rules>
 </activation>  <persona>
     <role>Senior Software Engineer</role>

--- a/_bmad/bmm/workflows/4-implementation/dev-story/instructions.xml
+++ b/_bmad/bmm/workflows/4-implementation/dev-story/instructions.xml
@@ -134,7 +134,7 @@
     <action if="incomplete task or subtask requirements ambiguous">ASK user to clarify or HALT</action>
   </step>
 
-  <step n="2" goal="Load project context and story information">
+  <step n="2" goal="Load project context, story information, and research technologies">
     <critical>Load all available context to inform implementation</critical>
 
     <action>Load {project_context} for coding standards and project-wide patterns (if exists)</action>
@@ -142,8 +142,17 @@
     <action>Load comprehensive context from story file's Dev Notes section</action>
     <action>Extract developer guidance from Dev Notes: architecture requirements, previous learnings, technical specifications</action>
     <action>Use enhanced story context to inform implementation decisions and approaches</action>
-    <output>✅ **Context Loaded**
-      Story and project context available for implementation
+
+    <!-- MANDATORY: Research phase before implementation -->
+    <critical>BEFORE any implementation, research the key technologies, APIs, and patterns involved in this story</critical>
+    <action>Identify the primary frameworks, libraries, and APIs referenced in the story tasks (e.g., Angular Material components, EF Core features, MediatR patterns, ngrx/signals APIs)</action>
+    <action>Use mcp__Ref__ref_search_documentation to look up current documentation for each identified technology — verify API signatures, configuration patterns, and best practices</action>
+    <action>Use WebSearch for any technology questions that Ref MCP cannot answer (e.g., recent breaking changes, migration guides, community patterns)</action>
+    <action>Record key findings in Dev Agent Record → Implementation Plan so research is not lost mid-session</action>
+    <action>This research step is NOT optional — documentation lookups are cheaper than debugging hallucinated APIs</action>
+
+    <output>✅ **Context Loaded + Research Complete**
+      Story context, project standards, and technology documentation reviewed.
     </output>
   </step>
 


### PR DESCRIPTION
## Summary
- **Ref MCP enforcement:** Added mandatory research phase to dev-story workflow Step 2, a hard rule in the dev agent, and a critical pattern in project-context.md — three layers of reinforcement so agents research docs before implementing
- **Dependency updates:** Synced project-context.md versions with latest Dependabot merges (EF Core 10.0.3, Angular 21.1.5, QuestPDF 2026.2.1, MediatR 14.0.0, FluentValidation 12.1.1, AWSSDK.S3 4.0.18.6) and added missing entries (PDFtoImage, IdentityModel tokens)
- **Protected branch note:** Documented that `main` is protected (no direct pushes) in project-context git workflow section

## Test plan
- [ ] Verify dev agent activates and shows Ref MCP rule in behavior
- [ ] Run a dev-story workflow and confirm Step 2 includes research phase
- [ ] Confirm dependency versions in project-context.md match actual csproj/package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)