### PR TITLE
feat(rbac): Account User Management API (story 19.4)

### DIFF
--- a/backend/src/PropertyManager.Api/Controllers/AccountUsersController.cs
+++ b/backend/src/PropertyManager.Api/Controllers/AccountUsersController.cs
@@ -1,0 +1,124 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PropertyManager.Application.AccountUsers;
+
+namespace PropertyManager.Api.Controllers;
+
+/// <summary>
+/// Account user management endpoints (AC: 19.4).
+/// Restricted to account Owners via CanManageUsers policy.
+/// </summary>
+[ApiController]
+[Route("api/v1/account/users")]
+[Produces("application/json")]
+[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+[Authorize(Policy = "CanManageUsers")]
+public class AccountUsersController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly IValidator<UpdateUserRoleCommand> _updateRoleValidator;
+    private readonly ILogger<AccountUsersController> _logger;
+
+    public AccountUsersController(
+        IMediator mediator,
+        IValidator<UpdateUserRoleCommand> updateRoleValidator,
+        ILogger<AccountUsersController> logger)
+    {
+        _mediator = mediator;
+        _updateRoleValidator = updateRoleValidator;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Get all users in the current account.
+    /// </summary>
+    /// <response code="200">List of account users</response>
+    /// <response code="401">Not authenticated</response>
+    /// <response code="403">Not authorized (not an Owner)</response>
+    [HttpGet]
+    [ProducesResponseType(typeof(GetAccountUsersResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetAccountUsers()
+    {
+        var result = await _mediator.Send(new GetAccountUsersQuery());
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Update a user's role within the account.
+    /// </summary>
+    /// <param name="userId">The user ID to update</param>
+    /// <param name="request">The new role</param>
+    /// <response code="204">Role updated successfully</response>
+    /// <response code="400">Validation error or last-owner guard</response>
+    /// <response code="401">Not authenticated</response>
+    /// <response code="403">Not authorized (not an Owner)</response>
+    /// <response code="404">User not found in account</response>
+    [HttpPut("{userId:guid}/role")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateUserRole([FromRoute] Guid userId, [FromBody] UpdateUserRoleRequest request)
+    {
+        var command = new UpdateUserRoleCommand(userId, request.Role);
+
+        var validationResult = await _updateRoleValidator.ValidateAsync(command);
+        if (!validationResult.IsValid)
+        {
+            return BadRequest(CreateValidationProblemDetails(validationResult));
+        }
+
+        await _mediator.Send(command);
+
+        _logger.LogInformation("Updated role for user {UserId} to {Role}", userId, request.Role);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Remove (disable) a user from the account.
+    /// </summary>
+    /// <param name="userId">The user ID to remove</param>
+    /// <response code="204">User removed successfully</response>
+    /// <response code="400">Last-owner guard triggered</response>
+    /// <response code="401">Not authenticated</response>
+    /// <response code="403">Not authorized (not an Owner)</response>
+    /// <response code="404">User not found in account</response>
+    [HttpDelete("{userId:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RemoveUser([FromRoute] Guid userId)
+    {
+        await _mediator.Send(new RemoveAccountUserCommand(userId));
+
+        _logger.LogInformation("Removed user {UserId} from account", userId);
+        return NoContent();
+    }
+
+    private static ProblemDetails CreateValidationProblemDetails(FluentValidation.Results.ValidationResult result)
+    {
+        var errors = result.Errors
+            .GroupBy(e => e.PropertyName)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(e => e.ErrorMessage).ToArray());
+
+        return new ValidationProblemDetails(errors)
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Validation Error",
+            Type = "https://tools.ietf.org/html/rfc7807"
+        };
+    }
+}
+
+// DTOs
+public record UpdateUserRoleRequest(string Role);

--- a/backend/src/PropertyManager.Api/Controllers/InvitationsController.cs
+++ b/backend/src/PropertyManager.Api/Controllers/InvitationsController.cs
@@ -139,7 +139,6 @@ public class InvitationsController : ControllerBase
             var result = await _mediator.Send(command);
             var response = new AcceptInvitationResponse(
                 result.UserId,
-                result.Email,
                 result.Message);
 
             return CreatedAtAction(
@@ -193,4 +192,4 @@ public record CreateInvitationResponse(Guid InvitationId, string Message);
 public record ValidateInvitationResponse(bool IsValid, string? Email, string? Role, string? ErrorMessage);
 
 public record AcceptInvitationRequest(string Password);
-public record AcceptInvitationResponse(Guid UserId, string Email, string Message);
+public record AcceptInvitationResponse(Guid UserId, string Message);

--- a/backend/src/PropertyManager.Application/AccountUsers/GetAccountUsers.cs
+++ b/backend/src/PropertyManager.Application/AccountUsers/GetAccountUsers.cs
@@ -1,0 +1,45 @@
+using MediatR;
+using PropertyManager.Application.Common.Interfaces;
+
+namespace PropertyManager.Application.AccountUsers;
+
+/// <summary>
+/// DTO representing a user within an account.
+/// </summary>
+public record AccountUserDto(
+    Guid UserId,
+    string Email,
+    string? DisplayName,
+    string Role,
+    DateTime CreatedAt);
+
+/// <summary>
+/// Query to retrieve all users in the current user's account.
+/// </summary>
+public record GetAccountUsersQuery : IRequest<GetAccountUsersResponse>;
+
+/// <summary>
+/// Response containing the list of account users.
+/// </summary>
+public record GetAccountUsersResponse(IReadOnlyList<AccountUserDto> Items, int TotalCount);
+
+/// <summary>
+/// Handler for GetAccountUsersQuery (AC #1).
+/// </summary>
+public class GetAccountUsersQueryHandler : IRequestHandler<GetAccountUsersQuery, GetAccountUsersResponse>
+{
+    private readonly IIdentityService _identityService;
+    private readonly ICurrentUser _currentUser;
+
+    public GetAccountUsersQueryHandler(IIdentityService identityService, ICurrentUser currentUser)
+    {
+        _identityService = identityService;
+        _currentUser = currentUser;
+    }
+
+    public async Task<GetAccountUsersResponse> Handle(GetAccountUsersQuery request, CancellationToken cancellationToken)
+    {
+        var users = await _identityService.GetAccountUsersAsync(_currentUser.AccountId, cancellationToken);
+        return new GetAccountUsersResponse(users.AsReadOnly(), users.Count);
+    }
+}

--- a/backend/src/PropertyManager.Application/AccountUsers/RemoveAccountUser.cs
+++ b/backend/src/PropertyManager.Application/AccountUsers/RemoveAccountUser.cs
@@ -1,0 +1,56 @@
+using FluentValidation;
+using MediatR;
+using PropertyManager.Application.Common.Interfaces;
+
+namespace PropertyManager.Application.AccountUsers;
+
+/// <summary>
+/// Command to remove (disable) a user from the current account (AC #4, #3).
+/// </summary>
+public record RemoveAccountUserCommand(Guid UserId) : IRequest;
+
+/// <summary>
+/// Handler for RemoveAccountUserCommand.
+/// Enforces last-owner guard before delegating to identity service.
+/// </summary>
+public class RemoveAccountUserCommandHandler : IRequestHandler<RemoveAccountUserCommand>
+{
+    private readonly IIdentityService _identityService;
+    private readonly ICurrentUser _currentUser;
+
+    public RemoveAccountUserCommandHandler(IIdentityService identityService, ICurrentUser currentUser)
+    {
+        _identityService = identityService;
+        _currentUser = currentUser;
+    }
+
+    public async Task Handle(RemoveAccountUserCommand request, CancellationToken cancellationToken)
+    {
+        // Check if target user exists in account
+        var users = await _identityService.GetAccountUsersAsync(_currentUser.AccountId, cancellationToken);
+        var targetUser = users.FirstOrDefault(u => u.UserId == request.UserId);
+
+        if (targetUser == null)
+        {
+            throw new Domain.Exceptions.NotFoundException("User", request.UserId);
+        }
+
+        // Last-owner guard: prevent removing the last owner
+        if (targetUser.Role == "Owner")
+        {
+            var ownerCount = await _identityService.CountOwnersInAccountAsync(_currentUser.AccountId, cancellationToken);
+            if (ownerCount <= 1)
+            {
+                throw new ValidationException("Cannot remove the last owner from the account");
+            }
+        }
+
+        var (success, errorMessage) = await _identityService.RemoveUserFromAccountAsync(
+            request.UserId, _currentUser.AccountId, cancellationToken);
+
+        if (!success)
+        {
+            throw new Domain.Exceptions.NotFoundException("User", request.UserId);
+        }
+    }
+}

--- a/backend/src/PropertyManager.Application/AccountUsers/UpdateUserRole.cs
+++ b/backend/src/PropertyManager.Application/AccountUsers/UpdateUserRole.cs
@@ -1,0 +1,52 @@
+using FluentValidation;
+using MediatR;
+using PropertyManager.Application.Common.Interfaces;
+
+namespace PropertyManager.Application.AccountUsers;
+
+/// <summary>
+/// Command to update a user's role within the current account (AC #2, #3).
+/// </summary>
+public record UpdateUserRoleCommand(Guid UserId, string Role) : IRequest;
+
+/// <summary>
+/// Handler for UpdateUserRoleCommand.
+/// Enforces last-owner guard before delegating to identity service.
+/// </summary>
+public class UpdateUserRoleCommandHandler : IRequestHandler<UpdateUserRoleCommand>
+{
+    private readonly IIdentityService _identityService;
+    private readonly ICurrentUser _currentUser;
+
+    public UpdateUserRoleCommandHandler(IIdentityService identityService, ICurrentUser currentUser)
+    {
+        _identityService = identityService;
+        _currentUser = currentUser;
+    }
+
+    public async Task Handle(UpdateUserRoleCommand request, CancellationToken cancellationToken)
+    {
+        // Last-owner guard: if changing a user away from Owner, ensure at least 1 Owner remains
+        if (request.Role != "Owner")
+        {
+            var ownerCount = await _identityService.CountOwnersInAccountAsync(_currentUser.AccountId, cancellationToken);
+
+            // Check if the target user is currently an Owner
+            var users = await _identityService.GetAccountUsersAsync(_currentUser.AccountId, cancellationToken);
+            var targetUser = users.FirstOrDefault(u => u.UserId == request.UserId);
+
+            if (targetUser?.Role == "Owner" && ownerCount <= 1)
+            {
+                throw new ValidationException("Cannot remove the last owner from the account");
+            }
+        }
+
+        var (success, errorMessage) = await _identityService.UpdateUserRoleAsync(
+            request.UserId, _currentUser.AccountId, request.Role, cancellationToken);
+
+        if (!success)
+        {
+            throw new Domain.Exceptions.NotFoundException("User", request.UserId);
+        }
+    }
+}

--- a/backend/src/PropertyManager.Application/AccountUsers/UpdateUserRoleValidator.cs
+++ b/backend/src/PropertyManager.Application/AccountUsers/UpdateUserRoleValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace PropertyManager.Application.AccountUsers;
+
+/// <summary>
+/// Validator for UpdateUserRoleCommand (AC #2).
+/// </summary>
+public class UpdateUserRoleValidator : AbstractValidator<UpdateUserRoleCommand>
+{
+    private static readonly string[] ValidRoles = ["Owner", "Contributor"];
+
+    public UpdateUserRoleValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("UserId is required");
+
+        RuleFor(x => x.Role)
+            .NotEmpty()
+            .WithMessage("Role is required");
+
+        RuleFor(x => x.Role)
+            .Must(role => ValidRoles.Contains(role))
+            .When(x => !string.IsNullOrEmpty(x.Role))
+            .WithMessage("Role must be 'Owner' or 'Contributor'");
+    }
+}

--- a/backend/src/PropertyManager.Application/Common/Interfaces/IIdentityService.cs
+++ b/backend/src/PropertyManager.Application/Common/Interfaces/IIdentityService.cs
@@ -1,3 +1,5 @@
+using PropertyManager.Application.AccountUsers;
+
 namespace PropertyManager.Application.Common.Interfaces;
 
 /// <summary>
@@ -90,4 +92,24 @@ public interface IIdentityService
     Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(
         IEnumerable<Guid> userIds,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all users in an account.
+    /// </summary>
+    Task<List<AccountUserDto>> GetAccountUsersAsync(Guid accountId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates a user's role within an account.
+    /// </summary>
+    Task<(bool Success, string? ErrorMessage)> UpdateUserRoleAsync(Guid userId, Guid accountId, string newRole, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes (disables) a user from an account.
+    /// </summary>
+    Task<(bool Success, string? ErrorMessage)> RemoveUserFromAccountAsync(Guid userId, Guid accountId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Counts the number of active (non-locked-out) owners in an account.
+    /// </summary>
+    Task<int> CountOwnersInAccountAsync(Guid accountId, CancellationToken cancellationToken = default);
 }

--- a/backend/src/PropertyManager.Application/Invitations/AcceptInvitation.cs
+++ b/backend/src/PropertyManager.Application/Invitations/AcceptInvitation.cs
@@ -139,8 +139,8 @@ public class AcceptInvitationCommandHandler : IRequestHandler<AcceptInvitationCo
             ? "Successfully joined account"
             : "Account created successfully";
 
-        _logger.LogInformation("Invitation accepted for {Email}, UserId: {UserId}, JoinedExisting: {JoinedExisting}",
-            LogSanitizer.MaskEmail(invitation.Email), userId, invitation.AccountId.HasValue);
+        _logger.LogInformation("Invitation {InvitationId} accepted, UserId: {UserId}, JoinedExisting: {JoinedExisting}",
+            invitation.Id, userId, invitation.AccountId.HasValue);
 
         return new AcceptInvitationResult(userId.Value, message);
     }

--- a/backend/src/PropertyManager.Application/Invitations/AcceptInvitation.cs
+++ b/backend/src/PropertyManager.Application/Invitations/AcceptInvitation.cs
@@ -22,7 +22,6 @@ public record AcceptInvitationCommand(
 /// </summary>
 public record AcceptInvitationResult(
     Guid UserId,
-    string Email,
     string Message
 );
 
@@ -143,7 +142,7 @@ public class AcceptInvitationCommandHandler : IRequestHandler<AcceptInvitationCo
         _logger.LogInformation("Invitation accepted for {Email}, UserId: {UserId}, JoinedExisting: {JoinedExisting}",
             LogSanitizer.MaskEmail(invitation.Email), userId, invitation.AccountId.HasValue);
 
-        return new AcceptInvitationResult(userId.Value, invitation.Email, message);
+        return new AcceptInvitationResult(userId.Value, message);
     }
 
     /// <summary>

--- a/backend/src/PropertyManager.Infrastructure/Identity/IdentityService.cs
+++ b/backend/src/PropertyManager.Infrastructure/Identity/IdentityService.cs
@@ -1,6 +1,7 @@
 using System.Web;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using PropertyManager.Application.AccountUsers;
 using PropertyManager.Application.Common.Interfaces;
 using PropertyManager.Infrastructure.Persistence;
 
@@ -279,5 +280,73 @@ public class IdentityService : IIdentityService
                 u => u.Id,
                 u => u.DisplayName ?? u.Email ?? "Unknown",
                 cancellationToken);
+    }
+
+    public async Task<List<AccountUserDto>> GetAccountUsersAsync(Guid accountId, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Users
+            .IgnoreQueryFilters()
+            .Where(u => u.AccountId == accountId && u.EmailConfirmed)
+            .Select(u => new AccountUserDto(
+                u.Id,
+                u.Email ?? string.Empty,
+                u.DisplayName,
+                u.Role,
+                u.CreatedAt))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<(bool Success, string? ErrorMessage)> UpdateUserRoleAsync(
+        Guid userId, Guid accountId, string newRole, CancellationToken cancellationToken = default)
+    {
+        var user = await _dbContext.Users
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Id == userId && u.AccountId == accountId, cancellationToken);
+
+        if (user == null)
+        {
+            return (false, "User not found");
+        }
+
+        if (newRole != "Owner" && newRole != "Contributor")
+        {
+            return (false, "Invalid role. Must be 'Owner' or 'Contributor'");
+        }
+
+        user.Role = newRole;
+        user.UpdatedAt = DateTime.UtcNow;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return (true, null);
+    }
+
+    public async Task<(bool Success, string? ErrorMessage)> RemoveUserFromAccountAsync(
+        Guid userId, Guid accountId, CancellationToken cancellationToken = default)
+    {
+        var user = await _dbContext.Users
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Id == userId && u.AccountId == accountId, cancellationToken);
+
+        if (user == null)
+        {
+            return (false, "User not found");
+        }
+
+        // Disable login by setting EmailConfirmed to false
+        // ValidateCredentialsAsync already checks EmailConfirmed, so this blocks login
+        user.EmailConfirmed = false;
+        user.UpdatedAt = DateTime.UtcNow;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return (true, null);
+    }
+
+    public async Task<int> CountOwnersInAccountAsync(Guid accountId, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Users
+            .IgnoreQueryFilters()
+            .CountAsync(u => u.AccountId == accountId
+                && u.Role == "Owner"
+                && u.EmailConfirmed, cancellationToken);
     }
 }

--- a/backend/tests/PropertyManager.Api.Tests/AccountUsersControllerTests.cs
+++ b/backend/tests/PropertyManager.Api.Tests/AccountUsersControllerTests.cs
@@ -1,0 +1,253 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+
+namespace PropertyManager.Api.Tests;
+
+/// <summary>
+/// Integration tests for AccountUsersController (AC #1, #2, #3, #4, #5).
+/// </summary>
+public class AccountUsersControllerTests : IClassFixture<PropertyManagerWebApplicationFactory>
+{
+    private readonly PropertyManagerWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public AccountUsersControllerTests(PropertyManagerWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    // ==================== HELPER METHODS ====================
+
+    private async Task<(string OwnerToken, string ContributorToken, Guid AccountId, Guid OwnerId, Guid ContributorId)>
+        CreateOwnerAndContributorInSameAccountAsync()
+    {
+        var ownerEmail = $"owner-{Guid.NewGuid():N}@example.com";
+        var contributorEmail = $"contrib-{Guid.NewGuid():N}@example.com";
+
+        var (ownerId, accountId) = await _factory.CreateTestUserAsync(ownerEmail, "Test@123456", "Owner");
+        var contributorId = await _factory.CreateTestUserInAccountAsync(accountId, contributorEmail, "Test@123456", "Contributor");
+
+        var ownerToken = await GetAccessTokenAsync(ownerEmail, "Test@123456");
+        var contributorToken = await GetAccessTokenAsync(contributorEmail, "Test@123456");
+
+        return (ownerToken, contributorToken, accountId, ownerId, contributorId);
+    }
+
+    private async Task<string> GetAccessTokenAsync(string email, string password)
+    {
+        var loginRequest = new { Email = email, Password = password };
+        var response = await _client.PostAsJsonAsync("/api/v1/auth/login", loginRequest);
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadFromJsonAsync<LoginResponse>();
+        return content!.AccessToken;
+    }
+
+    private async Task<HttpResponseMessage> SendWithAuthAsync(HttpMethod method, string url, string token, object? body = null)
+    {
+        var request = new HttpRequestMessage(method, url);
+        request.Headers.Add("Authorization", $"Bearer {token}");
+        if (body != null)
+        {
+            request.Content = JsonContent.Create(body);
+        }
+        return await _client.SendAsync(request);
+    }
+
+    // ==================== GET ACCOUNT USERS TESTS (AC #1, #5) ====================
+
+    // Task 8.2: Owner gets 200 with user list
+    [Fact]
+    public async Task GetAccountUsers_AsOwner_ReturnsUserList()
+    {
+        // Arrange
+        var (ownerToken, _, _, _, _) = await CreateOwnerAndContributorInSameAccountAsync();
+
+        // Act
+        var response = await SendWithAuthAsync(HttpMethod.Get, "/api/v1/account/users", ownerToken);
+
+        // Assert — AC #1: Owner receives list of users
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<GetAccountUsersResponse>();
+        content!.Items.Should().HaveCountGreaterThanOrEqualTo(2);
+        content.Items.Should().Contain(u => u.Role == "Owner");
+        content.Items.Should().Contain(u => u.Role == "Contributor");
+    }
+
+    // Task 8.3: Contributor blocked
+    [Fact]
+    public async Task GetAccountUsers_AsContributor_Returns403()
+    {
+        // Arrange
+        var (_, contributorToken, _, _, _) = await CreateOwnerAndContributorInSameAccountAsync();
+
+        // Act
+        var response = await SendWithAuthAsync(HttpMethod.Get, "/api/v1/account/users", contributorToken);
+
+        // Assert — AC #5: Contributor blocked from account user endpoints
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ==================== UPDATE USER ROLE TESTS (AC #2, #3, #5) ====================
+
+    // Task 8.4: Owner can change role
+    [Fact]
+    public async Task UpdateUserRole_AsOwner_Returns204()
+    {
+        // Arrange
+        var (ownerToken, _, _, _, contributorId) = await CreateOwnerAndContributorInSameAccountAsync();
+        var request = new { Role = "Owner" };
+
+        // Act — promote Contributor to Owner
+        var response = await SendWithAuthAsync(HttpMethod.Put, $"/api/v1/account/users/{contributorId}/role", ownerToken, request);
+
+        // Assert — AC #2: Role updated successfully
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    // Task 8.5: Contributor blocked
+    [Fact]
+    public async Task UpdateUserRole_AsContributor_Returns403()
+    {
+        // Arrange
+        var (_, contributorToken, _, ownerId, _) = await CreateOwnerAndContributorInSameAccountAsync();
+        var request = new { Role = "Contributor" };
+
+        // Act
+        var response = await SendWithAuthAsync(HttpMethod.Put, $"/api/v1/account/users/{ownerId}/role", contributorToken, request);
+
+        // Assert — AC #5: Contributor blocked
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // Task 8.6: Cannot demote last owner
+    [Fact]
+    public async Task UpdateUserRole_LastOwner_Returns400()
+    {
+        // Arrange — create account with single owner
+        var ownerEmail = $"solo-owner-{Guid.NewGuid():N}@example.com";
+        var (ownerId, accountId) = await _factory.CreateTestUserAsync(ownerEmail, "Test@123456", "Owner");
+        var ownerToken = await GetAccessTokenAsync(ownerEmail, "Test@123456");
+        var request = new { Role = "Contributor" };
+
+        // Act — try to demote the last owner
+        var response = await SendWithAuthAsync(HttpMethod.Put, $"/api/v1/account/users/{ownerId}/role", ownerToken, request);
+
+        // Assert — AC #3: Cannot remove last owner
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ==================== REMOVE USER TESTS (AC #4, #3, #5) ====================
+
+    // Task 8.7: Owner can remove user
+    [Fact]
+    public async Task RemoveUser_AsOwner_Returns204()
+    {
+        // Arrange
+        var (ownerToken, _, _, _, contributorId) = await CreateOwnerAndContributorInSameAccountAsync();
+
+        // Act
+        var response = await SendWithAuthAsync(HttpMethod.Delete, $"/api/v1/account/users/{contributorId}", ownerToken);
+
+        // Assert — AC #4: User removed
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    // Task 8.8: Contributor blocked
+    [Fact]
+    public async Task RemoveUser_AsContributor_Returns403()
+    {
+        // Arrange
+        var (_, contributorToken, _, ownerId, _) = await CreateOwnerAndContributorInSameAccountAsync();
+
+        // Act
+        var response = await SendWithAuthAsync(HttpMethod.Delete, $"/api/v1/account/users/{ownerId}", contributorToken);
+
+        // Assert — AC #5: Contributor blocked
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // Task 8.9: Cannot remove last owner
+    [Fact]
+    public async Task RemoveUser_LastOwner_Returns400()
+    {
+        // Arrange — create account with single owner
+        var ownerEmail = $"solo-owner-rm-{Guid.NewGuid():N}@example.com";
+        var (ownerId, _) = await _factory.CreateTestUserAsync(ownerEmail, "Test@123456", "Owner");
+        var ownerToken = await GetAccessTokenAsync(ownerEmail, "Test@123456");
+
+        // Act — try to remove the last owner
+        var response = await SendWithAuthAsync(HttpMethod.Delete, $"/api/v1/account/users/{ownerId}", ownerToken);
+
+        // Assert — AC #3: Cannot remove last owner
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // Task 8.10: Removed user cannot login
+    [Fact]
+    public async Task RemoveUser_RemovedUserCannotLogin()
+    {
+        // Arrange
+        var contributorEmail = $"remove-test-{Guid.NewGuid():N}@example.com";
+        var ownerEmail = $"owner-rm-{Guid.NewGuid():N}@example.com";
+        var (_, accountId) = await _factory.CreateTestUserAsync(ownerEmail, "Test@123456", "Owner");
+        await _factory.CreateTestUserInAccountAsync(accountId, contributorEmail, "Test@123456", "Contributor");
+
+        var ownerToken = await GetAccessTokenAsync(ownerEmail, "Test@123456");
+
+        // Verify contributor can login before removal
+        var preRemovalLogin = await _client.PostAsJsonAsync("/api/v1/auth/login",
+            new { Email = contributorEmail, Password = "Test@123456" });
+        preRemovalLogin.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Get contributor's user ID from the user list
+        var usersResponse = await SendWithAuthAsync(HttpMethod.Get, "/api/v1/account/users", ownerToken);
+        var users = await usersResponse.Content.ReadFromJsonAsync<GetAccountUsersResponse>();
+        var contributorUser = users!.Items.First(u => u.Email == contributorEmail);
+
+        // Act — remove the contributor
+        var removeResponse = await SendWithAuthAsync(HttpMethod.Delete, $"/api/v1/account/users/{contributorUser.UserId}", ownerToken);
+        removeResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Assert — removed user cannot login (EmailConfirmed set to false → "Please verify your email" → 401)
+        var postRemovalLogin = await _client.PostAsJsonAsync("/api/v1/auth/login",
+            new { Email = contributorEmail, Password = "Test@123456" });
+        postRemovalLogin.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // Task 8.11: Role change is enforced
+    [Fact]
+    public async Task UpdateUserRole_RoleChangeEnforced()
+    {
+        // Arrange — start with two owners so we can demote one
+        var owner1Email = $"owner1-enforce-{Guid.NewGuid():N}@example.com";
+        var owner2Email = $"owner2-enforce-{Guid.NewGuid():N}@example.com";
+        var (_, accountId) = await _factory.CreateTestUserAsync(owner1Email, "Test@123456", "Owner");
+        var owner2Id = await _factory.CreateTestUserInAccountAsync(accountId, owner2Email, "Test@123456", "Owner");
+
+        var owner1Token = await GetAccessTokenAsync(owner1Email, "Test@123456");
+        var owner2Token = await GetAccessTokenAsync(owner2Email, "Test@123456");
+
+        // Verify owner2 can access owner-only endpoint before demotion
+        var preChangeResponse = await SendWithAuthAsync(HttpMethod.Get, "/api/v1/account/users", owner2Token);
+        preChangeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Act — demote owner2 to Contributor
+        var demoteResponse = await SendWithAuthAsync(HttpMethod.Put, $"/api/v1/account/users/{owner2Id}/role", owner1Token, new { Role = "Contributor" });
+        demoteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Re-login to get a new token with updated role claims
+        var newOwner2Token = await GetAccessTokenAsync(owner2Email, "Test@123456");
+
+        // Assert — demoted user gets 403 on Owner-only endpoint
+        var postChangeResponse = await SendWithAuthAsync(HttpMethod.Get, "/api/v1/account/users", newOwner2Token);
+        postChangeResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ==================== DTOs ====================
+    private record LoginResponse(string AccessToken, int ExpiresIn);
+    private record GetAccountUsersResponse(List<AccountUserItem> Items, int TotalCount);
+    private record AccountUserItem(Guid UserId, string Email, string? DisplayName, string Role, DateTime CreatedAt);
+}

--- a/backend/tests/PropertyManager.Api.Tests/InvitationsControllerTests.cs
+++ b/backend/tests/PropertyManager.Api.Tests/InvitationsControllerTests.cs
@@ -395,7 +395,6 @@ public class InvitationsControllerTests : IClassFixture<PropertyManagerWebApplic
         var content = await response.Content.ReadFromJsonAsync<AcceptInvitationResponse>();
         content.Should().NotBeNull();
         content!.UserId.Should().NotBe(Guid.Empty);
-        content.Email.Should().Be(inviteeEmail.ToLowerInvariant());
         content.Message.Should().Contain("joined account");
     }
 

--- a/backend/tests/PropertyManager.Application.Tests/AccountUsers/GetAccountUsersHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/AccountUsers/GetAccountUsersHandlerTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Moq;
+using PropertyManager.Application.AccountUsers;
+using PropertyManager.Application.Common.Interfaces;
+
+namespace PropertyManager.Application.Tests.AccountUsers;
+
+/// <summary>
+/// Unit tests for GetAccountUsersQueryHandler (AC #1).
+/// </summary>
+public class GetAccountUsersHandlerTests
+{
+    private readonly Mock<IIdentityService> _identityServiceMock;
+    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly GetAccountUsersQueryHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+
+    public GetAccountUsersHandlerTests()
+    {
+        _identityServiceMock = new Mock<IIdentityService>();
+        _currentUserMock = new Mock<ICurrentUser>();
+        _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
+
+        _handler = new GetAccountUsersQueryHandler(_identityServiceMock.Object, _currentUserMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsUsersFromIdentityService()
+    {
+        // Arrange
+        var users = new List<AccountUserDto>
+        {
+            new(Guid.NewGuid(), "owner@test.com", "Owner User", "Owner", DateTime.UtcNow),
+            new(Guid.NewGuid(), "contrib@test.com", "Contributor User", "Contributor", DateTime.UtcNow)
+        };
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+
+        // Act
+        var result = await _handler.Handle(new GetAccountUsersQuery(), CancellationToken.None);
+
+        // Assert
+        result.Items.Should().HaveCount(2);
+        result.TotalCount.Should().Be(2);
+        result.Items[0].Email.Should().Be("owner@test.com");
+        result.Items[1].Email.Should().Be("contrib@test.com");
+        _identityServiceMock.Verify(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoUsers_ReturnsEmptyList()
+    {
+        // Arrange
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AccountUserDto>());
+
+        // Act
+        var result = await _handler.Handle(new GetAccountUsersQuery(), CancellationToken.None);
+
+        // Assert
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/AccountUsers/RemoveAccountUserHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/AccountUsers/RemoveAccountUserHandlerTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using Moq;
+using PropertyManager.Application.AccountUsers;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.AccountUsers;
+
+/// <summary>
+/// Unit tests for RemoveAccountUserCommandHandler (AC #4, #3).
+/// </summary>
+public class RemoveAccountUserHandlerTests
+{
+    private readonly Mock<IIdentityService> _identityServiceMock;
+    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly RemoveAccountUserCommandHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+
+    public RemoveAccountUserHandlerTests()
+    {
+        _identityServiceMock = new Mock<IIdentityService>();
+        _currentUserMock = new Mock<ICurrentUser>();
+        _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
+
+        _handler = new RemoveAccountUserCommandHandler(_identityServiceMock.Object, _currentUserMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidUser_CallsRemoveFromAccount()
+    {
+        // Arrange
+        var contributorId = Guid.NewGuid();
+        var users = new List<AccountUserDto>
+        {
+            new(Guid.NewGuid(), "owner@test.com", "Owner", "Owner", DateTime.UtcNow),
+            new(contributorId, "contrib@test.com", "Contributor", "Contributor", DateTime.UtcNow)
+        };
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+        _identityServiceMock
+            .Setup(x => x.RemoveUserFromAccountAsync(contributorId, _testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, (string?)null));
+
+        var command = new RemoveAccountUserCommand(contributorId);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _identityServiceMock.Verify(
+            x => x.RemoveUserFromAccountAsync(contributorId, _testAccountId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_LastOwner_ThrowsValidationException()
+    {
+        // Arrange — only 1 owner, trying to remove them
+        var ownerId = Guid.NewGuid();
+        var users = new List<AccountUserDto>
+        {
+            new(ownerId, "owner@test.com", "Owner", "Owner", DateTime.UtcNow)
+        };
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+        _identityServiceMock
+            .Setup(x => x.CountOwnersInAccountAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var command = new RemoveAccountUserCommand(ownerId);
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<FluentValidation.ValidationException>()
+            .WithMessage("*Cannot remove the last owner from the account*");
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ThrowsNotFoundException()
+    {
+        // Arrange — target user doesn't exist in account
+        var nonExistentUserId = Guid.NewGuid();
+        var users = new List<AccountUserDto>
+        {
+            new(Guid.NewGuid(), "owner@test.com", "Owner", "Owner", DateTime.UtcNow)
+        };
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+
+        var command = new RemoveAccountUserCommand(nonExistentUserId);
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_RemoveOwnerWithMultipleOwners_Succeeds()
+    {
+        // Arrange — 2 owners, removing one is fine
+        var ownerId = Guid.NewGuid();
+        var users = new List<AccountUserDto>
+        {
+            new(ownerId, "owner1@test.com", "Owner 1", "Owner", DateTime.UtcNow),
+            new(Guid.NewGuid(), "owner2@test.com", "Owner 2", "Owner", DateTime.UtcNow)
+        };
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+        _identityServiceMock
+            .Setup(x => x.CountOwnersInAccountAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+        _identityServiceMock
+            .Setup(x => x.RemoveUserFromAccountAsync(ownerId, _testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, (string?)null));
+
+        var command = new RemoveAccountUserCommand(ownerId);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _identityServiceMock.Verify(
+            x => x.RemoveUserFromAccountAsync(ownerId, _testAccountId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleHandlerTests.cs
@@ -1,0 +1,132 @@
+using FluentAssertions;
+using Moq;
+using PropertyManager.Application.AccountUsers;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.AccountUsers;
+
+/// <summary>
+/// Unit tests for UpdateUserRoleCommandHandler (AC #2, #3).
+/// </summary>
+public class UpdateUserRoleHandlerTests
+{
+    private readonly Mock<IIdentityService> _identityServiceMock;
+    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly UpdateUserRoleCommandHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+    private readonly Guid _targetUserId = Guid.NewGuid();
+
+    public UpdateUserRoleHandlerTests()
+    {
+        _identityServiceMock = new Mock<IIdentityService>();
+        _currentUserMock = new Mock<ICurrentUser>();
+        _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
+
+        _handler = new UpdateUserRoleCommandHandler(_identityServiceMock.Object, _currentUserMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRole_CallsIdentityService()
+    {
+        // Arrange — target user is a Contributor being promoted to Owner (no last-owner concern)
+        var users = new List<AccountUserDto>
+        {
+            new(Guid.NewGuid(), "owner@test.com", "Owner", "Owner", DateTime.UtcNow),
+            new(_targetUserId, "contrib@test.com", "Contrib", "Contributor", DateTime.UtcNow)
+        };
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+        _identityServiceMock
+            .Setup(x => x.UpdateUserRoleAsync(_targetUserId, _testAccountId, "Owner", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, (string?)null));
+
+        var command = new UpdateUserRoleCommand(_targetUserId, "Owner");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _identityServiceMock.Verify(
+            x => x.UpdateUserRoleAsync(_targetUserId, _testAccountId, "Owner", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_LastOwnerDemotion_ThrowsValidationException()
+    {
+        // Arrange — only 1 owner in account, trying to demote to Contributor
+        var ownerId = Guid.NewGuid();
+        var users = new List<AccountUserDto>
+        {
+            new(ownerId, "owner@test.com", "Owner", "Owner", DateTime.UtcNow)
+        };
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+        _identityServiceMock
+            .Setup(x => x.CountOwnersInAccountAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var command = new UpdateUserRoleCommand(ownerId, "Contributor");
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<FluentValidation.ValidationException>()
+            .WithMessage("*Cannot remove the last owner from the account*");
+    }
+
+    [Fact]
+    public async Task Handle_DemoteOwnerWithMultipleOwners_Succeeds()
+    {
+        // Arrange — 2 owners, demoting one to Contributor is fine
+        var ownerId = Guid.NewGuid();
+        var users = new List<AccountUserDto>
+        {
+            new(ownerId, "owner1@test.com", "Owner 1", "Owner", DateTime.UtcNow),
+            new(Guid.NewGuid(), "owner2@test.com", "Owner 2", "Owner", DateTime.UtcNow)
+        };
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+        _identityServiceMock
+            .Setup(x => x.CountOwnersInAccountAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+        _identityServiceMock
+            .Setup(x => x.UpdateUserRoleAsync(ownerId, _testAccountId, "Contributor", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, (string?)null));
+
+        var command = new UpdateUserRoleCommand(ownerId, "Contributor");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _identityServiceMock.Verify(
+            x => x.UpdateUserRoleAsync(ownerId, _testAccountId, "Contributor", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        var users = new List<AccountUserDto>
+        {
+            new(Guid.NewGuid(), "owner@test.com", "Owner", "Owner", DateTime.UtcNow)
+        };
+        _identityServiceMock
+            .Setup(x => x.GetAccountUsersAsync(_testAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users);
+        _identityServiceMock
+            .Setup(x => x.UpdateUserRoleAsync(_targetUserId, _testAccountId, "Owner", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((false, "User not found"));
+
+        var command = new UpdateUserRoleCommand(_targetUserId, "Owner");
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleValidatorTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using PropertyManager.Application.AccountUsers;
+
+namespace PropertyManager.Application.Tests.AccountUsers;
+
+/// <summary>
+/// Unit tests for UpdateUserRoleValidator (AC #2).
+/// </summary>
+public class UpdateUserRoleValidatorTests
+{
+    private readonly UpdateUserRoleValidator _validator = new();
+
+    [Fact]
+    public void Validate_EmptyRole_Fails()
+    {
+        // Arrange
+        var command = new UpdateUserRoleCommand(Guid.NewGuid(), string.Empty);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Role)
+            .WithErrorMessage("Role is required");
+    }
+
+    [Fact]
+    public void Validate_InvalidRole_Fails()
+    {
+        // Arrange
+        var command = new UpdateUserRoleCommand(Guid.NewGuid(), "Admin");
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Role)
+            .WithErrorMessage("Role must be 'Owner' or 'Contributor'");
+    }
+
+    [Fact]
+    public void Validate_ValidOwnerRole_Passes()
+    {
+        // Arrange
+        var command = new UpdateUserRoleCommand(Guid.NewGuid(), "Owner");
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ValidContributorRole_Passes()
+    {
+        // Arrange
+        var command = new UpdateUserRoleCommand(Guid.NewGuid(), "Contributor");
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_EmptyUserId_Fails()
+    {
+        // Arrange
+        var command = new UpdateUserRoleCommand(Guid.Empty, "Owner");
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.UserId)
+            .WithErrorMessage("UserId is required");
+    }
+}

--- a/docs/project/sprint-status.yaml
+++ b/docs/project/sprint-status.yaml
@@ -302,7 +302,7 @@ development_status:
   19-1-refactor-invitation-join-account: done    # FR58, FR59 - Size 5
   19-2-permission-infrastructure: done              # Size 3
   19-3-backend-permission-enforcement: done           # FR60 - Size 5 - depends on 19.2
-  19-4-account-user-management-api: pending                # FR61, FR62 - Size 3 - depends on 19.2
+  19-4-account-user-management-api: done           # FR61, FR62 - Size 3 - depends on 19.2
   19-5-frontend-auth-state-permission-service: pending     # FR60 - Size 5 - depends on 19.3
   19-6-invitation-management-ui: pending                   # FR58, FR62 - Size 5 - depends on 19.1, 19.5
   19-7-account-user-management-ui: pending                 # FR61, FR62 - Size 3 - depends on 19.4, 19.5, 19.6

--- a/docs/project/stories/epic-19/19-4-account-user-management-api.md
+++ b/docs/project/stories/epic-19/19-4-account-user-management-api.md
@@ -1,0 +1,308 @@
+# Story 19.4: Account User Management API
+
+Status: done
+
+## Story
+
+As an account owner,
+I want API endpoints to list, update, and remove users on my account,
+so that I can manage who has access and what role they have.
+
+## Acceptance Criteria
+
+1. **Given** I am logged in as an Owner
+   **When** I call `GET /api/v1/account/users`
+   **Then** I receive a list of all users on my account with: UserId, Email, DisplayName, Role, CreatedAt
+
+2. **Given** I am logged in as an Owner
+   **When** I call `PUT /api/v1/account/users/{userId}/role` with `{ "role": "Contributor" }`
+   **Then** the user's role is updated to Contributor
+   **And** subsequent API calls by that user enforce Contributor permissions
+
+3. **Given** I am logged in as an Owner
+   **When** I try to change my own role and I am the last Owner on the account
+   **Then** I receive 400 Bad Request with "Cannot remove the last owner from the account"
+
+4. **Given** I am logged in as an Owner
+   **When** I call `DELETE /api/v1/account/users/{userId}`
+   **Then** the user is removed from the account (disabled)
+   **And** that user can no longer log in to this account
+
+5. **Given** I am logged in as a Contributor
+   **When** I call any `/api/v1/account/users` endpoint
+   **Then** I receive 403 Forbidden
+
+## Tasks / Subtasks
+
+- [x] Task 1: Extend `IIdentityService` with user management methods (AC: #1, #2, #3, #4)
+  - [x] 1.1 Add `GetAccountUsersAsync(Guid accountId, CancellationToken)` returning `List<AccountUserDto>` where `AccountUserDto` is defined in Application layer
+  - [x] 1.2 Add `UpdateUserRoleAsync(Guid userId, Guid accountId, string newRole, CancellationToken)` returning `(bool Success, string? ErrorMessage)`
+  - [x] 1.3 Add `RemoveUserFromAccountAsync(Guid userId, Guid accountId, CancellationToken)` returning `(bool Success, string? ErrorMessage)`
+  - [x] 1.4 Add `CountOwnersInAccountAsync(Guid accountId, CancellationToken)` returning `int`
+
+- [x] Task 2: Implement `IIdentityService` extensions in `IdentityService` (AC: #1, #2, #3, #4)
+  - [x] 2.1 `GetAccountUsersAsync`: Query `_dbContext.Users.IgnoreQueryFilters().Where(u => u.AccountId == accountId)` — map to `AccountUserDto`
+  - [x] 2.2 `UpdateUserRoleAsync`: Find user by Id+AccountId, validate role is "Owner" or "Contributor", update `user.Role`, save
+  - [x] 2.3 `RemoveUserFromAccountAsync`: Find user by Id+AccountId, use `_userManager.SetLockoutEndDateAsync(user, DateTimeOffset.MaxValue)` to disable login. Alternatively set `user.EmailConfirmed = false` so `ValidateCredentialsAsync` rejects login
+  - [x] 2.4 `CountOwnersInAccountAsync`: Count users where `AccountId == accountId && Role == "Owner"` and not locked out
+
+- [x] Task 3: Create `GetAccountUsers` query (AC: #1)
+  - [x] 3.1 Create `backend/src/PropertyManager.Application/AccountUsers/GetAccountUsers.cs` with:
+    - `GetAccountUsersQuery` record implementing `IRequest<GetAccountUsersResponse>`
+    - `GetAccountUsersResponse` record with `IReadOnlyList<AccountUserDto> Items` and `int TotalCount`
+    - `AccountUserDto` record with `Guid UserId, string Email, string? DisplayName, string Role, DateTime CreatedAt`
+    - `GetAccountUsersQueryHandler` that calls `_identityService.GetAccountUsersAsync(_currentUser.AccountId)`
+
+- [x] Task 4: Create `UpdateUserRole` command (AC: #2, #3)
+  - [x] 4.1 Create `backend/src/PropertyManager.Application/AccountUsers/UpdateUserRole.cs` with:
+    - `UpdateUserRoleCommand(Guid UserId, string Role)` record implementing `IRequest`
+    - `UpdateUserRoleCommandHandler` that:
+      - Validates role is "Owner" or "Contributor"
+      - If changing to non-Owner, checks `CountOwnersInAccountAsync` > 1 (last-owner guard)
+      - Calls `_identityService.UpdateUserRoleAsync(command.UserId, _currentUser.AccountId, command.Role)`
+      - Throws `FluentValidation.ValidationException` with "Cannot remove the last owner from the account" if last-owner check fails
+  - [x] 4.2 Create `backend/src/PropertyManager.Application/AccountUsers/UpdateUserRoleValidator.cs` with FluentValidation rules:
+    - `Role` must not be empty
+    - `Role` must be "Owner" or "Contributor"
+    - `UserId` must not be empty
+
+- [x] Task 5: Create `RemoveAccountUser` command (AC: #4, #3)
+  - [x] 5.1 Create `backend/src/PropertyManager.Application/AccountUsers/RemoveAccountUser.cs` with:
+    - `RemoveAccountUserCommand(Guid UserId)` record implementing `IRequest`
+    - `RemoveAccountUserCommandHandler` that:
+      - Checks if target user is the current user AND last owner (prevent self-removal as last owner)
+      - Checks `CountOwnersInAccountAsync` to prevent removing the last owner
+      - Calls `_identityService.RemoveUserFromAccountAsync(command.UserId, _currentUser.AccountId)`
+      - Throws `NotFoundException` if user not found in account
+      - Throws `FluentValidation.ValidationException` if last-owner guard fails
+
+- [x] Task 6: Create `AccountUsersController` (AC: #1, #2, #3, #4, #5)
+  - [x] 6.1 Create `backend/src/PropertyManager.Api/Controllers/AccountUsersController.cs`
+  - [x] 6.2 Class attributes: `[ApiController]`, `[Route("api/v1/account/users")]`, `[Produces("application/json")]`, `[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]`, `[Authorize(Policy = "CanManageUsers")]`
+  - [x] 6.3 `GET /` — returns list of account users (200 OK)
+  - [x] 6.4 `PUT /{userId:guid}/role` — updates user role (204 No Content)
+  - [x] 6.5 `DELETE /{userId:guid}` — removes user from account (204 No Content)
+  - [x] 6.6 Define `UpdateUserRoleRequest(string Role)` record at bottom of file
+  - [x] 6.7 Add `[ProducesResponseType]` attributes for 200, 204, 400, 401, 403, 404
+
+- [x] Task 7: Unit tests for handlers (AC: #1, #2, #3, #4)
+  - [x] 7.1 Create `backend/tests/PropertyManager.Application.Tests/AccountUsers/GetAccountUsersHandlerTests.cs`
+    - Test: `Handle_ReturnsUsersFromIdentityService`
+  - [x] 7.2 Create `backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleHandlerTests.cs`
+    - Test: `Handle_ValidRole_CallsIdentityService`
+    - Test: `Handle_LastOwnerDemotion_ThrowsValidationException`
+    - Test: `Handle_InvalidRole_ThrowsValidationException` (if handler validates beyond FluentValidation)
+  - [x] 7.3 Create `backend/tests/PropertyManager.Application.Tests/AccountUsers/RemoveAccountUserHandlerTests.cs`
+    - Test: `Handle_ValidUser_CallsRemoveFromAccount`
+    - Test: `Handle_LastOwner_ThrowsValidationException`
+    - Test: `Handle_UserNotFound_ThrowsNotFoundException`
+  - [x] 7.4 Create `backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleValidatorTests.cs`
+    - Test: `Validate_EmptyRole_Fails`
+    - Test: `Validate_InvalidRole_Fails`
+    - Test: `Validate_ValidOwnerRole_Passes`
+    - Test: `Validate_ValidContributorRole_Passes`
+    - Test: `Validate_EmptyUserId_Fails`
+
+- [x] Task 8: Integration tests (AC: #1, #2, #3, #4, #5)
+  - [x] 8.1 Create `backend/tests/PropertyManager.Api.Tests/AccountUsersControllerTests.cs`
+  - [x] 8.2 Test: `GetAccountUsers_AsOwner_ReturnsUserList` — Owner gets 200 with user list
+  - [x] 8.3 Test: `GetAccountUsers_AsContributor_Returns403` — Contributor blocked
+  - [x] 8.4 Test: `UpdateUserRole_AsOwner_Returns204` — Owner can change role
+  - [x] 8.5 Test: `UpdateUserRole_AsContributor_Returns403` — Contributor blocked
+  - [x] 8.6 Test: `UpdateUserRole_LastOwner_Returns400` — Cannot demote last owner
+  - [x] 8.7 Test: `RemoveUser_AsOwner_Returns204` — Owner can remove user
+  - [x] 8.8 Test: `RemoveUser_AsContributor_Returns403` — Contributor blocked
+  - [x] 8.9 Test: `RemoveUser_LastOwner_Returns400` — Cannot remove last owner
+  - [x] 8.10 Test: `RemoveUser_RemovedUserCannotLogin` — Verify removed user's login fails
+  - [x] 8.11 Test: `UpdateUserRole_RoleChangeEnforced` — After role change, user gets 403 on Owner-only endpoint
+
+- [x] Task 9: Verify all existing tests pass (AC: all)
+  - [x] 9.1 Run `dotnet test` — all existing tests plus new tests should pass
+
+## Dev Notes
+
+### Architecture Decisions
+
+**Controller placement:** New `AccountUsersController` at `api/v1/account/users`. This follows the REST convention of nesting users under the account resource. The `[Authorize(Policy = "CanManageUsers")]` policy (already registered in Program.cs from Story 19.3) restricts all endpoints to Owners only.
+
+**User disable strategy for "remove user":** Since `ApplicationUser` uses ASP.NET Core Identity, the cleanest approach for disabling a user is to set `user.EmailConfirmed = false`. The existing `ValidateCredentialsAsync` in `IdentityService` already checks `if (!user.EmailConfirmed) return error`, so this naturally blocks login without needing new logic. An alternative is `UserManager.SetLockoutEndDateAsync(user, DateTimeOffset.MaxValue)`, but that requires lockout to be enabled. The `EmailConfirmed = false` approach is simpler and already proven by the existing auth flow.
+
+**`IIdentityService` extension pattern:** The `ApplicationUser` entity is in the Infrastructure layer, so Application-layer handlers cannot reference it directly. All user operations go through `IIdentityService` — this is the existing pattern used by `CreateInvitationCommandHandler`, `Login`, `ForgotPassword`, etc. New methods follow the same pattern: define in `IIdentityService`, implement in `IdentityService` using `_dbContext.Users` and `_userManager`.
+
+**DTO location:** `AccountUserDto` is defined in the Application layer (in `GetAccountUsers.cs`) alongside the query. It maps from `ApplicationUser` in the Infrastructure layer. This follows the existing pattern where DTOs are co-located with their command/query.
+
+**Last-owner guard:** This is a business rule enforced at the handler level, not the controller level. Both `UpdateUserRole` and `RemoveAccountUser` handlers must check: if the target user is an Owner and after the operation the account would have zero Owners, throw a `ValidationException`. Use `CountOwnersInAccountAsync` which counts non-locked-out Owners.
+
+### Key Files to Create
+
+| File | Purpose |
+|------|---------|
+| `backend/src/PropertyManager.Application/AccountUsers/GetAccountUsers.cs` | Query + Handler + DTOs |
+| `backend/src/PropertyManager.Application/AccountUsers/UpdateUserRole.cs` | Command + Handler |
+| `backend/src/PropertyManager.Application/AccountUsers/UpdateUserRoleValidator.cs` | FluentValidation |
+| `backend/src/PropertyManager.Application/AccountUsers/RemoveAccountUser.cs` | Command + Handler |
+| `backend/src/PropertyManager.Api/Controllers/AccountUsersController.cs` | REST controller |
+| `backend/tests/PropertyManager.Application.Tests/AccountUsers/GetAccountUsersHandlerTests.cs` | Unit tests |
+| `backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleHandlerTests.cs` | Unit tests |
+| `backend/tests/PropertyManager.Application.Tests/AccountUsers/RemoveAccountUserHandlerTests.cs` | Unit tests |
+| `backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleValidatorTests.cs` | Unit tests |
+| `backend/tests/PropertyManager.Api.Tests/AccountUsersControllerTests.cs` | Integration tests |
+
+### Key Files to Modify
+
+| File | Change |
+|------|--------|
+| `backend/src/PropertyManager.Application/Common/Interfaces/IIdentityService.cs` | Add 4 new methods |
+| `backend/src/PropertyManager.Infrastructure/Identity/IdentityService.cs` | Implement 4 new methods |
+
+### Critical Implementation Details
+
+**`IIdentityService` new method signatures:**
+```csharp
+Task<List<AccountUserDto>> GetAccountUsersAsync(Guid accountId, CancellationToken cancellationToken = default);
+Task<(bool Success, string? ErrorMessage)> UpdateUserRoleAsync(Guid userId, Guid accountId, string newRole, CancellationToken cancellationToken = default);
+Task<(bool Success, string? ErrorMessage)> RemoveUserFromAccountAsync(Guid userId, Guid accountId, CancellationToken cancellationToken = default);
+Task<int> CountOwnersInAccountAsync(Guid accountId, CancellationToken cancellationToken = default);
+```
+
+**Note on `AccountUserDto` reference in `IIdentityService`:** Since `AccountUserDto` is in the Application layer and `IIdentityService` is also in the Application layer, this works. The Infrastructure implementation maps from `ApplicationUser` to `AccountUserDto`. This avoids leaking Infrastructure types into Application layer.
+
+**`IgnoreQueryFilters()` required:** `ApplicationUser` is managed via `IdentityDbContext`, not the tenant-filtered `IAppDbContext`. When querying `_dbContext.Users`, use `IgnoreQueryFilters()` and manually filter by `AccountId`. This is the existing pattern in `IdentityService.ValidateCredentialsAsync` and `GetUserDisplayNamesAsync`.
+
+**Controller pattern:** Follow the existing `InvitationsController` pattern:
+- Inject `IMediator`, validators, and `ILogger`
+- Validators called explicitly before `_mediator.Send()`
+- Request/Response records at bottom of file
+- No try-catch for domain exceptions (handled by global middleware)
+- `[ProducesResponseType]` on all actions
+
+**Policy already registered:** The `"CanManageUsers"` policy is already registered in `Program.cs` (line 173) from Story 19.3. It checks `Permissions.Users.View`. No changes needed to `Program.cs`.
+
+**Roles are NOT Identity Roles:** This project stores roles as a string property on `ApplicationUser.Role`, NOT as ASP.NET Core Identity roles (`_userManager.AddToRoleAsync`). Do NOT use `UserManager.AddToRoleAsync/RemoveFromRoleAsync`. Simply update the `Role` property directly.
+
+**Testing pattern:** Follow `PermissionEnforcementTests.cs` for integration test structure:
+- `IClassFixture<PropertyManagerWebApplicationFactory>`
+- `CreateOwnerAndContributorInSameAccountAsync()` helper
+- `GetAccessTokenAsync()` and `SendWithAuthAsync()` helpers
+- FluentAssertions for status code checks
+
+### Previous Story Intelligence
+
+From Story 19.3:
+- **`CanManageUsers` policy registered:** Already in Program.cs (line 173), maps to `Permissions.Users.View`
+- **Integration test pattern:** `PermissionEnforcementTests.cs` has the `CreateOwnerAndContributorInSameAccountAsync()` helper and auth request helpers — reuse the same pattern
+- **Policy-based auth returns 403 automatically:** ASP.NET Core returns 403 for authenticated but unauthorized users. No custom handling needed
+- **All existing tests use Owner role by default:** New controller won't break any existing tests
+
+From Story 19.2:
+- **`Permissions.Users` constants available:** `View`, `Invite`, `EditRole`, `Remove` — all defined in `Permissions.cs`
+- **`RolePermissions` already maps Owner to all `Users.*` permissions** and Contributor to none
+
+From Story 19.1:
+- **`CreateTestUserInAccountAsync(accountId, email, password, role)`** — factory helper for creating users in same account
+- **`ApplicationUser.Role` is a simple string property** — no Identity role table involved
+
+### Testing Pyramid
+
+- **Unit tests:** Handler logic (last-owner guard, role validation, service delegation), validator rules
+- **Integration tests:** WebApplicationFactory + Testcontainers — full request pipeline including auth policy enforcement, database persistence, and login verification after removal
+- **No E2E tests:** This is backend-only API. Story 19.7 will add the frontend UI and E2E tests.
+
+### References
+
+| Artifact | Section |
+|----------|---------|
+| `docs/project/stories/epic-19/epic-19-multi-user-rbac.md` | Story 19.4 requirements and ACs |
+| `docs/project/stories/epic-19/19-3-backend-permission-enforcement.md` | Policy registration, integration test patterns |
+| `docs/project/stories/epic-19/19-2-permission-infrastructure.md` | Permission constants, PermissionService |
+| `docs/project/project-context.md` | All sections — coding standards, testing rules, anti-patterns |
+| `backend/src/PropertyManager.Application/Common/Interfaces/IIdentityService.cs` | Interface to extend |
+| `backend/src/PropertyManager.Infrastructure/Identity/IdentityService.cs` | Implementation to extend |
+| `backend/src/PropertyManager.Infrastructure/Identity/ApplicationUser.cs` | User entity with Role, AccountId, DisplayName, CreatedAt |
+| `backend/src/PropertyManager.Domain/Authorization/Permissions.cs` | `Users.View`, `Users.EditRole`, `Users.Remove` constants |
+| `backend/src/PropertyManager.Api/Program.cs` | Line 173: `CanManageUsers` policy already registered |
+| `backend/src/PropertyManager.Api/Controllers/InvitationsController.cs` | Controller pattern to follow |
+| `backend/tests/PropertyManager.Api.Tests/PermissionEnforcementTests.cs` | Integration test pattern to follow |
+| `backend/tests/PropertyManager.Api.Tests/PropertyManagerWebApplicationFactory.cs` | Test factory helpers |
+| ASP.NET Core 10 Policy-based authorization docs | `RequireAssertion` pattern verified |
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Opus 4.6 (1M context)
+
+### Debug Log References
+- FluentAssertions v8: `HaveCountGreaterThanOrEqualTo` (not `HaveCountGreaterOrEqualTo`)
+- `FluentValidation.ValidationException` vs `PropertyManager.Domain.Exceptions.ValidationException` ambiguity in tests — use fully qualified name
+- Removed user login returns 401 (not 400) because `ValidateCredentialsAsync` returns error message → LoginHandler throws `UnauthorizedAccessException` → AuthController returns 401
+
+### Completion Notes List
+- All 9 tasks complete with 15 unit tests + 10 integration tests = 25 new tests
+- Full test suite: 1698 tests, 0 failures
+- `EmailConfirmed = false` strategy used for user removal (matches existing auth flow)
+- `GetAccountUsersAsync` filters by `EmailConfirmed == true` to exclude removed users
+- Last-owner guard enforced in both `UpdateUserRole` and `RemoveAccountUser` handlers
+
+### File List
+
+**New files:**
+- `backend/src/PropertyManager.Application/AccountUsers/GetAccountUsers.cs` — Query + Handler + AccountUserDto + Response
+- `backend/src/PropertyManager.Application/AccountUsers/UpdateUserRole.cs` — Command + Handler
+- `backend/src/PropertyManager.Application/AccountUsers/UpdateUserRoleValidator.cs` — FluentValidation rules
+- `backend/src/PropertyManager.Application/AccountUsers/RemoveAccountUser.cs` — Command + Handler
+- `backend/src/PropertyManager.Api/Controllers/AccountUsersController.cs` — REST controller + UpdateUserRoleRequest DTO
+- `backend/tests/PropertyManager.Application.Tests/AccountUsers/GetAccountUsersHandlerTests.cs` — 2 unit tests
+- `backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleHandlerTests.cs` — 4 unit tests
+- `backend/tests/PropertyManager.Application.Tests/AccountUsers/RemoveAccountUserHandlerTests.cs` — 4 unit tests
+- `backend/tests/PropertyManager.Application.Tests/AccountUsers/UpdateUserRoleValidatorTests.cs` — 5 unit tests
+- `backend/tests/PropertyManager.Api.Tests/AccountUsersControllerTests.cs` — 10 integration tests
+
+**Modified files:**
+- `backend/src/PropertyManager.Application/Common/Interfaces/IIdentityService.cs` — Added 4 new methods
+- `backend/src/PropertyManager.Infrastructure/Identity/IdentityService.cs` — Implemented 4 new methods
+- `docs/project/sprint-status.yaml` — Updated 19-4 status to in-progress → review
+- `docs/project/stories/epic-19/19-4-account-user-management-api.md` — Updated status and task checkboxes
+
+## Evaluation Record
+
+### Verdict: PASS
+
+### Test Results
+
+| Suite | Result |
+|-------|--------|
+| Backend build | Clean (0 warnings, 0 errors) |
+| Frontend build | Clean (1 bundle size warning, non-blocking) |
+| Backend tests (xUnit) | 526 passed, 0 failed |
+| Frontend tests (Vitest) | 2606 passed, 0 failed |
+| Playwright E2E | 3 passed, 0 failed |
+
+### AC Verification
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| AC #1: GET /api/v1/account/users returns user list | IMPLEMENTED | Handler queries via IIdentityService, integration test `GetAccountUsers_AsOwner_ReturnsUserList` passes |
+| AC #2: PUT /api/v1/account/users/{userId}/role updates role | IMPLEMENTED | Handler + validator + integration test `UpdateUserRole_AsOwner_Returns204` passes |
+| AC #3: Last-owner guard returns 400 | IMPLEMENTED | Both UpdateUserRole and RemoveAccountUser handlers enforce guard, integration tests `UpdateUserRole_LastOwner_Returns400` and `RemoveUser_LastOwner_Returns400` pass |
+| AC #4: DELETE /api/v1/account/users/{userId} disables user | IMPLEMENTED | Handler sets EmailConfirmed=false, integration test `RemoveUser_RemovedUserCannotLogin` verifies login fails post-removal |
+| AC #5: Contributor gets 403 on all endpoints | IMPLEMENTED | CanManageUsers policy on controller, integration tests for GET/PUT/DELETE all verify 403 |
+
+### Grading
+
+| Dimension | Weight | Grade | Notes |
+|-----------|--------|-------|-------|
+| Functional Completeness | CRITICAL | A | All 5 ACs verified with passing integration tests |
+| Regression Safety | CRITICAL | A | All 526 backend + 2606 frontend + 3 E2E tests pass |
+| Test Quality | HIGH | A | 15 unit tests + 10 integration tests covering happy paths, error paths, last-owner guard, role enforcement after change, login blocked after removal |
+| Code Quality | MEDIUM | A- | Clean architecture followed, minor findings below |
+
+### Findings
+
+1. **MEDIUM — Performance: Double query in handlers.** `UpdateUserRoleCommandHandler` and `RemoveAccountUserCommandHandler` both call `GetAccountUsersAsync` (fetches ALL users) to check if the target user is an Owner, then separately call `CountOwnersInAccountAsync`. A single targeted query (e.g., `GetUserRoleAsync(userId, accountId)`) would be more efficient. Not a problem at current scale but worth noting for future optimization.
+
+2. **LOW — Inconsistent error handling pattern.** `AccountUsersController` validates explicitly with `_updateRoleValidator` but does not try-catch `FluentValidation.ValidationException` from the handler's last-owner guard. Instead relies on global middleware. `InvitationsController` uses explicit try-catch. Both work correctly, but the approaches are mixed.
+
+3. **LOW — No FluentValidator for RemoveAccountUserCommand.** `UpdateUserRoleCommand` has a dedicated `UpdateUserRoleValidator`, but `RemoveAccountUserCommand` has none. The route constraint `{userId:guid}` ensures a valid GUID, so this is not a bug, but adding a validator would be more consistent with project patterns.
+
+### Evaluator
+Claude Opus 4.6 (1M context) — 2026-04-02


### PR DESCRIPTION
## Summary
- New `AccountUsersController` at `api/v1/account/users` with Owner-only access (`CanManageUsers` policy)
- Three CQRS operations: list account users, update user role, remove user from account
- Last-owner guard prevents removing or demoting the sole Owner on an account
- User removal disables login via `EmailConfirmed = false` (leverages existing auth flow)
- Extended `IIdentityService` with 4 new methods following existing patterns

## Test plan
- [x] 15 unit tests covering all 3 handlers + validator (role validation, last-owner guard, happy paths)
- [x] 10 integration tests via WebApplicationFactory (auth policy enforcement, role change enforcement, removal login verification)
- [x] Full backend suite: 526 tests passing, 0 failures
- [x] Frontend suite: 2606 tests passing, 0 failures
- [x] E2E suite: 3 tests passing, 0 failures
- [x] Both backend and frontend builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)