### PR TITLE
feat(tenant): add Tenant role with property-level scoping

### DIFF
--- a/backend/src/PropertyManager.Application/Auth/Login.cs
+++ b/backend/src/PropertyManager.Application/Auth/Login.cs
@@ -67,7 +67,7 @@ public class LoginCommandHandler : IRequestHandler<LoginCommand, LoginResult>
     public async Task<LoginResult> Handle(LoginCommand request, CancellationToken cancellationToken)
     {
         // Validate credentials (checks email exists, password correct, email verified)
-        var (success, userId, accountId, role, email, displayName, errorMessage) = await _identityService.ValidateCredentialsAsync(
+        var (success, userId, accountId, role, email, displayName, propertyId, errorMessage) = await _identityService.ValidateCredentialsAsync(
             request.Email,
             request.Password,
             cancellationToken);
@@ -90,6 +90,7 @@ public class LoginCommandHandler : IRequestHandler<LoginCommand, LoginResult>
             role!,
             email!,
             displayName,
+            propertyId,
             cancellationToken);
 
         // Generate and store refresh token (AC4.6)

--- a/backend/src/PropertyManager.Application/Auth/RefreshToken.cs
+++ b/backend/src/PropertyManager.Application/Auth/RefreshToken.cs
@@ -40,7 +40,7 @@ public class RefreshTokenCommandHandler : IRequestHandler<RefreshTokenCommand, R
     public async Task<RefreshTokenResult> Handle(RefreshTokenCommand request, CancellationToken cancellationToken)
     {
         // Validate the refresh token
-        var (isValid, userId, accountId, role, email, displayName) = await _jwtService.ValidateRefreshTokenAsync(
+        var (isValid, userId, accountId, role, email, displayName, propertyId) = await _jwtService.ValidateRefreshTokenAsync(
             request.RefreshToken,
             cancellationToken);
 
@@ -57,6 +57,7 @@ public class RefreshTokenCommandHandler : IRequestHandler<RefreshTokenCommand, R
             role,
             email,
             displayName,
+            propertyId,
             cancellationToken);
 
         _logger.LogInformation(

--- a/backend/src/PropertyManager.Application/Common/Interfaces/ICurrentUser.cs
+++ b/backend/src/PropertyManager.Application/Common/Interfaces/ICurrentUser.cs
@@ -10,5 +10,6 @@ public interface ICurrentUser
     Guid UserId { get; }
     Guid AccountId { get; }
     string Role { get; }
+    Guid? PropertyId { get; }
     bool IsAuthenticated { get; }
 }

--- a/backend/src/PropertyManager.Application/Common/Interfaces/IIdentityService.cs
+++ b/backend/src/PropertyManager.Application/Common/Interfaces/IIdentityService.cs
@@ -18,6 +18,7 @@ public interface IIdentityService
         string password,
         Guid accountId,
         string role,
+        Guid? propertyId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -30,6 +31,7 @@ public interface IIdentityService
         string password,
         Guid accountId,
         string role,
+        Guid? propertyId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -55,7 +57,7 @@ public interface IIdentityService
     /// Checks email exists, password is correct, and email is verified.
     /// </summary>
     /// <returns>Tuple of (Success, UserId, AccountId, Role, Email, DisplayName, ErrorMessage).</returns>
-    Task<(bool Success, Guid? UserId, Guid? AccountId, string? Role, string? Email, string? DisplayName, string? ErrorMessage)> ValidateCredentialsAsync(
+    Task<(bool Success, Guid? UserId, Guid? AccountId, string? Role, string? Email, string? DisplayName, Guid? PropertyId, string? ErrorMessage)> ValidateCredentialsAsync(
         string email,
         string password,
         CancellationToken cancellationToken = default);

--- a/backend/src/PropertyManager.Application/Common/Interfaces/IJwtService.cs
+++ b/backend/src/PropertyManager.Application/Common/Interfaces/IJwtService.cs
@@ -17,6 +17,7 @@ public interface IJwtService
         string role,
         string email,
         string? displayName,
+        Guid? propertyId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -33,7 +34,7 @@ public interface IJwtService
     /// Validates a refresh token and returns the associated user info if valid.
     /// </summary>
     /// <returns>Tuple of (IsValid, UserId, AccountId, Role, Email, DisplayName).</returns>
-    Task<(bool IsValid, Guid? UserId, Guid? AccountId, string? Role, string? Email, string? DisplayName)> ValidateRefreshTokenAsync(
+    Task<(bool IsValid, Guid? UserId, Guid? AccountId, string? Role, string? Email, string? DisplayName, Guid? PropertyId)> ValidateRefreshTokenAsync(
         string refreshToken,
         CancellationToken cancellationToken = default);
 

--- a/backend/src/PropertyManager.Application/Common/Interfaces/IPermissionService.cs
+++ b/backend/src/PropertyManager.Application/Common/Interfaces/IPermissionService.cs
@@ -9,4 +9,5 @@ public interface IPermissionService
     bool HasPermission(string permission);
     bool IsOwner();
     bool IsContributor();
+    bool IsTenant();
 }

--- a/backend/src/PropertyManager.Application/Invitations/AcceptInvitation.cs
+++ b/backend/src/PropertyManager.Application/Invitations/AcceptInvitation.cs
@@ -116,6 +116,7 @@ public class AcceptInvitationCommandHandler : IRequestHandler<AcceptInvitationCo
             request.Password,
             accountId,
             role,
+            propertyId: null,
             cancellationToken);
 
         if (userId is null)

--- a/backend/src/PropertyManager.Domain/Authorization/Permissions.cs
+++ b/backend/src/PropertyManager.Domain/Authorization/Permissions.cs
@@ -10,9 +10,16 @@ public static class Permissions
     {
         public const string View = "Properties.View";
         public const string ViewList = "Properties.ViewList";
+        public const string ViewAssigned = "Properties.ViewAssigned";
         public const string Create = "Properties.Create";
         public const string Edit = "Properties.Edit";
         public const string Delete = "Properties.Delete";
+    }
+
+    public static class MaintenanceRequests
+    {
+        public const string Create = "MaintenanceRequests.Create";
+        public const string ViewOwn = "MaintenanceRequests.ViewOwn";
     }
 
     public static class Expenses

--- a/backend/src/PropertyManager.Domain/Authorization/RolePermissions.cs
+++ b/backend/src/PropertyManager.Domain/Authorization/RolePermissions.cs
@@ -64,6 +64,13 @@ public static class RolePermissions
                 Permissions.Users.Invite,
                 Permissions.Users.EditRole,
                 Permissions.Users.Remove,
+
+                // Maintenance Requests (Owner has all permissions)
+                Permissions.MaintenanceRequests.Create,
+                Permissions.MaintenanceRequests.ViewOwn,
+
+                // Properties - ViewAssigned (Owner has all property permissions)
+                Permissions.Properties.ViewAssigned,
             },
 
             ["Contributor"] = new HashSet<string>
@@ -74,6 +81,13 @@ public static class RolePermissions
                 Permissions.WorkOrders.View,
                 Permissions.WorkOrders.EditStatus,
                 Permissions.WorkOrders.AddNotes,
+            },
+
+            ["Tenant"] = new HashSet<string>
+            {
+                Permissions.MaintenanceRequests.Create,
+                Permissions.MaintenanceRequests.ViewOwn,
+                Permissions.Properties.ViewAssigned,
             },
         };
 }

--- a/backend/src/PropertyManager.Infrastructure/Identity/ApplicationUser.cs
+++ b/backend/src/PropertyManager.Infrastructure/Identity/ApplicationUser.cs
@@ -16,7 +16,7 @@ public class ApplicationUser : IdentityUser<Guid>
     public Guid AccountId { get; set; }
 
     /// <summary>
-    /// User role within the account: "Owner" or "Contributor".
+    /// User role within the account: "Owner", "Contributor", or "Tenant".
     /// </summary>
     public string Role { get; set; } = "Owner";
 
@@ -36,6 +36,17 @@ public class ApplicationUser : IdentityUser<Guid>
     [MaxLength(100)]
     public string? DisplayName { get; set; }
 
-    // Navigation property
+    /// <summary>
+    /// Foreign key to the Property (tenant-to-property scoping).
+    /// Nullable — only set for users with the Tenant role.
+    /// </summary>
+    public Guid? PropertyId { get; set; }
+
+    // Navigation properties
     public Account Account { get; set; } = null!;
+
+    /// <summary>
+    /// The property assigned to this tenant user. Null for Owner/Contributor users.
+    /// </summary>
+    public Property? AssignedProperty { get; set; }
 }

--- a/backend/src/PropertyManager.Infrastructure/Identity/CurrentUserService.cs
+++ b/backend/src/PropertyManager.Infrastructure/Identity/CurrentUserService.cs
@@ -47,6 +47,15 @@ public class CurrentUserService : ICurrentUser
         }
     }
 
+    public Guid? PropertyId
+    {
+        get
+        {
+            var propertyIdClaim = _httpContextAccessor.HttpContext?.User?.FindFirst("propertyId")?.Value;
+            return Guid.TryParse(propertyIdClaim, out var propertyId) ? propertyId : null;
+        }
+    }
+
     public bool IsAuthenticated =>
         _httpContextAccessor.HttpContext?.User?.Identity?.IsAuthenticated ?? false;
 }

--- a/backend/src/PropertyManager.Infrastructure/Identity/IdentityService.cs
+++ b/backend/src/PropertyManager.Infrastructure/Identity/IdentityService.cs
@@ -28,9 +28,10 @@ public class IdentityService : IIdentityService
         string password,
         Guid accountId,
         string role,
+        Guid? propertyId = null,
         CancellationToken cancellationToken = default)
     {
-        return await CreateUserInternalAsync(email, password, accountId, role, emailConfirmed: false);
+        return await CreateUserInternalAsync(email, password, accountId, role, emailConfirmed: false, propertyId: propertyId);
     }
 
     public async Task<(Guid? UserId, IEnumerable<string> Errors)> CreateUserWithConfirmedEmailAsync(
@@ -38,9 +39,10 @@ public class IdentityService : IIdentityService
         string password,
         Guid accountId,
         string role,
+        Guid? propertyId = null,
         CancellationToken cancellationToken = default)
     {
-        return await CreateUserInternalAsync(email, password, accountId, role, emailConfirmed: true);
+        return await CreateUserInternalAsync(email, password, accountId, role, emailConfirmed: true, propertyId: propertyId);
     }
 
     private async Task<(Guid? UserId, IEnumerable<string> Errors)> CreateUserInternalAsync(
@@ -48,7 +50,8 @@ public class IdentityService : IIdentityService
         string password,
         Guid accountId,
         string role,
-        bool emailConfirmed)
+        bool emailConfirmed,
+        Guid? propertyId = null)
     {
         var user = new ApplicationUser
         {
@@ -56,7 +59,8 @@ public class IdentityService : IIdentityService
             UserName = email,
             AccountId = accountId,
             Role = role,
-            EmailConfirmed = emailConfirmed
+            EmailConfirmed = emailConfirmed,
+            PropertyId = propertyId
         };
 
         var result = await _userManager.CreateAsync(user, password);
@@ -145,7 +149,7 @@ public class IdentityService : IIdentityService
         }
     }
 
-    public async Task<(bool Success, Guid? UserId, Guid? AccountId, string? Role, string? Email, string? DisplayName, string? ErrorMessage)> ValidateCredentialsAsync(
+    public async Task<(bool Success, Guid? UserId, Guid? AccountId, string? Role, string? Email, string? DisplayName, Guid? PropertyId, string? ErrorMessage)> ValidateCredentialsAsync(
         string email,
         string password,
         CancellationToken cancellationToken = default)
@@ -160,23 +164,23 @@ public class IdentityService : IIdentityService
 
         if (user == null)
         {
-            return (false, null, null, null, null, null, invalidCredentialsError);
+            return (false, null, null, null, null, null, null, invalidCredentialsError);
         }
 
         // Check if email is verified per AC4.4
         if (!user.EmailConfirmed)
         {
-            return (false, null, null, null, null, null, "Please verify your email before logging in");
+            return (false, null, null, null, null, null, null, "Please verify your email before logging in");
         }
 
         // Validate password
         var passwordValid = await _userManager.CheckPasswordAsync(user, password);
         if (!passwordValid)
         {
-            return (false, null, null, null, null, null, invalidCredentialsError);
+            return (false, null, null, null, null, null, null, invalidCredentialsError);
         }
 
-        return (true, user.Id, user.AccountId, user.Role, user.Email, user.DisplayName, null);
+        return (true, user.Id, user.AccountId, user.Role, user.Email, user.DisplayName, user.PropertyId, null);
     }
 
     public async Task<Guid?> GetUserIdByEmailAsync(string email, CancellationToken cancellationToken = default)
@@ -315,9 +319,9 @@ public class IdentityService : IIdentityService
             return (false, "User not found");
         }
 
-        if (newRole != "Owner" && newRole != "Contributor")
+        if (newRole != "Owner" && newRole != "Contributor" && newRole != "Tenant")
         {
-            return (false, "Invalid role. Must be 'Owner' or 'Contributor'");
+            return (false, "Invalid role. Must be 'Owner', 'Contributor', or 'Tenant'");
         }
 
         user.Role = newRole;

--- a/backend/src/PropertyManager.Infrastructure/Identity/JwtService.cs
+++ b/backend/src/PropertyManager.Infrastructure/Identity/JwtService.cs
@@ -33,6 +33,7 @@ public class JwtService : IJwtService
         string role,
         string email,
         string? displayName,
+        Guid? propertyId = null,
         CancellationToken cancellationToken = default)
     {
         var expiresIn = _settings.AccessTokenExpiryMinutes * 60; // Convert to seconds
@@ -54,6 +55,11 @@ public class JwtService : IJwtService
         if (!string.IsNullOrEmpty(displayName))
         {
             claims.Add(new("displayName", displayName));
+        }
+
+        if (propertyId.HasValue)
+        {
+            claims.Add(new("propertyId", propertyId.Value.ToString()));
         }
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.Secret));
@@ -104,7 +110,7 @@ public class JwtService : IJwtService
         return refreshToken;
     }
 
-    public async Task<(bool IsValid, Guid? UserId, Guid? AccountId, string? Role, string? Email, string? DisplayName)> ValidateRefreshTokenAsync(
+    public async Task<(bool IsValid, Guid? UserId, Guid? AccountId, string? Role, string? Email, string? DisplayName, Guid? PropertyId)> ValidateRefreshTokenAsync(
         string refreshToken,
         CancellationToken cancellationToken = default)
     {
@@ -117,7 +123,7 @@ public class JwtService : IJwtService
 
         if (storedToken == null || !storedToken.IsValid)
         {
-            return (false, null, null, null, null, null);
+            return (false, null, null, null, null, null, null);
         }
 
         // Get user info
@@ -127,10 +133,10 @@ public class JwtService : IJwtService
 
         if (user == null)
         {
-            return (false, null, null, null, null, null);
+            return (false, null, null, null, null, null, null);
         }
 
-        return (true, storedToken.UserId, storedToken.AccountId, user.Role, user.Email, user.DisplayName);
+        return (true, storedToken.UserId, storedToken.AccountId, user.Role, user.Email, user.DisplayName, user.PropertyId);
     }
 
     public async Task RevokeRefreshTokenAsync(

--- a/backend/src/PropertyManager.Infrastructure/Identity/PermissionService.cs
+++ b/backend/src/PropertyManager.Infrastructure/Identity/PermissionService.cs
@@ -32,4 +32,6 @@ public class PermissionService : IPermissionService
     public bool IsOwner() => string.Equals(_currentUser.Role, "Owner", StringComparison.Ordinal);
 
     public bool IsContributor() => string.Equals(_currentUser.Role, "Contributor", StringComparison.Ordinal);
+
+    public bool IsTenant() => string.Equals(_currentUser.Role, "Tenant", StringComparison.Ordinal);
 }

--- a/backend/src/PropertyManager.Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/PropertyManager.Infrastructure/Persistence/AppDbContext.cs
@@ -59,6 +59,16 @@ public class AppDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid
         // Apply all entity configurations from the assembly
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
 
+        // Configure ApplicationUser FK to Property for tenant scoping
+        modelBuilder.Entity<ApplicationUser>()
+            .HasOne(u => u.AssignedProperty)
+            .WithMany()
+            .HasForeignKey(u => u.PropertyId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<ApplicationUser>()
+            .HasIndex(u => u.PropertyId);
+
         // Configure global query filters for tenant isolation (ITenantEntity)
         ConfigureTenantFilters(modelBuilder);
 

--- a/backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260411220453_AddTenantPropertyId.Designer.cs
+++ b/backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260411220453_AddTenantPropertyId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PropertyManager.Domain.ValueObjects;
@@ -13,9 +14,11 @@ using PropertyManager.Infrastructure.Persistence;
 namespace PropertyManager.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411220453_AddTenantPropertyId")]
+    partial class AddTenantPropertyId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260411220453_AddTenantPropertyId.cs
+++ b/backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260411220453_AddTenantPropertyId.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PropertyManager.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantPropertyId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "PropertyId",
+                table: "AspNetUsers",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUsers_PropertyId",
+                table: "AspNetUsers",
+                column: "PropertyId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AspNetUsers_Properties_PropertyId",
+                table: "AspNetUsers",
+                column: "PropertyId",
+                principalTable: "Properties",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AspNetUsers_Properties_PropertyId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AspNetUsers_PropertyId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "PropertyId",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/Common/PermissionServiceTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Common/PermissionServiceTests.cs
@@ -193,6 +193,107 @@ public class PermissionServiceTests
         result.Should().BeFalse();
     }
 
+    // ===== Tenant Role Tests (Story 20.1 AC: #1, #4, #5) =====
+
+    // AC: #1, #5 — RolePermissions contains "Tenant" key with exactly 3 permissions
+    [Fact]
+    public void RolePermissions_Tenant_HasExactlyThreePermissions()
+    {
+        RolePermissions.Mappings.Should().ContainKey("Tenant");
+        var tenantPermissions = RolePermissions.Mappings["Tenant"];
+        tenantPermissions.Should().HaveCount(3);
+        tenantPermissions.Should().Contain(Permissions.MaintenanceRequests.Create);
+        tenantPermissions.Should().Contain(Permissions.MaintenanceRequests.ViewOwn);
+        tenantPermissions.Should().Contain(Permissions.Properties.ViewAssigned);
+    }
+
+    // AC: #5 — Tenant has MaintenanceRequests.Create permission
+    [Fact]
+    public void HasPermission_TenantWithMaintenanceRequestsCreate_ReturnsTrue()
+    {
+        var service = CreateService("Tenant");
+
+        var result = service.HasPermission(Permissions.MaintenanceRequests.Create);
+
+        result.Should().BeTrue();
+    }
+
+    // AC: #5 — Tenant has MaintenanceRequests.ViewOwn permission
+    [Fact]
+    public void HasPermission_TenantWithMaintenanceRequestsViewOwn_ReturnsTrue()
+    {
+        var service = CreateService("Tenant");
+
+        var result = service.HasPermission(Permissions.MaintenanceRequests.ViewOwn);
+
+        result.Should().BeTrue();
+    }
+
+    // AC: #5 — Tenant has Properties.ViewAssigned permission
+    [Fact]
+    public void HasPermission_TenantWithPropertiesViewAssigned_ReturnsTrue()
+    {
+        var service = CreateService("Tenant");
+
+        var result = service.HasPermission(Permissions.Properties.ViewAssigned);
+
+        result.Should().BeTrue();
+    }
+
+    // AC: #4 — Tenant does NOT have landlord permissions
+    [Theory]
+    [InlineData("Properties.ViewList")]
+    [InlineData("Properties.Create")]
+    [InlineData("Expenses.View")]
+    [InlineData("Income.View")]
+    [InlineData("Receipts.ViewAll")]
+    [InlineData("WorkOrders.View")]
+    [InlineData("Vendors.View")]
+    [InlineData("Reports.View")]
+    [InlineData("Account.View")]
+    [InlineData("Users.View")]
+    public void HasPermission_TenantWithLandlordPermission_ReturnsFalse(string permission)
+    {
+        var service = CreateService("Tenant");
+
+        var result = service.HasPermission(permission);
+
+        result.Should().BeFalse();
+    }
+
+    // AC: #1 — IsTenant returns true when role is "Tenant"
+    [Fact]
+    public void IsTenant_WhenRoleIsTenant_ReturnsTrue()
+    {
+        var service = CreateService("Tenant");
+
+        var result = service.IsTenant();
+
+        result.Should().BeTrue();
+    }
+
+    // AC: #1 — IsTenant returns false when role is "Owner"
+    [Fact]
+    public void IsTenant_WhenRoleIsOwner_ReturnsFalse()
+    {
+        var service = CreateService("Owner");
+
+        var result = service.IsTenant();
+
+        result.Should().BeFalse();
+    }
+
+    // AC: #1 — IsTenant returns false when role is "Contributor"
+    [Fact]
+    public void IsTenant_WhenRoleIsContributor_ReturnsFalse()
+    {
+        var service = CreateService("Contributor");
+
+        var result = service.IsTenant();
+
+        result.Should().BeFalse();
+    }
+
     /// <summary>
     /// Helper to get all permission constants via reflection.
     /// </summary>

--- a/backend/tests/PropertyManager.Application.Tests/Invitations/AcceptInvitationTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Invitations/AcceptInvitationTests.cs
@@ -78,7 +78,7 @@ public class AcceptInvitationTests
         _mockIdentityService.Setup(x => x.EmailExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         _mockIdentityService.Setup(x => x.CreateUserWithConfirmedEmailAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((_createdUserId, Enumerable.Empty<string>()));
     }
 
@@ -106,6 +106,7 @@ public class AcceptInvitationTests
             "NewUser@123456",
             _existingAccountId,
             "Owner",
+            It.IsAny<Guid?>(),
             It.IsAny<CancellationToken>()), Times.Once);
 
         // Verify NO new Account was added
@@ -132,6 +133,7 @@ public class AcceptInvitationTests
             "NewUser@123456",
             _existingAccountId,
             "Contributor",
+            It.IsAny<Guid?>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -163,6 +165,7 @@ public class AcceptInvitationTests
             "NewUser@123456",
             It.IsAny<Guid>(),
             "Owner",
+            It.IsAny<Guid?>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -175,7 +178,7 @@ public class AcceptInvitationTests
         _mockIdentityService.Setup(x => x.EmailExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         _mockIdentityService.Setup(x => x.CreateUserWithConfirmedEmailAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(((Guid?)null, new[] { "Password too weak" }));
         _mockDbContext.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
@@ -211,7 +214,7 @@ public class AcceptInvitationTests
         _mockIdentityService.Setup(x => x.EmailExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         _mockIdentityService.Setup(x => x.CreateUserWithConfirmedEmailAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(((Guid?)null, new[] { "Password too weak" }));
         _mockDbContext.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 

--- a/backend/tests/PropertyManager.Infrastructure.Tests/DatabaseFixture.cs
+++ b/backend/tests/PropertyManager.Infrastructure.Tests/DatabaseFixture.cs
@@ -58,6 +58,7 @@ public class TestCurrentUser : ICurrentUser
     public Guid UserId { get; set; }
     public Guid AccountId { get; set; }
     public string Role { get; set; } = "Owner";
+    public Guid? PropertyId { get; set; }
     public bool IsAuthenticated { get; set; } = true;
 }
 

--- a/backend/tests/PropertyManager.Infrastructure.Tests/Identity/JwtServiceTests.cs
+++ b/backend/tests/PropertyManager.Infrastructure.Tests/Identity/JwtServiceTests.cs
@@ -43,7 +43,7 @@ public class JwtServiceTests
 
         // Act
         var (accessToken, _) = await _jwtService.GenerateAccessTokenAsync(
-            userId, accountId, role, email, displayName, CancellationToken.None);
+            userId, accountId, role, email, displayName, propertyId: null, CancellationToken.None);
 
         // Assert
         var handler = new JwtSecurityTokenHandler();
@@ -64,7 +64,7 @@ public class JwtServiceTests
 
         // Act
         var (accessToken, _) = await _jwtService.GenerateAccessTokenAsync(
-            userId, accountId, role, email, displayName, CancellationToken.None);
+            userId, accountId, role, email, displayName, propertyId: null, CancellationToken.None);
 
         // Assert
         var handler = new JwtSecurityTokenHandler();
@@ -85,7 +85,7 @@ public class JwtServiceTests
 
         // Act
         var (accessToken, _) = await _jwtService.GenerateAccessTokenAsync(
-            userId, accountId, role, email, displayName, CancellationToken.None);
+            userId, accountId, role, email, displayName, propertyId: null, CancellationToken.None);
 
         // Assert
         var handler = new JwtSecurityTokenHandler();
@@ -107,7 +107,7 @@ public class JwtServiceTests
 
         // Act
         var (accessToken, _) = await _jwtService.GenerateAccessTokenAsync(
-            userId, accountId, role, email, displayName, CancellationToken.None);
+            userId, accountId, role, email, displayName, propertyId: null, CancellationToken.None);
 
         // Assert
         var handler = new JwtSecurityTokenHandler();
@@ -118,5 +118,48 @@ public class JwtServiceTests
         token.Claims.Should().Contain(c => c.Type == "role" && c.Value == role);
         token.Claims.Should().Contain(c => c.Type == "email" && c.Value == email);
         token.Claims.Should().Contain(c => c.Type == "displayName" && c.Value == displayName);
+    }
+
+    [Fact]
+    public async Task GenerateAccessToken_IncludesPropertyIdClaim_WhenProvided()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var accountId = Guid.NewGuid();
+        var propertyId = Guid.NewGuid();
+        var role = "Tenant";
+        var email = "tenant@example.com";
+        string? displayName = "Tenant User";
+
+        // Act
+        var (accessToken, _) = await _jwtService.GenerateAccessTokenAsync(
+            userId, accountId, role, email, displayName, propertyId: propertyId, CancellationToken.None);
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(accessToken);
+
+        token.Claims.Should().Contain(c => c.Type == "propertyId" && c.Value == propertyId.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateAccessToken_OmitsPropertyIdClaim_WhenNull()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var accountId = Guid.NewGuid();
+        var role = "Owner";
+        var email = "owner@example.com";
+        string? displayName = "Owner User";
+
+        // Act
+        var (accessToken, _) = await _jwtService.GenerateAccessTokenAsync(
+            userId, accountId, role, email, displayName, propertyId: null, CancellationToken.None);
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(accessToken);
+
+        token.Claims.Should().NotContain(c => c.Type == "propertyId");
     }
 }

--- a/docs/project/sprint-status.yaml
+++ b/docs/project/sprint-status.yaml
@@ -307,3 +307,20 @@ development_status:
   19-6-invitation-management-ui: done              # FR58, FR62 - Size 5 - depends on 19.1, 19.5
   19-7-account-user-management-ui: done              # FR61, FR62 - Size 3 - depends on 19.4, 19.5, 19.6
   epic-19-retrospective: optional
+
+  # ============================================================
+  # TENANT PORTAL
+  # Source: epic-20-tenant-portal.md
+  # PRD: prd-tenant-portal.md
+  # Added: 2026-04-11
+  # Dependencies: 20.1 first, then 20.2 and 20.3 parallel,
+  #   20.4 depends on 20.3, 20.5 depends on 20.1+20.3,
+  #   20.6 depends on 20.5, 20.7 depends on 20.3,
+  #   20.8 depends on 20.7, 20.9 depends on 20.7,
+  #   20.10 depends on 20.8, 20.11 depends on 20.5
+  # ============================================================
+
+  # Epic 20: Tenant Portal
+  # User Outcome: "Tenants can submit maintenance requests and I can triage them into work orders"
+  epic-20: in-progress
+  20-1-tenant-role-property-association: done    # FR-TP2, FR-TP3, FR-TP10, NFR-TP3 - Size 5

--- a/docs/project/stories/epic-20/20-1-tenant-role-property-association.md
+++ b/docs/project/stories/epic-20/20-1-tenant-role-property-association.md
@@ -1,0 +1,297 @@
+# Story 20.1: Tenant Role & Property Association
+
+Status: done
+
+## Story
+
+As a system administrator,
+I want a Tenant role with property-level scoping,
+so that tenants can be associated with a specific property and restricted from landlord workflows.
+
+## Acceptance Criteria
+
+1. **Given** the application roles,
+   **When** the system starts,
+   **Then** a "Tenant" role exists alongside "Owner" and "Contributor"
+
+2. **Given** an ApplicationUser with the Tenant role,
+   **When** querying the user,
+   **Then** a PropertyId field is present linking the tenant to exactly one property
+
+3. **Given** a property,
+   **When** querying its tenants,
+   **Then** multiple users with the Tenant role can be associated with that property
+
+4. **Given** a user with the Tenant role,
+   **When** the user attempts to access any landlord endpoint (properties list, expenses, income, reports, vendors, work orders),
+   **Then** the API returns 403 Forbidden
+
+5. **Given** a Tenant permission set,
+   **When** permissions are evaluated,
+   **Then** the Tenant role has only: MaintenanceRequests.Create, MaintenanceRequests.ViewOwn, Property.ViewAssigned
+
+6. **Given** the database,
+   **When** the migration runs,
+   **Then** a nullable PropertyId column is added to the user record (nullable because Owner/Contributor users don't have one)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add Tenant permissions to Domain authorization (AC: #1, #5)
+  - [x] 1.1 Add `MaintenanceRequests` permission class to `Permissions.cs` with constants: `Create = "MaintenanceRequests.Create"`, `ViewOwn = "MaintenanceRequests.ViewOwn"`
+  - [x] 1.2 Add `Properties.ViewAssigned` constant to the existing `Properties` class in `Permissions.cs` (value: `"Properties.ViewAssigned"`)
+  - [x] 1.3 Add `"Tenant"` role mapping to `RolePermissions.cs` with exactly three permissions: `Permissions.MaintenanceRequests.Create`, `Permissions.MaintenanceRequests.ViewOwn`, `Permissions.Properties.ViewAssigned`
+
+- [x] Task 2: Add PropertyId to ApplicationUser entity (AC: #2, #3, #6)
+  - [x] 2.1 Add `public Guid? PropertyId { get; set; }` to `ApplicationUser` in `backend/src/PropertyManager.Infrastructure/Identity/ApplicationUser.cs` (nullable — only set for Tenant role users)
+  - [x] 2.2 Add navigation property `public Property? AssignedProperty { get; set; }` to `ApplicationUser`
+  - [x] 2.3 Update `ApplicationUser` XML doc comment on `Role` property from `"Owner" or "Contributor"` to `"Owner", "Contributor", or "Tenant"`
+
+- [x] Task 3: Create EF Core migration for PropertyId FK (AC: #6)
+  - [x] 3.1 Add FK configuration in `AppDbContext.OnModelCreating()` or a new `ApplicationUserConfiguration.cs` — configure `PropertyId` as optional FK to `Properties` table with `DeleteBehavior.SetNull`
+  - [x] 3.2 Create migration: `dotnet ef migrations add AddTenantPropertyId --project src/PropertyManager.Infrastructure --startup-project src/PropertyManager.Api`
+  - [x] 3.3 Apply migration: `dotnet ef database update --project src/PropertyManager.Infrastructure --startup-project src/PropertyManager.Api`
+  - [x] 3.4 Verify migration creates nullable `PropertyId` column on `AspNetUsers` table with FK to `Properties`
+
+- [x] Task 4: Add PropertyId to JWT claims for tenant users (AC: #2)
+  - [x] 4.1 Extend `JwtService.GenerateAccessTokenAsync()` signature to accept optional `Guid? propertyId` parameter
+  - [x] 4.2 When `propertyId` has a value, add `new Claim("propertyId", propertyId.Value.ToString())` to the claims list
+  - [x] 4.3 Update `IJwtService` interface to match the new parameter
+  - [x] 4.4 Update all callers of `GenerateAccessTokenAsync` (auth controller login/refresh flows) to pass `propertyId` from the user record
+  - [x] 4.5 Update `ValidateRefreshTokenAsync` to include PropertyId in its return tuple and pass it through
+
+- [x] Task 5: Extend ICurrentUser and CurrentUserService with PropertyId (AC: #2)
+  - [x] 5.1 Add `Guid? PropertyId { get; }` to `ICurrentUser` interface in `backend/src/PropertyManager.Application/Common/Interfaces/ICurrentUser.cs`
+  - [x] 5.2 Implement `PropertyId` property in `CurrentUserService` — extract from JWT claim `"propertyId"`, parse as `Guid?` (null if claim not present)
+
+- [x] Task 6: Extend PermissionService and IPermissionService (AC: #1, #4)
+  - [x] 6.1 Add `bool IsTenant()` method to `IPermissionService` interface
+  - [x] 6.2 Implement `IsTenant()` in `PermissionService` — checks `_currentUser.Role == "Tenant"`
+
+- [x] Task 7: Update role validation in IdentityService (AC: #1)
+  - [x] 7.1 Update `UpdateUserRoleAsync` in `IdentityService.cs` — add "Tenant" to valid roles check (currently only allows "Owner" and "Contributor")
+  - [x] 7.2 Extend `CreateUserInternalAsync` to accept optional `Guid? propertyId` parameter and set it on the `ApplicationUser` if provided
+  - [x] 7.3 Update `IIdentityService.CreateUserAsync` and `CreateUserWithConfirmedEmailAsync` signatures to accept optional `Guid? propertyId = null`
+  - [x] 7.4 Update `ValidateCredentialsAsync` return tuple to include `Guid? PropertyId` — read from `user.PropertyId`
+
+- [x] Task 8: Update frontend auth types for PropertyId (AC: #2)
+  - [x] 8.1 Add `propertyId: string | null` to `User` interface in `frontend/src/app/core/services/auth.service.ts`
+  - [x] 8.2 Update `decodeToken()` in `AuthService` to extract `propertyId` from JWT payload (null if not present)
+  - [x] 8.3 Add `readonly isTenant = computed(() => this.authService.currentUser()?.role === 'Tenant')` to `PermissionService`
+  - [x] 8.4 Update `PermissionService.canAccess()` — Tenant role can only access tenant routes (empty for now, will be populated in Story 20.5)
+
+- [x] Task 9: Backend unit tests (AC: #1, #4, #5)
+  - [x] 9.1 Test: `RolePermissions` contains "Tenant" key with exactly 3 permissions (MaintenanceRequests.Create, MaintenanceRequests.ViewOwn, Properties.ViewAssigned)
+  - [x] 9.2 Test: `PermissionService.HasPermission()` returns true for Tenant permissions when role is Tenant
+  - [x] 9.3 Test: `PermissionService.HasPermission()` returns false for Owner-only permissions (e.g., Expenses.View) when role is Tenant
+  - [x] 9.4 Test: `PermissionService.IsTenant()` returns true when role is "Tenant"
+  - [x] 9.5 Test: `PermissionService.IsTenant()` returns false when role is "Owner" or "Contributor"
+  - [x] 9.6 Test: Tenant role does NOT have any of these permissions: Properties.ViewList, Properties.Create, Expenses.View, Income.View, Receipts.ViewAll, WorkOrders.View, Vendors.View, Reports.View, Account.View, Users.View
+
+- [x] Task 10: Frontend unit tests (AC: #1, #2)
+  - [x] 10.1 Test: `PermissionService.isTenant` returns true when user role is "Tenant"
+  - [x] 10.2 Test: `PermissionService.canAccess()` returns false for all landlord routes when role is "Tenant"
+  - [x] 10.3 Test: `AuthService.decodeToken()` extracts `propertyId` from JWT payload
+  - [x] 10.4 Test: `User` interface includes `propertyId` field
+
+- [x] Task 11: Verify all existing tests pass (AC: all)
+  - [x] 11.1 Run `dotnet test` — all backend tests pass (1735 tests)
+  - [x] 11.2 Run `npm test` — all frontend tests pass (2694 tests)
+  - [x] 11.3 Run `dotnet build` and `ng build` — both compile without errors
+
+## Dev Notes
+
+### Architecture: Backend + Frontend Foundation
+
+This is a foundational story that establishes the Tenant role across the entire stack. No new API endpoints or UI components — this story modifies existing infrastructure so that subsequent stories (20.2 onward) can build on a solid Tenant role.
+
+### Key Files to Modify
+
+**Domain Layer:**
+- `backend/src/PropertyManager.Domain/Authorization/Permissions.cs` — add `MaintenanceRequests` class and `Properties.ViewAssigned`
+- `backend/src/PropertyManager.Domain/Authorization/RolePermissions.cs` — add Tenant role mapping
+
+**Infrastructure Layer:**
+- `backend/src/PropertyManager.Infrastructure/Identity/ApplicationUser.cs` — add `PropertyId` and `AssignedProperty` nav property
+- `backend/src/PropertyManager.Infrastructure/Identity/IdentityService.cs` — extend user creation with PropertyId, update role validation
+- `backend/src/PropertyManager.Infrastructure/Identity/CurrentUserService.cs` — add PropertyId extraction from JWT
+- `backend/src/PropertyManager.Infrastructure/Identity/PermissionService.cs` — add IsTenant()
+- `backend/src/PropertyManager.Infrastructure/Identity/JwtService.cs` — add propertyId to JWT claims
+
+**Application Layer:**
+- `backend/src/PropertyManager.Application/Common/Interfaces/ICurrentUser.cs` — add PropertyId
+- `backend/src/PropertyManager.Application/Common/Interfaces/IPermissionService.cs` — add IsTenant()
+- `backend/src/PropertyManager.Application/Common/Interfaces/IIdentityService.cs` — extend signatures with PropertyId
+- `backend/src/PropertyManager.Application/Common/Interfaces/IJwtService.cs` — extend GenerateAccessTokenAsync
+
+**Frontend:**
+- `frontend/src/app/core/services/auth.service.ts` — add propertyId to User interface and decodeToken
+- `frontend/src/app/core/auth/permission.service.ts` — add isTenant computed, update canAccess
+
+### Critical Patterns to Follow
+
+1. **Role is a string, not an enum.** The existing pattern stores role as a string ("Owner", "Contributor") on ApplicationUser.Role and in JWT claims. Follow this pattern — add "Tenant" as a string value, not a new enum.
+
+2. **Permissions use string constants.** Follow the existing pattern in `Permissions.cs` — nested static classes with `const string` fields.
+
+3. **RolePermissions uses Dictionary<string, HashSet<string>>.** Add the Tenant entry as a new dictionary key with a HashSet of exactly 3 permission strings.
+
+4. **JWT claims are string key-value pairs.** The existing JWT has claims: `userId`, `accountId`, `role`, `email`, optional `displayName`. Add `propertyId` only when it has a value (for Tenant users). Owner/Contributor tokens remain unchanged.
+
+5. **ICurrentUser is injected everywhere.** Any property added to ICurrentUser must also be added to CurrentUserService. The AppDbContext uses ICurrentUser for tenant filtering via AccountId — PropertyId is separate from this (it's tenant-to-property scoping, not multi-tenancy).
+
+6. **PropertyId FK goes on AspNetUsers.** ApplicationUser already has AccountId (FK to Account). Add PropertyId (FK to Property) with SetNull delete behavior so deleting a property sets PropertyId to null rather than cascading.
+
+7. **UpdateUserRoleAsync currently only allows Owner/Contributor.** This must be updated to include "Tenant" as a valid role, but note that changing TO Tenant requires setting PropertyId too — consider whether this method needs to accept an optional PropertyId. For this story, just allow the role string; PropertyId assignment will be handled via the invitation flow in Story 20.2.
+
+### Migration Notes
+
+- Column: `PropertyId` (nullable Guid) on `AspNetUsers` table
+- FK: References `Properties.Id` with `ON DELETE SET NULL`
+- Index: Consider adding index on `PropertyId` for querying tenants by property
+
+### Testing Strategy
+
+- **Backend unit tests** for permission mappings (RolePermissions, PermissionService) — these are pure logic tests, no database needed
+- **Frontend unit tests** for PermissionService and AuthService token decoding
+- **No integration tests in this story** — Story 20.11 will provide comprehensive authorization lockdown tests
+- **No E2E tests** — no UI changes in this story
+
+### Previous Story Intelligence
+
+From Story 19.7 (last Epic 19 story):
+- The settings page has a user management section with role dropdowns (Owner/Contributor) — when Tenant role is added, consider whether Tenants should appear in this list (likely yes but with restrictions — defer to Story 20.2+)
+- Frontend PermissionService already has `isOwner` and `isContributor` computed signals — adding `isTenant` follows the same pattern
+- The `owner.guard.ts` redirects non-Owner users to `/dashboard` — Tenant users should be redirected to a tenant dashboard instead (Story 20.5 handles this)
+- `UpdateUserRoleAsync` validates role is "Owner" or "Contributor" — needs "Tenant" added
+
+From Epic 19 architecture:
+- Roles are stored as strings on ApplicationUser, not via ASP.NET Identity Roles table
+- Permission checks happen via `IPermissionService.HasPermission()` which looks up `RolePermissions.Mappings`
+- Authorization policies in `Program.cs` use `AddPermissionPolicy()` helper — Tenant permissions don't need new policies yet (maintenance request endpoints come in Story 20.3)
+
+## References
+
+- Epic file: `docs/project/stories/epic-20/epic-20-tenant-portal.md` (Story 20.1)
+- PRD: `docs/project/prd-tenant-portal.md` (FR-TP2, FR-TP3, FR-TP10, NFR-TP3)
+- Architecture: `docs/project/architecture.md`
+- Project Context: `docs/project/project-context.md`
+
+## Dev Agent Record
+
+### Implementation Log
+- Added `MaintenanceRequests` permission class (Create, ViewOwn) and `Properties.ViewAssigned` to Permissions.cs
+- Added Tenant role mapping to RolePermissions.cs with 3 permissions; also added new permissions to Owner role
+- Added `PropertyId` (nullable Guid) and `AssignedProperty` nav property to ApplicationUser
+- Created migration `AddTenantPropertyId` — nullable PropertyId column, FK to Properties with SetNull, index on PropertyId
+- Extended JwtService.GenerateAccessTokenAsync with optional `propertyId` parameter; adds claim when present
+- Extended ValidateRefreshTokenAsync return tuple to include PropertyId from user record
+- Updated LoginCommandHandler and RefreshTokenCommandHandler to pass propertyId through
+- Extended IIdentityService.ValidateCredentialsAsync return tuple with PropertyId
+- Extended CreateUserAsync/CreateUserWithConfirmedEmailAsync with optional `propertyId` parameter
+- Updated UpdateUserRoleAsync to accept "Tenant" as valid role
+- Added `Guid? PropertyId` to ICurrentUser and CurrentUserService (extracts from JWT "propertyId" claim)
+- Added `IsTenant()` to IPermissionService and PermissionService
+- Added `propertyId: string | null` to frontend User interface; updated decodeToken to extract it
+- Added `isTenant` computed signal to frontend PermissionService
+- Updated frontend `canAccess()` — Tenant gets empty route set (to be populated in Story 20.5)
+- Fixed existing test files: added propertyId to all User object literals, updated mock setups for new parameter positions
+
+### Test Results
+- Backend: 1735 tests passed (1108 Application + 96 Infrastructure + 531 Api)
+- Frontend: 2694 tests passed (114 test files)
+- New backend tests: 13 (RolePermissions Tenant mapping, HasPermission for 3 tenant perms, HasPermission deny for 10 landlord perms, IsTenant true/false x3)
+- New frontend tests: 14 (isTenant 4, canAccess Tenant deny 8, propertyId extraction 2)
+- No regressions
+
+### File List
+**New files:**
+- `backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260411220453_AddTenantPropertyId.cs`
+- `backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260411220453_AddTenantPropertyId.Designer.cs`
+
+**Modified files:**
+- `backend/src/PropertyManager.Domain/Authorization/Permissions.cs`
+- `backend/src/PropertyManager.Domain/Authorization/RolePermissions.cs`
+- `backend/src/PropertyManager.Infrastructure/Identity/ApplicationUser.cs`
+- `backend/src/PropertyManager.Infrastructure/Identity/JwtService.cs`
+- `backend/src/PropertyManager.Infrastructure/Identity/CurrentUserService.cs`
+- `backend/src/PropertyManager.Infrastructure/Identity/PermissionService.cs`
+- `backend/src/PropertyManager.Infrastructure/Identity/IdentityService.cs`
+- `backend/src/PropertyManager.Infrastructure/Persistence/AppDbContext.cs`
+- `backend/src/PropertyManager.Application/Common/Interfaces/ICurrentUser.cs`
+- `backend/src/PropertyManager.Application/Common/Interfaces/IPermissionService.cs`
+- `backend/src/PropertyManager.Application/Common/Interfaces/IIdentityService.cs`
+- `backend/src/PropertyManager.Application/Common/Interfaces/IJwtService.cs`
+- `backend/src/PropertyManager.Application/Auth/Login.cs`
+- `backend/src/PropertyManager.Application/Auth/RefreshToken.cs`
+- `backend/src/PropertyManager.Application/Invitations/AcceptInvitation.cs`
+- `backend/tests/PropertyManager.Application.Tests/Common/PermissionServiceTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/Invitations/AcceptInvitationTests.cs`
+- `backend/tests/PropertyManager.Infrastructure.Tests/Identity/JwtServiceTests.cs`
+- `backend/tests/PropertyManager.Infrastructure.Tests/DatabaseFixture.cs`
+- `frontend/src/app/core/services/auth.service.ts`
+- `frontend/src/app/core/services/auth.service.spec.ts`
+- `frontend/src/app/core/auth/permission.service.ts`
+- `frontend/src/app/core/auth/permission.service.spec.ts`
+- `frontend/src/app/core/auth/owner.guard.spec.ts`
+- `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.spec.ts`
+- `frontend/src/app/core/components/bottom-nav/bottom-nav.component.spec.ts`
+- `frontend/src/app/features/dashboard/dashboard.component.spec.ts`
+- `frontend/src/app/features/properties/properties.component.spec.ts`
+- `frontend/src/app/features/settings/settings.component.spec.ts`
+- `docs/project/stories/epic-20/20-1-tenant-role-property-association.md`
+- `docs/project/sprint-status.yaml`
+
+### Review Notes
+- Owner role was updated to include the new MaintenanceRequests and Properties.ViewAssigned permissions to pass the existing "Owner has all permissions" test
+- The EF model snapshot was also updated by the migration (auto-generated Designer.cs)
+
+## Evaluation (2026-04-11)
+
+### Verdict: CONDITIONAL PASS
+
+### Test Results
+- Backend: 1735 tests passed (1108 Application + 96 Infrastructure + 531 Api) - ALL GREEN
+- Frontend: 2694 tests passed (114 test files) - ALL GREEN
+- E2E: Pre-existing flaky failures only (30-second timeouts on expense/filter tests due to shared DB state) - NOT regressions
+- Builds: dotnet build and ng build both succeed (0 errors, 0 warnings backend; budget warning on frontend is pre-existing)
+
+### AC Verification
+
+| AC | Description | Status | Method |
+|----|-------------|--------|--------|
+| 1 | Tenant role exists alongside Owner and Contributor | VERIFIED | Code + test: RolePermissions_Tenant_HasExactlyThreePermissions |
+| 2 | PropertyId field on ApplicationUser | VERIFIED | Code: ApplicationUser.cs, ICurrentUser, JWT claims |
+| 3 | Multiple tenants per property | VERIFIED | Code: FK with WithMany() in AppDbContext, nullable column |
+| 4 | Tenant blocked from landlord endpoints | VERIFIED | Tests: 10 landlord permissions denied; frontend canAccess blocks all routes |
+| 5 | Tenant has exactly 3 permissions | VERIFIED | Test: RolePermissions_Tenant_HasExactlyThreePermissions asserts exact count + values |
+| 6 | Migration adds nullable PropertyId | VERIFIED | Migration file: AddTenantPropertyId.cs - nullable UUID, FK SetNull, index |
+
+### Smoke Test (Playwright MCP)
+- Login with claude@claude.com: SUCCESS
+- Dashboard loads with all navigation: SUCCESS
+- Settings page loads with User Management: SUCCESS
+- No visual regressions observed
+
+### Findings (3 required, 3 found)
+
+**Finding 1 (MUST FIX): Migration files are untracked**
+The migration files `20260411220453_AddTenantPropertyId.cs` and `20260411220453_AddTenantPropertyId.Designer.cs` are untracked (`??` in git status). They will NOT be included in the commit/PR. These must be staged with `git add`.
+
+**Finding 2 (SHOULD FIX): Missing JwtService test for propertyId claim inclusion**
+No backend test verifies that `JwtService.GenerateAccessTokenAsync` actually includes the `propertyId` claim in the JWT when a non-null Guid is provided. The existing JwtServiceTests were updated to pass `propertyId: null` but no positive test was added. A test like `GenerateAccessToken_WithPropertyId_IncludesPropertyIdClaim` should verify the claim is present and has the correct value. This is the core of AC #2 (JWT carries propertyId for tenant users).
+
+**Finding 3 (INFO): UpdateUserRoleAsync does not clear PropertyId when changing FROM Tenant**
+When `UpdateUserRoleAsync` changes a user's role from "Tenant" to "Owner" or "Contributor", the `PropertyId` is not cleared to null. This could leave orphaned PropertyId values on non-Tenant users. The story notes say "PropertyId assignment will be handled via the invitation flow in Story 20.2" -- acceptable to defer this cleanup, but it should be tracked. Not a blocker for this story.
+
+### Grading
+
+| Dimension | Grade | Notes |
+|-----------|-------|-------|
+| Functional Completeness (CRITICAL) | PASS | All 6 ACs verified through code inspection and tests |
+| Regression Safety (CRITICAL) | PASS | All 1735 backend + 2694 frontend tests pass. Builds clean. |
+| Test Quality (HIGH) | CONDITIONAL | 13 backend + 14 frontend new tests. Good coverage of permission mappings. Missing JwtService propertyId positive test. |
+| Code Quality (MEDIUM) | PASS | Clean architecture followed. FK config correct. SetNull delete behavior. Proper null handling throughout. |
+
+### Required Actions Before Shipping
+1. ~~Stage the migration files~~ — FIXED: will be staged during Ship phase
+2. ~~Add JwtService test for propertyId claim~~ — FIXED: Added `GenerateAccessToken_IncludesPropertyIdClaim_WhenProvided` and `GenerateAccessToken_OmitsPropertyIdClaim_WhenNull` tests (6/6 JwtService tests passing)

--- a/docs/project/stories/epic-20/epic-20-tenant-portal.md
+++ b/docs/project/stories/epic-20/epic-20-tenant-portal.md
@@ -1,0 +1,409 @@
+# Tenant Portal - Epic Breakdown
+
+**Author:** Dave
+**Date:** 2026-04-11
+**Version:** 1.0
+**Source PRD:** prd-tenant-portal.md
+
+---
+
+## Overview
+
+This document breaks down the Tenant Portal PRD into implementable stories with BDD acceptance criteria. The tenant portal is delivered as a single epic (Epic 20) with ordered stories that build on each other.
+
+**Dependencies:** Epic 19 (Multi-User Account with RBAC) must be complete. The tenant portal extends the invitation infrastructure, role system, and permission framework established there.
+
+---
+
+## Epic Summary
+
+| Epic | Name | Stories | Description |
+|------|------|---------|-------------|
+| 20 | Tenant Portal | 11 | Tenant maintenance requests, landlord inbox, role-based routing |
+
+## Functional Requirements Coverage
+
+| FR | Description | Story |
+|----|-------------|-------|
+| FR-TP1 | Landlord invites tenant to property via email | 20.2 |
+| FR-TP2 | Tenant associated with exactly one property | 20.1 |
+| FR-TP3 | Property can have multiple tenants | 20.1 |
+| FR-TP4 | Tenant accepts invitation, scoped to property | 20.2 |
+| FR-TP5 | Invitation reuses existing infrastructure | 20.2 |
+| FR-TP6 | Tenant sees property info (read-only) | 20.5 |
+| FR-TP7 | Tenant submits request with description + photos | 20.6 |
+| FR-TP8 | Tenant views all requests for their property (shared) | 20.5 |
+| FR-TP9 | Tenant sees simplified status | 20.5 |
+| FR-TP10 | Tenant cannot access financial data or landlord workflows | 20.1, 20.11 |
+| FR-TP11 | Tenant routed to tenant dashboard on login | 20.5 |
+| FR-TP12 | Landlord sees single inbox across all properties | 20.7 |
+| FR-TP13 | Landlord converts request to work order | 20.8 |
+| FR-TP14 | Conversion pre-populates work order | 20.8 |
+| FR-TP15 | Landlord dismisses request with reason | 20.9 |
+| FR-TP16 | Tenant sees updated status | 20.8, 20.9 |
+| FR-TP17 | Work order completion resolves request | 20.10 |
+| FR-TP18 | MaintenanceRequest is separate from WorkOrder | 20.3 |
+| FR-TP19 | MaintenanceRequest entity fields | 20.3 |
+| FR-TP20 | Status state machine | 20.3 |
+| FR-TP21 | Photos use S3 presigned URL infrastructure | 20.4 |
+
+| NFR | Description | Story |
+|-----|-------------|-------|
+| NFR-TP1 | Tenant scoped to property + requests only | 20.11 |
+| NFR-TP2 | Tenant cannot access financials via API | 20.11 |
+| NFR-TP3 | Role-based authorization checks | 20.1, 20.11 |
+| NFR-TP4 | Invitation token security | 20.2 |
+| NFR-TP5 | Tenant dashboard < 3s on mobile | 20.5 |
+| NFR-TP6 | Paginated request list | 20.3 |
+| NFR-TP7 | Mobile-first tenant views | 20.5, 20.6 |
+| NFR-TP8 | Photo capture iOS Safari + Android Chrome | 20.6 |
+
+---
+
+## Epic 20: Tenant Portal
+
+### Objective
+
+Enable tenants to submit maintenance requests through a mobile-first experience in the existing app, and give landlords a single inbox to triage those requests into work orders or dismiss them.
+
+### Dependency Chain
+
+```
+20.1 (Tenant Role) ──→ 20.2 (Invitation)
+                   ──→ 20.3 (Entity & API) ──→ 20.4 (Photos)
+                                            ──→ 20.7 (Landlord Inbox) ──→ 20.8 (Convert) ──→ 20.10 (Resolution)
+                                                                       ──→ 20.9 (Dismiss)
+20.1 + 20.3 ──→ 20.5 (Tenant Dashboard) ──→ 20.6 (Submit Request UI)
+20.5 ──→ 20.11 (Authorization Lockdown)
+```
+
+---
+
+### Story 20.1: Tenant Role & Property Association
+
+**User Story:** As a system administrator, I want a Tenant role with property-level scoping, so that tenants can be associated with a specific property and restricted from landlord workflows.
+
+**Source:** FR-TP2, FR-TP3, FR-TP10, NFR-TP3
+
+**Acceptance Criteria:**
+
+- **AC-20.1.1:** Given the application roles, When the system starts, Then a "Tenant" role exists alongside "Owner" and "Contributor"
+
+- **AC-20.1.2:** Given an ApplicationUser with the Tenant role, When querying the user, Then a PropertyId field is present linking the tenant to exactly one property
+
+- **AC-20.1.3:** Given a property, When querying its tenants, Then multiple users with the Tenant role can be associated with that property
+
+- **AC-20.1.4:** Given a user with the Tenant role, When the user attempts to access any landlord endpoint (properties list, expenses, income, reports, vendors, work orders), Then the API returns 403 Forbidden
+
+- **AC-20.1.5:** Given a Tenant permission set, When permissions are evaluated, Then the Tenant role has only: MaintenanceRequests.Create, MaintenanceRequests.ViewOwn, Property.ViewAssigned
+
+- **AC-20.1.6:** Given the database, When the migration runs, Then a nullable PropertyId column is added to the user record (nullable because Owner/Contributor users don't have one)
+
+**Technical Notes:**
+- Add `PropertyId` (nullable Guid) to `ApplicationUser`
+- Add Tenant role to `RolePermissions.cs` with minimal permission set
+- EF Core migration for PropertyId FK on AspNetUsers
+- Add PropertyId to JWT claims for tenant users
+- Seed Tenant role in identity setup
+
+---
+
+### Story 20.2: Tenant Invitation Flow
+
+**User Story:** As a landlord, I want to invite a tenant to a specific property via email, so that the tenant can create an account and immediately access their property.
+
+**Source:** FR-TP1, FR-TP4, FR-TP5, NFR-TP4
+
+**Acceptance Criteria:**
+
+- **AC-20.2.1:** Given a landlord on the property detail page, When they invite a tenant by email, Then an invitation is created with role "Tenant" and the associated PropertyId
+
+- **AC-20.2.2:** Given an invitation with role "Tenant" and a PropertyId, When the tenant accepts the invitation, Then their account is created with the Tenant role and PropertyId set to the invited property
+
+- **AC-20.2.3:** Given an existing user who is not yet a tenant, When they accept a tenant invitation, Then their role and PropertyId are updated accordingly
+
+- **AC-20.2.4:** Given a tenant invitation, When the invitation email is sent, Then the email includes the property address so the tenant knows what they're accepting
+
+- **AC-20.2.5:** Given an invitation, When the invitation is created, Then the PropertyId is validated to ensure it belongs to the landlord's account
+
+- **AC-20.2.6:** Given an expired or already-accepted tenant invitation, When a user tries to accept it, Then the system returns an appropriate error
+
+**Technical Notes:**
+- Extend `Invitation` entity with nullable `PropertyId`
+- Extend `CreateInvitationCommand` to accept PropertyId when role is Tenant
+- Extend `AcceptInvitationCommand` to set PropertyId on the new user when role is Tenant
+- Validate PropertyId is required when invitation role is Tenant
+- Add PropertyId to invitation email template context
+- Frontend: add "Invite Tenant" action on property detail page (reuse invitation dialog with property pre-selected)
+
+---
+
+### Story 20.3: MaintenanceRequest Entity & API
+
+**User Story:** As a developer, I want the MaintenanceRequest domain entity and CRUD API, so that tenants can submit requests and landlords can manage them.
+
+**Source:** FR-TP18, FR-TP19, FR-TP20, NFR-TP6
+
+**Acceptance Criteria:**
+
+- **AC-20.3.1:** Given the domain layer, When the MaintenanceRequest entity is defined, Then it has: Id, Description, Status, DismissalReason (nullable), PropertyId, SubmittedByUserId, WorkOrderId (nullable), AccountId, CreatedAt, UpdatedAt
+
+- **AC-20.3.2:** Given the MaintenanceRequest status enum, When defined, Then valid statuses are: Submitted, InProgress, Resolved, Dismissed
+
+- **AC-20.3.3:** Given valid status transitions, When a status change is attempted, Then only these transitions are allowed: Submitted → InProgress, Submitted → Dismissed, InProgress → Resolved
+
+- **AC-20.3.4:** Given a tenant user, When they POST to the create endpoint with a description, Then a MaintenanceRequest is created with status Submitted, the tenant's PropertyId, and the tenant's UserId
+
+- **AC-20.3.5:** Given a tenant user, When they GET maintenance requests, Then they receive all requests for their property (shared visibility), paginated
+
+- **AC-20.3.6:** Given a landlord user, When they GET maintenance requests, Then they receive requests across all their properties, paginated, with property info included
+
+- **AC-20.3.7:** Given a landlord user, When they GET a single maintenance request, Then they see the full detail including description, status, submitter info, property info, and dismissal reason if applicable
+
+- **AC-20.3.8:** Given the EF Core configuration, When the migration runs, Then the MaintenanceRequests table is created with proper FKs, indexes, and AccountId for multi-tenancy
+
+- **AC-20.3.9:** Given the MaintenanceRequest entity, When queried, Then global query filters apply for AccountId and soft delete (DeletedAt)
+
+**Technical Notes:**
+- Domain: `MaintenanceRequest.cs` entity, `MaintenanceRequestStatus` enum
+- Application: `CreateMaintenanceRequest.cs`, `GetMaintenanceRequests.cs`, `GetMaintenanceRequestById.cs`
+- Validators for create (description required, max length)
+- API: `MaintenanceRequestsController.cs`
+- Tenant endpoint returns requests filtered by PropertyId; landlord endpoint returns all
+- EF Core config: `MaintenanceRequestConfiguration.cs` with indexes on PropertyId, AccountId, Status
+
+---
+
+### Story 20.4: Maintenance Request Photos
+
+**User Story:** As a tenant, I want to attach photos to my maintenance request, so that the landlord can see what's wrong before visiting.
+
+**Source:** FR-TP21
+
+**Acceptance Criteria:**
+
+- **AC-20.4.1:** Given a maintenance request, When a tenant requests a presigned upload URL, Then the system returns an S3 presigned URL scoped to maintenance request photos
+
+- **AC-20.4.2:** Given a photo uploaded to S3, When the tenant confirms the upload, Then a MaintenanceRequestPhoto record is created linking the photo to the request
+
+- **AC-20.4.3:** Given a maintenance request with photos, When anyone views the request, Then presigned download URLs are returned for each photo
+
+- **AC-20.4.4:** Given the MaintenanceRequestPhoto entity, Then it has: Id, MaintenanceRequestId, S3Key, FileName, ContentType, FileSize, DisplayOrder
+
+- **AC-20.4.5:** Given a maintenance request, When photos are queried, Then they are ordered by DisplayOrder
+
+**Technical Notes:**
+- Domain: `MaintenanceRequestPhoto.cs` entity
+- Reuse existing `IStorageService` and presigned URL patterns from receipt/work order photos
+- Application: `GetMaintenanceRequestPhotoUploadUrl.cs`, `ConfirmMaintenanceRequestPhotoUpload.cs`
+- Include photos in `GetMaintenanceRequestById` response
+- S3 key pattern: `accounts/{accountId}/maintenance-requests/{requestId}/photos/{photoId}`
+
+---
+
+### Story 20.5: Tenant Dashboard & Role-Based Routing
+
+**User Story:** As a tenant, I want to log in and see a dashboard showing my property and maintenance requests, so that I can manage my requests without seeing landlord workflows.
+
+**Source:** FR-TP6, FR-TP8, FR-TP9, FR-TP11, NFR-TP5, NFR-TP7
+
+**Acceptance Criteria:**
+
+- **AC-20.5.1:** Given a user with the Tenant role, When they log in, Then they are routed to the tenant dashboard (not the landlord dashboard)
+
+- **AC-20.5.2:** Given a tenant on their dashboard, When the page loads, Then they see their property information (address, name) in read-only format
+
+- **AC-20.5.3:** Given a tenant on their dashboard, When the page loads, Then they see a list of all maintenance requests for their property (submitted by any tenant on that property)
+
+- **AC-20.5.4:** Given a maintenance request in the list, When the tenant views it, Then they see the description, status (Submitted / In Progress / Resolved / Dismissed), and dismissal reason if dismissed
+
+- **AC-20.5.5:** Given a tenant, When they navigate the app, Then the navigation shows only tenant-relevant items (dashboard, submit request) — no properties list, expenses, income, reports, vendors, or work orders
+
+- **AC-20.5.6:** Given a tenant, When they manually navigate to a landlord route (e.g., /expenses), Then the Angular route guard redirects them to the tenant dashboard
+
+- **AC-20.5.7:** Given a landlord user, When they log in, Then they are routed to the existing landlord dashboard as before (no regression)
+
+- **AC-20.5.8:** Given the tenant dashboard, When viewed on a mobile device, Then the layout is mobile-first and usable on small screens
+
+**Technical Notes:**
+- Frontend: `features/tenant-dashboard/` with components, store, routes
+- Angular route guard: `tenantGuard` checks role, redirects non-tenants; `landlordGuard` redirects tenants
+- `app.routes.ts`: role-based route splitting
+- Tenant store fetches property detail + maintenance requests via API
+- Navigation component conditionally renders items based on role from auth service
+- Mobile-first SCSS with responsive breakpoints
+
+---
+
+### Story 20.6: Submit Maintenance Request (Tenant UI)
+
+**User Story:** As a tenant, I want to submit a maintenance request with a description and photos from my phone, so that my landlord knows about the issue.
+
+**Source:** FR-TP7, NFR-TP7, NFR-TP8
+
+**Acceptance Criteria:**
+
+- **AC-20.6.1:** Given a tenant on the dashboard, When they tap "Submit Request", Then a form appears with a description field and photo upload area
+
+- **AC-20.6.2:** Given the submit form, When the tenant enters a description and submits, Then a maintenance request is created with status "Submitted"
+
+- **AC-20.6.3:** Given the submit form, When the tenant attaches photos, Then photos are uploaded to S3 via presigned URLs and linked to the request
+
+- **AC-20.6.4:** Given a successful submission, When the request is created, Then the tenant sees a success notification and the new request appears in their list
+
+- **AC-20.6.5:** Given the submit form on a mobile device, When the tenant taps the photo upload, Then they can choose from camera or photo gallery (native browser behavior)
+
+- **AC-20.6.6:** Given the submit form, When the description is empty, Then validation prevents submission with an error message
+
+- **AC-20.6.7:** Given the submit form, When viewed on mobile, Then the form is mobile-optimized (full-width inputs, large tap targets)
+
+**Technical Notes:**
+- Frontend: `features/tenant-dashboard/components/submit-request/`
+- Reuse photo upload patterns from work order photo upload
+- MatFormField for description (textarea), photo upload component
+- Mobile-first: large touch targets, full-width layout
+- Test on iOS Safari and Android Chrome via Playwright MCP
+
+---
+
+### Story 20.7: Landlord Maintenance Request Inbox
+
+**User Story:** As a landlord, I want a single inbox showing all maintenance requests across my properties, so that I can triage them efficiently.
+
+**Source:** FR-TP12
+
+**Acceptance Criteria:**
+
+- **AC-20.7.1:** Given a landlord user, When they navigate to the maintenance request inbox, Then they see all maintenance requests across all properties in their account
+
+- **AC-20.7.2:** Given the inbox, When requests are listed, Then each request shows: property name/address, description (truncated), submitter name, status, and submission date
+
+- **AC-20.7.3:** Given the inbox, When a landlord clicks a request, Then they see the full request detail including description, photos, status, submitter info, and property info
+
+- **AC-20.7.4:** Given the inbox, When there are many requests, Then the list is paginated
+
+- **AC-20.7.5:** Given the inbox, When requests exist in different statuses, Then requests are visually distinguishable by status (e.g., badges or color coding)
+
+- **AC-20.7.6:** Given the landlord navigation, When the tenant portal is active, Then a "Maintenance Requests" item appears in the landlord navigation
+
+**Technical Notes:**
+- Frontend: `features/maintenance-requests/` with inbox component, detail component, store
+- New nav item for landlords
+- Uses the landlord variant of the GET maintenance requests API (all properties)
+- Status badges using Angular Material chips or similar
+- Paginated list with property grouping or filtering option
+
+---
+
+### Story 20.8: Convert Request to Work Order
+
+**User Story:** As a landlord, I want to convert a maintenance request into a work order, so that I can track the repair through my existing workflow.
+
+**Source:** FR-TP13, FR-TP14, FR-TP16
+
+**Acceptance Criteria:**
+
+- **AC-20.8.1:** Given a maintenance request with status "Submitted", When the landlord clicks "Convert to Work Order", Then the work order creation form opens
+
+- **AC-20.8.2:** Given the work order creation form opened from a conversion, When the form loads, Then the description is pre-populated from the maintenance request
+
+- **AC-20.8.3:** Given the work order creation form opened from a conversion, When the form loads, Then the property is pre-selected from the maintenance request's property
+
+- **AC-20.8.4:** Given a maintenance request with photos, When converting to a work order, Then the photos are copied/linked to the new work order
+
+- **AC-20.8.5:** Given a successful work order creation from conversion, When the work order is saved, Then the maintenance request's WorkOrderId is set and status changes to "InProgress"
+
+- **AC-20.8.6:** Given a maintenance request that has been converted, When the tenant views it, Then the status shows "In Progress"
+
+- **AC-20.8.7:** Given a maintenance request with status other than "Submitted", When the landlord tries to convert it, Then the action is not available
+
+**Technical Notes:**
+- Application: `ConvertMaintenanceRequestToWorkOrder.cs` command — creates work order, links it, updates status
+- Reuse existing `CreateWorkOrder` logic, extend to accept source maintenance request
+- Copy photos from maintenance request S3 path to work order S3 path, or reference same S3 keys
+- Frontend: "Convert to Work Order" button on request detail, navigates to pre-populated work order form
+- Status transition validation in domain entity
+
+---
+
+### Story 20.9: Dismiss Maintenance Request
+
+**User Story:** As a landlord, I want to dismiss a maintenance request with a reason, so that the tenant understands why their request won't be addressed.
+
+**Source:** FR-TP15, FR-TP16
+
+**Acceptance Criteria:**
+
+- **AC-20.9.1:** Given a maintenance request with status "Submitted", When the landlord clicks "Dismiss", Then a dialog appears requiring a dismissal reason
+
+- **AC-20.9.2:** Given the dismissal dialog, When the landlord enters a reason and confirms, Then the maintenance request status changes to "Dismissed" and the reason is stored
+
+- **AC-20.9.3:** Given the dismissal dialog, When the reason field is empty, Then the confirm action is disabled
+
+- **AC-20.9.4:** Given a dismissed maintenance request, When the tenant views it, Then the status shows "Dismissed" and the landlord's reason is displayed
+
+- **AC-20.9.5:** Given a maintenance request with status other than "Submitted", When the landlord tries to dismiss it, Then the action is not available
+
+**Technical Notes:**
+- Application: `DismissMaintenanceRequest.cs` command — sets status to Dismissed, stores reason
+- Validator: DismissalReason required, max length
+- Frontend: dismiss button on request detail, opens confirmation dialog with reason textarea
+- Status transition validation in domain entity (same as 20.8)
+
+---
+
+### Story 20.10: Request Resolution Sync
+
+**User Story:** As a tenant, I want my maintenance request to show "Resolved" when the landlord completes the associated work order, so that I know the issue has been fixed.
+
+**Source:** FR-TP17
+
+**Acceptance Criteria:**
+
+- **AC-20.10.1:** Given a work order linked to a maintenance request, When the work order status changes to "Completed", Then the maintenance request status automatically changes to "Resolved"
+
+- **AC-20.10.2:** Given a work order linked to a maintenance request, When the work order status changes to something other than "Completed" (e.g., Assigned), Then the maintenance request status remains "InProgress"
+
+- **AC-20.10.3:** Given a maintenance request that is "Resolved", When the tenant views it, Then the status shows "Resolved"
+
+- **AC-20.10.4:** Given a work order that is NOT linked to a maintenance request, When the work order is completed, Then no maintenance request status change occurs (backward compatible)
+
+**Technical Notes:**
+- Modify existing `UpdateWorkOrderStatus` handler to check for linked maintenance request
+- When work order → Completed and a linked MaintenanceRequest exists, update request status to Resolved
+- Keep it simple: synchronous update in the same transaction, not event-driven
+- Unit tests for both linked and unlinked work order completion scenarios
+
+---
+
+### Story 20.11: Tenant Authorization Lockdown
+
+**User Story:** As a system owner, I want integration tests proving that tenants cannot access landlord data, so that I have confidence in the security boundary.
+
+**Source:** NFR-TP1, NFR-TP2, NFR-TP3
+
+**Acceptance Criteria:**
+
+- **AC-20.11.1:** Given a user with the Tenant role, When they call GET /api/v1/properties, Then the API returns 403 Forbidden
+
+- **AC-20.11.2:** Given a user with the Tenant role, When they call any expense endpoint (GET, POST, PUT, DELETE), Then the API returns 403 Forbidden
+
+- **AC-20.11.3:** Given a user with the Tenant role, When they call any income endpoint, Then the API returns 403 Forbidden
+
+- **AC-20.11.4:** Given a user with the Tenant role, When they call any report endpoint, Then the API returns 403 Forbidden
+
+- **AC-20.11.5:** Given a user with the Tenant role, When they call any vendor endpoint, Then the API returns 403 Forbidden
+
+- **AC-20.11.6:** Given a user with the Tenant role, When they call any work order endpoint directly, Then the API returns 403 Forbidden
+
+- **AC-20.11.7:** Given a user with the Tenant role, When they call GET /api/v1/maintenance-requests, Then they receive only requests for their property (not other properties in the account)
+
+- **AC-20.11.8:** Given a user with the Tenant role, When they call the convert-to-work-order or dismiss endpoints, Then the API returns 403 Forbidden (these are landlord-only actions)
+
+- **AC-20.11.9:** Given a user with the Tenant role on Property A, When they try to create a maintenance request for Property B, Then the API returns 403 Forbidden
+
+**Technical Notes:**
+- Integration tests using WebApplicationFactory
+- Create test tenant user, authenticate, attempt all landlord endpoints
+- Verify property-scoping: tenant can only see/create for their assigned property
+- These tests serve as a security regression suite — run in CI on every PR

--- a/frontend/src/app/core/auth/owner.guard.spec.ts
+++ b/frontend/src/app/core/auth/owner.guard.spec.ts
@@ -16,6 +16,7 @@ describe('ownerGuard', () => {
       role,
       email: 'test@example.com',
       displayName: 'Test User',
+      propertyId: null,
     };
   }
 

--- a/frontend/src/app/core/auth/permission.service.spec.ts
+++ b/frontend/src/app/core/auth/permission.service.spec.ts
@@ -15,6 +15,7 @@ describe('PermissionService', () => {
       role,
       email: 'test@example.com',
       displayName: 'Test User',
+      propertyId: null,
     };
   }
 
@@ -61,6 +62,28 @@ describe('PermissionService', () => {
     it('should return false for null user', () => {
       currentUserSignal.set(null);
       expect(service.isContributor()).toBe(false);
+    });
+  });
+
+  describe('isTenant', () => {
+    it('should return true for Tenant role', () => {
+      currentUserSignal.set(createUser('Tenant'));
+      expect(service.isTenant()).toBe(true);
+    });
+
+    it('should return false for Owner role', () => {
+      currentUserSignal.set(createUser('Owner'));
+      expect(service.isTenant()).toBe(false);
+    });
+
+    it('should return false for Contributor role', () => {
+      currentUserSignal.set(createUser('Contributor'));
+      expect(service.isTenant()).toBe(false);
+    });
+
+    it('should return false for null user', () => {
+      currentUserSignal.set(null);
+      expect(service.isTenant()).toBe(false);
     });
   });
 
@@ -136,6 +159,47 @@ describe('PermissionService', () => {
     it('should allow Contributor to access /work-orders/123', () => {
       currentUserSignal.set(createUser('Contributor'));
       expect(service.canAccess('/work-orders/123')).toBe(true);
+    });
+
+    // Tenant role — AC: #4 — Tenant denied all landlord routes
+    it('should deny Tenant access to /expenses', () => {
+      currentUserSignal.set(createUser('Tenant'));
+      expect(service.canAccess('/expenses')).toBe(false);
+    });
+
+    it('should deny Tenant access to /properties', () => {
+      currentUserSignal.set(createUser('Tenant'));
+      expect(service.canAccess('/properties')).toBe(false);
+    });
+
+    it('should deny Tenant access to /vendors', () => {
+      currentUserSignal.set(createUser('Tenant'));
+      expect(service.canAccess('/vendors')).toBe(false);
+    });
+
+    it('should deny Tenant access to /reports', () => {
+      currentUserSignal.set(createUser('Tenant'));
+      expect(service.canAccess('/reports')).toBe(false);
+    });
+
+    it('should deny Tenant access to /settings', () => {
+      currentUserSignal.set(createUser('Tenant'));
+      expect(service.canAccess('/settings')).toBe(false);
+    });
+
+    it('should deny Tenant access to /dashboard', () => {
+      currentUserSignal.set(createUser('Tenant'));
+      expect(service.canAccess('/dashboard')).toBe(false);
+    });
+
+    it('should deny Tenant access to /receipts', () => {
+      currentUserSignal.set(createUser('Tenant'));
+      expect(service.canAccess('/receipts')).toBe(false);
+    });
+
+    it('should deny Tenant access to /work-orders', () => {
+      currentUserSignal.set(createUser('Tenant'));
+      expect(service.canAccess('/work-orders')).toBe(false);
     });
 
     // Null user

--- a/frontend/src/app/core/auth/permission.service.ts
+++ b/frontend/src/app/core/auth/permission.service.ts
@@ -19,13 +19,23 @@ export class PermissionService {
   /** True if the current user has the Contributor role */
   readonly isContributor = computed(() => this.authService.currentUser()?.role === 'Contributor');
 
+  /** True if the current user has the Tenant role */
+  readonly isTenant = computed(() => this.authService.currentUser()?.role === 'Tenant');
+
   /**
    * Check if the current user's role allows access to the given route path.
    * Owners can access all routes. Contributors can only access a subset.
+   * Tenants can only access tenant routes (populated in Story 20.5).
    */
   canAccess(route: string): boolean {
     if (this.isOwner()) return true;
     if (!this.authService.currentUser()) return false;
+
+    // Tenant-accessible routes (empty for now, will be populated in Story 20.5)
+    if (this.isTenant()) {
+      const tenantRoutes: string[] = [];
+      return tenantRoutes.some((r) => route === r || route.startsWith(r + '/'));
+    }
 
     // Contributor-accessible routes
     const contributorRoutes = ['/dashboard', '/receipts', '/work-orders'];

--- a/frontend/src/app/core/components/bottom-nav/bottom-nav.component.spec.ts
+++ b/frontend/src/app/core/components/bottom-nav/bottom-nav.component.spec.ts
@@ -28,6 +28,7 @@ describe('BottomNavComponent', () => {
       role,
       email: 'test@example.com',
       displayName: 'Test User',
+      propertyId: null,
     };
 
     TestBed.resetTestingModule();

--- a/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.spec.ts
+++ b/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.spec.ts
@@ -35,6 +35,7 @@ describe('SidebarNavComponent', () => {
       role,
       email: 'test@example.com',
       displayName: 'John Doe',
+      propertyId: null,
     };
 
     mockLogout = vi.fn().mockReturnValue(of(undefined));
@@ -183,6 +184,7 @@ describe('SidebarNavComponent', () => {
         role: 'Owner',
         email: 'fallback@example.com',
         displayName: null,
+        propertyId: null,
       };
 
       const mockAuthServiceNoDisplayName = {
@@ -225,6 +227,7 @@ describe('SidebarNavComponent', () => {
         role: 'Owner',
         email: '',
         displayName: null,
+        propertyId: null,
       };
 
       const mockAuthServiceNoEmail = {

--- a/frontend/src/app/core/services/auth.service.spec.ts
+++ b/frontend/src/app/core/services/auth.service.spec.ts
@@ -20,6 +20,7 @@ describe('AuthService', () => {
     role: 'Owner',
     email: 'test@example.com',
     displayName: 'Test User',
+    propertyId: null,
   };
 
   // Create a mock JWT token (header.payload.signature)
@@ -538,6 +539,28 @@ describe('AuthService', () => {
   });
 
   describe('token decoding edge cases', () => {
+    it('should extract propertyId from JWT payload when present', () => {
+      const tenantUser = { ...mockUser, role: 'Tenant', propertyId: 'prop-789' };
+      const token = createMockToken(tenantUser);
+      const response = { accessToken: token, expiresIn: 3600 };
+
+      service.login('test@example.com', 'password').subscribe();
+      httpMock.expectOne(`${baseUrl}/login`).flush(response);
+
+      expect(service.currentUser()?.propertyId).toBe('prop-789');
+    });
+
+    it('should set propertyId to null when not present in JWT payload', () => {
+      const ownerUser = { ...mockUser, propertyId: undefined };
+      const token = createMockToken(ownerUser);
+      const response = { accessToken: token, expiresIn: 3600 };
+
+      service.login('test@example.com', 'password').subscribe();
+      httpMock.expectOne(`${baseUrl}/login`).flush(response);
+
+      expect(service.currentUser()?.propertyId).toBeNull();
+    });
+
     it('should handle token without displayName', () => {
       const userWithoutDisplayName = { ...mockUser, displayName: undefined };
       const token = createMockToken(userWithoutDisplayName);

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -30,6 +30,7 @@ export interface User {
   role: string;
   email: string;
   displayName: string | null;
+  propertyId: string | null;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -208,6 +209,7 @@ export class AuthService {
         role: payload.role,
         email: payload.email,
         displayName: payload.displayName || null,
+        propertyId: payload.propertyId || null,
       };
     } catch {
       return null;

--- a/frontend/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/features/dashboard/dashboard.component.spec.ts
@@ -22,6 +22,7 @@ describe('DashboardComponent', () => {
     role: 'Owner',
     email: 'test@example.com',
     displayName: 'Test User',
+    propertyId: null,
   };
 
   const mockProperties: PropertySummaryDto[] = [

--- a/frontend/src/app/features/properties/properties.component.spec.ts
+++ b/frontend/src/app/features/properties/properties.component.spec.ts
@@ -34,6 +34,7 @@ describe('PropertiesComponent', () => {
       role,
       email: 'test@example.com',
       displayName: 'Test User',
+      propertyId: null,
     };
   }
 
@@ -122,6 +123,7 @@ describe('PropertiesComponent — Contributor role (AC: #4)', () => {
       role,
       email: 'test@example.com',
       displayName: 'Test User',
+      propertyId: null,
     };
   }
 
@@ -166,6 +168,7 @@ describe('PropertiesComponent loading state', () => {
       role,
       email: 'test@example.com',
       displayName: 'Test User',
+      propertyId: null,
     };
   }
 
@@ -214,6 +217,7 @@ describe('PropertiesComponent error state', () => {
       role,
       email: 'test@example.com',
       displayName: 'Test User',
+      propertyId: null,
     };
   }
 
@@ -264,6 +268,7 @@ describe('PropertiesComponent empty state', () => {
       role,
       email: 'test@example.com',
       displayName: 'Test User',
+      propertyId: null,
     };
   }
 

--- a/frontend/src/app/features/settings/settings.component.spec.ts
+++ b/frontend/src/app/features/settings/settings.component.spec.ts
@@ -84,7 +84,7 @@ describe('SettingsComponent (User Management)', () => {
     };
 
     mockAuthService = {
-      currentUser: signal({ userId: 'u1', accountId: 'a1', role: 'Owner', email: 'owner@example.com', displayName: 'Owner User' }),
+      currentUser: signal({ userId: 'u1', accountId: 'a1', role: 'Owner', email: 'owner@example.com', displayName: 'Owner User', propertyId: null }),
     };
 
     await TestBed.configureTestingModule({


### PR DESCRIPTION
## Summary

- Add **Tenant role** to RolePermissions with exactly 3 permissions: `MaintenanceRequests.Create`, `MaintenanceRequests.ViewOwn`, `Properties.ViewAssigned`
- Add nullable `PropertyId` FK on `ApplicationUser` linking tenant users to their assigned property (EF Core migration included)
- Extend JWT claims with conditional `propertyId` for tenant users; extend `ICurrentUser`, `IPermissionService`, `IJwtService`, `IIdentityService` interfaces
- Update frontend `PermissionService` with `isTenant` computed signal; block tenant access to all landlord routes via `canAccess()`
- 15 new backend tests (permission mappings, JwtService propertyId claim) + 14 new frontend tests (isTenant signal, route blocking, token decoding)

**Epic 20: Tenant Portal — Story 20.1 of 11**

This is the foundational infrastructure story. No new endpoints or UI — it establishes the role, permissions, and data model that all subsequent tenant portal stories build on.

## Test plan

- [x] Backend: 1737 tests passing (13 new permission + 2 new JWT tests)
- [x] Frontend: 2694 tests passing (14 new tests)
- [x] Both `dotnet build` and `ng build` compile cleanly
- [x] EF Core migration applied locally
- [x] Smoke test: existing landlord flows unaffected (login, dashboard, settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)