### PR TITLE
feat: maintenance request photo upload/view/delete API (Story 20.4)

### DIFF
--- a/backend/src/PropertyManager.Api/Controllers/MaintenanceRequestPhotosController.cs
+++ b/backend/src/PropertyManager.Api/Controllers/MaintenanceRequestPhotosController.cs
@@ -1,0 +1,217 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PropertyManager.Application.MaintenanceRequestPhotos;
+
+namespace PropertyManager.Api.Controllers;
+
+/// <summary>
+/// Maintenance request photo management endpoints.
+/// </summary>
+[ApiController]
+[Route("api/v1/maintenance-requests/{maintenanceRequestId:guid}/photos")]
+[Produces("application/json")]
+[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+public class MaintenanceRequestPhotosController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly IValidator<GenerateMaintenanceRequestPhotoUploadUrlCommand> _uploadUrlValidator;
+    private readonly IValidator<ConfirmMaintenanceRequestPhotoUploadCommand> _confirmValidator;
+    private readonly IValidator<DeleteMaintenanceRequestPhotoCommand> _deleteValidator;
+    private readonly ILogger<MaintenanceRequestPhotosController> _logger;
+
+    public MaintenanceRequestPhotosController(
+        IMediator mediator,
+        IValidator<GenerateMaintenanceRequestPhotoUploadUrlCommand> uploadUrlValidator,
+        IValidator<ConfirmMaintenanceRequestPhotoUploadCommand> confirmValidator,
+        IValidator<DeleteMaintenanceRequestPhotoCommand> deleteValidator,
+        ILogger<MaintenanceRequestPhotosController> logger)
+    {
+        _mediator = mediator;
+        _uploadUrlValidator = uploadUrlValidator;
+        _confirmValidator = confirmValidator;
+        _deleteValidator = deleteValidator;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Generate a presigned S3 upload URL for a maintenance request photo.
+    /// </summary>
+    /// <param name="maintenanceRequestId">Maintenance request GUID</param>
+    /// <param name="request">Content type, file size, and original file name</param>
+    /// <returns>Presigned upload URL details</returns>
+    /// <response code="200">Returns presigned upload URL</response>
+    /// <response code="400">If validation fails (invalid content type or file size)</response>
+    /// <response code="401">If user is not authenticated</response>
+    /// <response code="404">If maintenance request not found</response>
+    [HttpPost("upload-url")]
+    [ProducesResponseType(typeof(GenerateMaintenanceRequestPhotoUploadUrlResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GenerateUploadUrl(Guid maintenanceRequestId, [FromBody] MaintenanceRequestPhotoUploadUrlRequest request)
+    {
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(
+            maintenanceRequestId,
+            request.ContentType,
+            request.FileSizeBytes,
+            request.OriginalFileName);
+
+        var validationResult = await _uploadUrlValidator.ValidateAsync(command);
+        if (!validationResult.IsValid)
+        {
+            var problemDetails = CreateValidationProblemDetails(validationResult);
+            return BadRequest(problemDetails);
+        }
+
+        var response = await _mediator.Send(command);
+
+        _logger.LogInformation(
+            "Generated maintenance request photo upload URL: MaintenanceRequestId={MaintenanceRequestId}, StorageKey={StorageKey}",
+            maintenanceRequestId,
+            response.StorageKey);
+
+        return Ok(response);
+    }
+
+    /// <summary>
+    /// Confirm a maintenance request photo upload and create record.
+    /// Auto-sets IsPrimary=true if this is the first photo for the maintenance request.
+    /// </summary>
+    /// <param name="maintenanceRequestId">Maintenance request GUID</param>
+    /// <param name="request">Storage keys, content type, file size, and original file name</param>
+    /// <returns>Created photo details with URLs</returns>
+    /// <response code="201">Returns created photo details</response>
+    /// <response code="400">If validation fails</response>
+    /// <response code="401">If user is not authenticated</response>
+    /// <response code="404">If maintenance request not found</response>
+    [HttpPost]
+    [ProducesResponseType(typeof(ConfirmMaintenanceRequestPhotoUploadResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ConfirmUpload(Guid maintenanceRequestId, [FromBody] MaintenanceRequestPhotoConfirmRequest request)
+    {
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            maintenanceRequestId,
+            request.StorageKey,
+            request.ThumbnailStorageKey,
+            request.ContentType,
+            request.FileSizeBytes,
+            request.OriginalFileName);
+
+        var validationResult = await _confirmValidator.ValidateAsync(command);
+        if (!validationResult.IsValid)
+        {
+            var problemDetails = CreateValidationProblemDetails(validationResult);
+            return BadRequest(problemDetails);
+        }
+
+        var response = await _mediator.Send(command);
+
+        _logger.LogInformation(
+            "Confirmed maintenance request photo upload: MaintenanceRequestId={MaintenanceRequestId}, PhotoId={PhotoId}",
+            maintenanceRequestId,
+            response.Id);
+
+        return Created($"/api/v1/maintenance-requests/{maintenanceRequestId}/photos/{response.Id}", response);
+    }
+
+    /// <summary>
+    /// Get all photos for a maintenance request ordered by DisplayOrder.
+    /// </summary>
+    /// <param name="maintenanceRequestId">Maintenance request GUID</param>
+    /// <returns>List of photos with presigned view URLs</returns>
+    /// <response code="200">Returns list of photos</response>
+    /// <response code="401">If user is not authenticated</response>
+    /// <response code="404">If maintenance request not found</response>
+    [HttpGet]
+    [ProducesResponseType(typeof(GetMaintenanceRequestPhotosResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPhotos(Guid maintenanceRequestId)
+    {
+        var query = new GetMaintenanceRequestPhotosQuery(maintenanceRequestId);
+        var response = await _mediator.Send(query);
+
+        _logger.LogInformation(
+            "Retrieved {Count} photos for maintenance request: {MaintenanceRequestId}",
+            response.Items.Count,
+            maintenanceRequestId);
+
+        return Ok(response);
+    }
+
+    /// <summary>
+    /// Delete a maintenance request photo.
+    /// If deleted photo was primary, promotes next photo by DisplayOrder.
+    /// </summary>
+    /// <param name="maintenanceRequestId">Maintenance request GUID</param>
+    /// <param name="photoId">Photo GUID</param>
+    /// <returns>No content on success</returns>
+    /// <response code="204">Photo deleted successfully</response>
+    /// <response code="401">If user is not authenticated</response>
+    /// <response code="404">If maintenance request or photo not found</response>
+    [HttpDelete("{photoId:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeletePhoto(Guid maintenanceRequestId, Guid photoId)
+    {
+        var command = new DeleteMaintenanceRequestPhotoCommand(maintenanceRequestId, photoId);
+
+        var validationResult = await _deleteValidator.ValidateAsync(command);
+        if (!validationResult.IsValid)
+        {
+            var problemDetails = CreateValidationProblemDetails(validationResult);
+            return BadRequest(problemDetails);
+        }
+
+        await _mediator.Send(command);
+
+        _logger.LogInformation(
+            "Deleted maintenance request photo: MaintenanceRequestId={MaintenanceRequestId}, PhotoId={PhotoId}",
+            maintenanceRequestId,
+            photoId);
+
+        return NoContent();
+    }
+
+    private ValidationProblemDetails CreateValidationProblemDetails(FluentValidation.Results.ValidationResult validationResult)
+    {
+        var errors = validationResult.Errors
+            .GroupBy(e => e.PropertyName)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(e => e.ErrorMessage).ToArray());
+
+        return new ValidationProblemDetails(errors)
+        {
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+            Title = "One or more validation errors occurred.",
+            Status = StatusCodes.Status400BadRequest,
+            Instance = HttpContext.Request.Path,
+            Extensions = { ["traceId"] = HttpContext.TraceIdentifier }
+        };
+    }
+}
+
+/// <summary>
+/// Request model for generating a maintenance request photo upload URL.
+/// </summary>
+public record MaintenanceRequestPhotoUploadUrlRequest(
+    string ContentType,
+    long FileSizeBytes,
+    string OriginalFileName);
+
+/// <summary>
+/// Request model for confirming a maintenance request photo upload.
+/// </summary>
+public record MaintenanceRequestPhotoConfirmRequest(
+    string StorageKey,
+    string ThumbnailStorageKey,
+    string ContentType,
+    long FileSizeBytes,
+    string OriginalFileName);

--- a/backend/src/PropertyManager.Application/Common/Interfaces/IAppDbContext.cs
+++ b/backend/src/PropertyManager.Application/Common/Interfaces/IAppDbContext.cs
@@ -32,6 +32,7 @@ public interface IAppDbContext
     DbSet<Note> Notes { get; }
     DbSet<VendorPhoto> VendorPhotos { get; }
     DbSet<MaintenanceRequest> MaintenanceRequests { get; }
+    DbSet<MaintenanceRequestPhoto> MaintenanceRequestPhotos { get; }
 
     /// <summary>
     /// Provides access to database-related information and operations (e.g., transactions).

--- a/backend/src/PropertyManager.Application/Common/Interfaces/IPhotoService.cs
+++ b/backend/src/PropertyManager.Application/Common/Interfaces/IPhotoService.cs
@@ -9,7 +9,8 @@ public enum PhotoEntityType
     Properties,
     Vendors,
     Users,
-    WorkOrders
+    WorkOrders,
+    MaintenanceRequests
 }
 
 /// <summary>

--- a/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUpload.cs
+++ b/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUpload.cs
@@ -1,0 +1,141 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Response model for confirmed maintenance request photo upload.
+/// </summary>
+public record ConfirmMaintenanceRequestPhotoUploadResponse(
+    Guid Id,
+    string? ThumbnailUrl,
+    string? ViewUrl);
+
+/// <summary>
+/// Command to confirm a maintenance request photo upload and create MaintenanceRequestPhoto record.
+/// Auto-sets IsPrimary=true if this is the first photo for the maintenance request.
+/// </summary>
+public record ConfirmMaintenanceRequestPhotoUploadCommand(
+    Guid MaintenanceRequestId,
+    string StorageKey,
+    string ThumbnailStorageKey,
+    string ContentType,
+    long FileSizeBytes,
+    string OriginalFileName
+) : IRequest<ConfirmMaintenanceRequestPhotoUploadResponse>;
+
+/// <summary>
+/// Handler for ConfirmMaintenanceRequestPhotoUploadCommand.
+/// Creates MaintenanceRequestPhoto record with auto-primary logic for first photo.
+/// </summary>
+public class ConfirmMaintenanceRequestPhotoUploadHandler : IRequestHandler<ConfirmMaintenanceRequestPhotoUploadCommand, ConfirmMaintenanceRequestPhotoUploadResponse>
+{
+    private readonly IPhotoService _photoService;
+    private readonly IAppDbContext _dbContext;
+    private readonly ICurrentUser _currentUser;
+
+    public ConfirmMaintenanceRequestPhotoUploadHandler(
+        IPhotoService photoService,
+        IAppDbContext dbContext,
+        ICurrentUser currentUser)
+    {
+        _photoService = photoService;
+        _dbContext = dbContext;
+        _currentUser = currentUser;
+    }
+
+    public async Task<ConfirmMaintenanceRequestPhotoUploadResponse> Handle(
+        ConfirmMaintenanceRequestPhotoUploadCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Verify maintenance request exists and belongs to user's account
+        var maintenanceRequest = await _dbContext.MaintenanceRequests
+            .Where(mr => mr.Id == request.MaintenanceRequestId
+                && mr.AccountId == _currentUser.AccountId
+                && mr.DeletedAt == null)
+            .Select(mr => new { mr.Id, mr.PropertyId })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (maintenanceRequest is null)
+        {
+            throw new NotFoundException(nameof(MaintenanceRequest), request.MaintenanceRequestId);
+        }
+
+        // Tenant users can only access requests on their assigned property
+        if (_currentUser.Role == "Tenant" && _currentUser.PropertyId.HasValue
+            && maintenanceRequest.PropertyId != _currentUser.PropertyId.Value)
+        {
+            throw new NotFoundException(nameof(MaintenanceRequest), request.MaintenanceRequestId);
+        }
+
+        // Validate storage key belongs to current user's account
+        var keyParts = request.StorageKey.Split('/');
+        if (keyParts.Length < 1 || !Guid.TryParse(keyParts[0], out var keyAccountId))
+        {
+            throw new ArgumentException("Invalid storage key format", nameof(request.StorageKey));
+        }
+
+        if (keyAccountId != _currentUser.AccountId)
+        {
+            throw new UnauthorizedAccessException("Cannot confirm upload for another account");
+        }
+
+        // Confirm upload and generate thumbnail via IPhotoService
+        var confirmRequest = new ConfirmPhotoUploadRequest(
+            request.StorageKey,
+            request.ThumbnailStorageKey);
+
+        var photoRecord = await _photoService.ConfirmUploadAsync(
+            confirmRequest,
+            request.ContentType,
+            request.FileSizeBytes,
+            cancellationToken);
+
+        // Check if this is the first photo for the maintenance request (auto-primary logic)
+        var existingPhotoCount = await _dbContext.MaintenanceRequestPhotos
+            .CountAsync(p => p.MaintenanceRequestId == request.MaintenanceRequestId, cancellationToken);
+
+        var isFirstPhoto = existingPhotoCount == 0;
+
+        // Determine DisplayOrder (next in sequence)
+        var maxDisplayOrder = await _dbContext.MaintenanceRequestPhotos
+            .Where(p => p.MaintenanceRequestId == request.MaintenanceRequestId)
+            .MaxAsync(p => (int?)p.DisplayOrder, cancellationToken) ?? -1;
+
+        var photo = new MaintenanceRequestPhoto
+        {
+            AccountId = _currentUser.AccountId,
+            MaintenanceRequestId = request.MaintenanceRequestId,
+            StorageKey = photoRecord.StorageKey,
+            ThumbnailStorageKey = photoRecord.ThumbnailStorageKey,
+            OriginalFileName = request.OriginalFileName,
+            ContentType = photoRecord.ContentType,
+            FileSizeBytes = photoRecord.FileSizeBytes,
+            DisplayOrder = maxDisplayOrder + 1,
+            IsPrimary = isFirstPhoto,
+            CreatedByUserId = _currentUser.UserId
+        };
+
+        _dbContext.MaintenanceRequestPhotos.Add(photo);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        // Generate presigned URLs for response
+        string? thumbnailUrl = null;
+        string? viewUrl = null;
+
+        if (!string.IsNullOrEmpty(photo.ThumbnailStorageKey))
+        {
+            thumbnailUrl = await _photoService.GetThumbnailUrlAsync(photo.ThumbnailStorageKey, cancellationToken);
+        }
+
+        viewUrl = await _photoService.GetPhotoUrlAsync(photo.StorageKey, cancellationToken);
+
+        return new ConfirmMaintenanceRequestPhotoUploadResponse(
+            Id: photo.Id,
+            ThumbnailUrl: thumbnailUrl,
+            ViewUrl: viewUrl);
+    }
+}

--- a/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUploadValidator.cs
+++ b/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUploadValidator.cs
@@ -1,0 +1,46 @@
+using FluentValidation;
+using PropertyManager.Application.Common.Interfaces;
+
+namespace PropertyManager.Application.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Validator for ConfirmMaintenanceRequestPhotoUploadCommand.
+/// </summary>
+public class ConfirmMaintenanceRequestPhotoUploadValidator : AbstractValidator<ConfirmMaintenanceRequestPhotoUploadCommand>
+{
+    public ConfirmMaintenanceRequestPhotoUploadValidator()
+    {
+        RuleFor(x => x.MaintenanceRequestId)
+            .NotEmpty().WithMessage("Maintenance request ID is required");
+
+        RuleFor(x => x.StorageKey)
+            .NotEmpty().WithMessage("Storage key is required")
+            .MaximumLength(500).WithMessage("Storage key must not exceed 500 characters");
+
+        RuleFor(x => x.ThumbnailStorageKey)
+            .NotEmpty().WithMessage("Thumbnail storage key is required")
+            .MaximumLength(500).WithMessage("Thumbnail storage key must not exceed 500 characters");
+
+        RuleFor(x => x.ContentType)
+            .NotEmpty().WithMessage("Content type is required")
+            .Must(BeAllowedContentType)
+            .WithMessage($"Content type must be one of: {string.Join(", ", PhotoValidation.AllowedContentTypes)}");
+
+        RuleFor(x => x.FileSizeBytes)
+            .GreaterThan(0).WithMessage("File size must be greater than 0")
+            .LessThanOrEqualTo(PhotoValidation.MaxFileSizeBytes)
+            .WithMessage($"File size must not exceed {PhotoValidation.MaxFileSizeBytes / (1024 * 1024)}MB");
+
+        RuleFor(x => x.OriginalFileName)
+            .NotEmpty().WithMessage("Original file name is required")
+            .MaximumLength(255).WithMessage("File name must not exceed 255 characters");
+    }
+
+    private static bool BeAllowedContentType(string contentType)
+    {
+        if (string.IsNullOrEmpty(contentType))
+            return false;
+
+        return PhotoValidation.AllowedContentTypes.Contains(contentType);
+    }
+}

--- a/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhoto.cs
+++ b/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhoto.cs
@@ -1,0 +1,101 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Command to delete a maintenance request photo.
+/// If deleted photo was primary, promotes next photo by DisplayOrder.
+/// </summary>
+public record DeleteMaintenanceRequestPhotoCommand(
+    Guid MaintenanceRequestId,
+    Guid PhotoId
+) : IRequest;
+
+/// <summary>
+/// Handler for DeleteMaintenanceRequestPhotoCommand.
+/// Removes photo from S3 and DB, promotes next photo if deleted was primary.
+/// </summary>
+public class DeleteMaintenanceRequestPhotoHandler : IRequestHandler<DeleteMaintenanceRequestPhotoCommand>
+{
+    private readonly IPhotoService _photoService;
+    private readonly IAppDbContext _dbContext;
+    private readonly ICurrentUser _currentUser;
+
+    public DeleteMaintenanceRequestPhotoHandler(
+        IPhotoService photoService,
+        IAppDbContext dbContext,
+        ICurrentUser currentUser)
+    {
+        _photoService = photoService;
+        _dbContext = dbContext;
+        _currentUser = currentUser;
+    }
+
+    public async Task Handle(
+        DeleteMaintenanceRequestPhotoCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Verify maintenance request exists and enforce tenant property scoping
+        var maintenanceRequest = await _dbContext.MaintenanceRequests
+            .Where(mr => mr.Id == request.MaintenanceRequestId
+                && mr.AccountId == _currentUser.AccountId
+                && mr.DeletedAt == null)
+            .Select(mr => new { mr.Id, mr.PropertyId })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (maintenanceRequest is null)
+        {
+            throw new NotFoundException(nameof(MaintenanceRequest), request.MaintenanceRequestId);
+        }
+
+        // Tenant users can only access requests on their assigned property
+        if (_currentUser.Role == "Tenant" && _currentUser.PropertyId.HasValue
+            && maintenanceRequest.PropertyId != _currentUser.PropertyId.Value)
+        {
+            throw new NotFoundException(nameof(MaintenanceRequest), request.MaintenanceRequestId);
+        }
+
+        // Find the photo and verify it belongs to user's account
+        var photo = await _dbContext.MaintenanceRequestPhotos
+            .FirstOrDefaultAsync(p => p.Id == request.PhotoId
+                && p.MaintenanceRequestId == request.MaintenanceRequestId
+                && p.AccountId == _currentUser.AccountId, cancellationToken);
+
+        if (photo == null)
+        {
+            throw new NotFoundException(nameof(MaintenanceRequestPhoto), request.PhotoId);
+        }
+
+        var wasPrimary = photo.IsPrimary;
+        var maintenanceRequestId = photo.MaintenanceRequestId;
+
+        // Delete from S3
+        await _photoService.DeletePhotoAsync(
+            photo.StorageKey,
+            photo.ThumbnailStorageKey,
+            cancellationToken);
+
+        // Delete from DB
+        _dbContext.MaintenanceRequestPhotos.Remove(photo);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        // If deleted photo was primary, promote next photo by DisplayOrder
+        if (wasPrimary)
+        {
+            var nextPhoto = await _dbContext.MaintenanceRequestPhotos
+                .Where(p => p.MaintenanceRequestId == maintenanceRequestId)
+                .OrderBy(p => p.DisplayOrder)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (nextPhoto != null)
+            {
+                nextPhoto.IsPrimary = true;
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+    }
+}

--- a/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhotoValidator.cs
+++ b/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhotoValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace PropertyManager.Application.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Validator for DeleteMaintenanceRequestPhotoCommand.
+/// </summary>
+public class DeleteMaintenanceRequestPhotoValidator : AbstractValidator<DeleteMaintenanceRequestPhotoCommand>
+{
+    public DeleteMaintenanceRequestPhotoValidator()
+    {
+        RuleFor(x => x.MaintenanceRequestId)
+            .NotEmpty().WithMessage("Maintenance request ID is required");
+
+        RuleFor(x => x.PhotoId)
+            .NotEmpty().WithMessage("Photo ID is required");
+    }
+}

--- a/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrl.cs
+++ b/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrl.cs
@@ -1,0 +1,91 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Response model containing presigned upload URL details for maintenance request photos.
+/// </summary>
+public record GenerateMaintenanceRequestPhotoUploadUrlResponse(
+    string UploadUrl,
+    string StorageKey,
+    string ThumbnailStorageKey,
+    DateTime ExpiresAt);
+
+/// <summary>
+/// Command to generate a presigned upload URL for a maintenance request photo.
+/// </summary>
+public record GenerateMaintenanceRequestPhotoUploadUrlCommand(
+    Guid MaintenanceRequestId,
+    string ContentType,
+    long FileSizeBytes,
+    string OriginalFileName
+) : IRequest<GenerateMaintenanceRequestPhotoUploadUrlResponse>;
+
+/// <summary>
+/// Handler for GenerateMaintenanceRequestPhotoUploadUrlCommand.
+/// Uses IPhotoService to generate presigned upload URL after verifying maintenance request ownership.
+/// Tenant users can only access requests on their assigned property.
+/// </summary>
+public class GenerateMaintenanceRequestPhotoUploadUrlHandler : IRequestHandler<GenerateMaintenanceRequestPhotoUploadUrlCommand, GenerateMaintenanceRequestPhotoUploadUrlResponse>
+{
+    private readonly IPhotoService _photoService;
+    private readonly IAppDbContext _dbContext;
+    private readonly ICurrentUser _currentUser;
+
+    public GenerateMaintenanceRequestPhotoUploadUrlHandler(
+        IPhotoService photoService,
+        IAppDbContext dbContext,
+        ICurrentUser currentUser)
+    {
+        _photoService = photoService;
+        _dbContext = dbContext;
+        _currentUser = currentUser;
+    }
+
+    public async Task<GenerateMaintenanceRequestPhotoUploadUrlResponse> Handle(
+        GenerateMaintenanceRequestPhotoUploadUrlCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Verify maintenance request exists and belongs to user's account
+        var maintenanceRequest = await _dbContext.MaintenanceRequests
+            .Where(mr => mr.Id == request.MaintenanceRequestId
+                && mr.AccountId == _currentUser.AccountId
+                && mr.DeletedAt == null)
+            .Select(mr => new { mr.Id, mr.PropertyId })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (maintenanceRequest is null)
+        {
+            throw new NotFoundException(nameof(MaintenanceRequest), request.MaintenanceRequestId);
+        }
+
+        // Tenant users can only access requests on their assigned property
+        if (_currentUser.Role == "Tenant" && _currentUser.PropertyId.HasValue
+            && maintenanceRequest.PropertyId != _currentUser.PropertyId.Value)
+        {
+            throw new NotFoundException(nameof(MaintenanceRequest), request.MaintenanceRequestId);
+        }
+
+        var photoRequest = new PhotoUploadRequest(
+            PhotoEntityType.MaintenanceRequests,
+            request.MaintenanceRequestId,
+            request.ContentType,
+            request.FileSizeBytes,
+            request.OriginalFileName);
+
+        var result = await _photoService.GenerateUploadUrlAsync(
+            _currentUser.AccountId,
+            photoRequest,
+            cancellationToken);
+
+        return new GenerateMaintenanceRequestPhotoUploadUrlResponse(
+            UploadUrl: result.UploadUrl,
+            StorageKey: result.StorageKey,
+            ThumbnailStorageKey: result.ThumbnailStorageKey,
+            ExpiresAt: result.ExpiresAt);
+    }
+}

--- a/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrlValidator.cs
+++ b/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrlValidator.cs
@@ -1,0 +1,39 @@
+using FluentValidation;
+using PropertyManager.Application.Common.Interfaces;
+
+namespace PropertyManager.Application.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Validator for GenerateMaintenanceRequestPhotoUploadUrlCommand.
+/// Uses PhotoValidation constants for consistency.
+/// </summary>
+public class GenerateMaintenanceRequestPhotoUploadUrlValidator : AbstractValidator<GenerateMaintenanceRequestPhotoUploadUrlCommand>
+{
+    public GenerateMaintenanceRequestPhotoUploadUrlValidator()
+    {
+        RuleFor(x => x.MaintenanceRequestId)
+            .NotEmpty().WithMessage("Maintenance request ID is required");
+
+        RuleFor(x => x.ContentType)
+            .NotEmpty().WithMessage("Content type is required")
+            .Must(BeAllowedContentType)
+            .WithMessage($"Content type must be one of: {string.Join(", ", PhotoValidation.AllowedContentTypes)}");
+
+        RuleFor(x => x.FileSizeBytes)
+            .GreaterThan(0).WithMessage("File size must be greater than 0")
+            .LessThanOrEqualTo(PhotoValidation.MaxFileSizeBytes)
+            .WithMessage($"File size must not exceed {PhotoValidation.MaxFileSizeBytes / (1024 * 1024)}MB");
+
+        RuleFor(x => x.OriginalFileName)
+            .NotEmpty().WithMessage("Original file name is required")
+            .MaximumLength(255).WithMessage("File name must not exceed 255 characters");
+    }
+
+    private static bool BeAllowedContentType(string contentType)
+    {
+        if (string.IsNullOrEmpty(contentType))
+            return false;
+
+        return PhotoValidation.AllowedContentTypes.Contains(contentType);
+    }
+}

--- a/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GetMaintenanceRequestPhotos.cs
+++ b/backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GetMaintenanceRequestPhotos.cs
@@ -1,0 +1,130 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.MaintenanceRequestPhotos;
+
+/// <summary>
+/// DTO for maintenance request photo in list response.
+/// Reused by GetMaintenanceRequestById detail endpoint.
+/// </summary>
+public record MaintenanceRequestPhotoDto(
+    Guid Id,
+    string? ThumbnailUrl,
+    string? ViewUrl,
+    bool IsPrimary,
+    int DisplayOrder,
+    string? OriginalFileName,
+    long? FileSizeBytes,
+    DateTime CreatedAt);
+
+/// <summary>
+/// Response model for GetMaintenanceRequestPhotos query.
+/// </summary>
+public record GetMaintenanceRequestPhotosResponse(
+    IReadOnlyList<MaintenanceRequestPhotoDto> Items);
+
+/// <summary>
+/// Query to get all photos for a maintenance request ordered by DisplayOrder.
+/// Includes presigned view URLs.
+/// </summary>
+public record GetMaintenanceRequestPhotosQuery(
+    Guid MaintenanceRequestId
+) : IRequest<GetMaintenanceRequestPhotosResponse>;
+
+/// <summary>
+/// Handler for GetMaintenanceRequestPhotosQuery.
+/// Returns all photos for the maintenance request with presigned URLs.
+/// </summary>
+public class GetMaintenanceRequestPhotosHandler : IRequestHandler<GetMaintenanceRequestPhotosQuery, GetMaintenanceRequestPhotosResponse>
+{
+    private readonly IPhotoService _photoService;
+    private readonly IAppDbContext _dbContext;
+    private readonly ICurrentUser _currentUser;
+
+    public GetMaintenanceRequestPhotosHandler(
+        IPhotoService photoService,
+        IAppDbContext dbContext,
+        ICurrentUser currentUser)
+    {
+        _photoService = photoService;
+        _dbContext = dbContext;
+        _currentUser = currentUser;
+    }
+
+    public async Task<GetMaintenanceRequestPhotosResponse> Handle(
+        GetMaintenanceRequestPhotosQuery request,
+        CancellationToken cancellationToken)
+    {
+        // Verify maintenance request exists and belongs to user's account
+        var maintenanceRequest = await _dbContext.MaintenanceRequests
+            .Where(mr => mr.Id == request.MaintenanceRequestId
+                && mr.AccountId == _currentUser.AccountId
+                && mr.DeletedAt == null)
+            .Select(mr => new { mr.Id, mr.PropertyId })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (maintenanceRequest is null)
+        {
+            throw new NotFoundException(nameof(MaintenanceRequest), request.MaintenanceRequestId);
+        }
+
+        // Tenant users can only access requests on their assigned property
+        if (_currentUser.Role == "Tenant" && _currentUser.PropertyId.HasValue
+            && maintenanceRequest.PropertyId != _currentUser.PropertyId.Value)
+        {
+            throw new NotFoundException(nameof(MaintenanceRequest), request.MaintenanceRequestId);
+        }
+
+        // Get all photos ordered by DisplayOrder
+        var photos = await _dbContext.MaintenanceRequestPhotos
+            .Where(p => p.MaintenanceRequestId == request.MaintenanceRequestId && p.AccountId == _currentUser.AccountId)
+            .OrderBy(p => p.DisplayOrder)
+            .Select(p => new
+            {
+                p.Id,
+                p.StorageKey,
+                p.ThumbnailStorageKey,
+                p.IsPrimary,
+                p.DisplayOrder,
+                p.OriginalFileName,
+                p.FileSizeBytes,
+                p.CreatedAt
+            })
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        // Generate presigned URLs for each photo in parallel for better performance
+        var urlTasks = photos.Select(async photo =>
+        {
+            string? thumbnailUrl = null;
+            string? viewUrl = null;
+
+            if (!string.IsNullOrEmpty(photo.ThumbnailStorageKey))
+            {
+                thumbnailUrl = await _photoService.GetThumbnailUrlAsync(photo.ThumbnailStorageKey, cancellationToken);
+            }
+
+            if (!string.IsNullOrEmpty(photo.StorageKey))
+            {
+                viewUrl = await _photoService.GetPhotoUrlAsync(photo.StorageKey, cancellationToken);
+            }
+
+            return new MaintenanceRequestPhotoDto(
+                Id: photo.Id,
+                ThumbnailUrl: thumbnailUrl,
+                ViewUrl: viewUrl,
+                IsPrimary: photo.IsPrimary,
+                DisplayOrder: photo.DisplayOrder,
+                OriginalFileName: photo.OriginalFileName,
+                FileSizeBytes: photo.FileSizeBytes,
+                CreatedAt: photo.CreatedAt);
+        }).ToList();
+
+        var photoDtos = await Task.WhenAll(urlTasks);
+
+        return new GetMaintenanceRequestPhotosResponse(photoDtos.ToList());
+    }
+}

--- a/backend/src/PropertyManager.Application/MaintenanceRequests/GetMaintenanceRequestById.cs
+++ b/backend/src/PropertyManager.Application/MaintenanceRequests/GetMaintenanceRequestById.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.MaintenanceRequestPhotos;
 using PropertyManager.Domain.Exceptions;
 
 namespace PropertyManager.Application.MaintenanceRequests;
@@ -20,15 +21,18 @@ public class GetMaintenanceRequestByIdQueryHandler : IRequestHandler<GetMaintena
     private readonly IAppDbContext _dbContext;
     private readonly ICurrentUser _currentUser;
     private readonly IIdentityService _identityService;
+    private readonly IPhotoService _photoService;
 
     public GetMaintenanceRequestByIdQueryHandler(
         IAppDbContext dbContext,
         ICurrentUser currentUser,
-        IIdentityService identityService)
+        IIdentityService identityService,
+        IPhotoService photoService)
     {
         _dbContext = dbContext;
         _currentUser = currentUser;
         _identityService = identityService;
+        _photoService = photoService;
     }
 
     public async Task<MaintenanceRequestDto> Handle(GetMaintenanceRequestByIdQuery request, CancellationToken cancellationToken)
@@ -38,6 +42,7 @@ public class GetMaintenanceRequestByIdQueryHandler : IRequestHandler<GetMaintena
                 && mr.AccountId == _currentUser.AccountId
                 && mr.DeletedAt == null)
             .Include(mr => mr.Property)
+            .Include(mr => mr.Photos)
             .AsNoTracking()
             .FirstOrDefaultAsync(cancellationToken);
 
@@ -57,6 +62,43 @@ public class GetMaintenanceRequestByIdQueryHandler : IRequestHandler<GetMaintena
         var displayNames = await _identityService.GetUserDisplayNamesAsync(
             new[] { maintenanceRequest.SubmittedByUserId }, cancellationToken);
 
+        // Generate presigned URLs for photos in parallel
+        var photos = maintenanceRequest.Photos
+            .OrderBy(p => p.DisplayOrder)
+            .ToList();
+
+        var photoDtos = new List<MaintenanceRequestPhotoDto>();
+        if (photos.Count > 0)
+        {
+            var urlTasks = photos.Select(async photo =>
+            {
+                string? thumbnailUrl = null;
+                string? viewUrl = null;
+
+                if (!string.IsNullOrEmpty(photo.ThumbnailStorageKey))
+                {
+                    thumbnailUrl = await _photoService.GetThumbnailUrlAsync(photo.ThumbnailStorageKey, cancellationToken);
+                }
+
+                if (!string.IsNullOrEmpty(photo.StorageKey))
+                {
+                    viewUrl = await _photoService.GetPhotoUrlAsync(photo.StorageKey, cancellationToken);
+                }
+
+                return new MaintenanceRequestPhotoDto(
+                    Id: photo.Id,
+                    ThumbnailUrl: thumbnailUrl,
+                    ViewUrl: viewUrl,
+                    IsPrimary: photo.IsPrimary,
+                    DisplayOrder: photo.DisplayOrder,
+                    OriginalFileName: photo.OriginalFileName,
+                    FileSizeBytes: photo.FileSizeBytes,
+                    CreatedAt: photo.CreatedAt);
+            }).ToList();
+
+            photoDtos.AddRange(await Task.WhenAll(urlTasks));
+        }
+
         return new MaintenanceRequestDto(
             maintenanceRequest.Id,
             maintenanceRequest.PropertyId,
@@ -69,7 +111,8 @@ public class GetMaintenanceRequestByIdQueryHandler : IRequestHandler<GetMaintena
             displayNames.GetValueOrDefault(maintenanceRequest.SubmittedByUserId),
             maintenanceRequest.WorkOrderId,
             maintenanceRequest.CreatedAt,
-            maintenanceRequest.UpdatedAt
+            maintenanceRequest.UpdatedAt,
+            Photos: photoDtos
         );
     }
 }

--- a/backend/src/PropertyManager.Application/MaintenanceRequests/MaintenanceRequestDto.cs
+++ b/backend/src/PropertyManager.Application/MaintenanceRequests/MaintenanceRequestDto.cs
@@ -1,3 +1,5 @@
+using PropertyManager.Application.MaintenanceRequestPhotos;
+
 namespace PropertyManager.Application.MaintenanceRequests;
 
 /// <summary>
@@ -15,5 +17,6 @@ public record MaintenanceRequestDto(
     string? SubmittedByUserName,
     Guid? WorkOrderId,
     DateTime CreatedAt,
-    DateTime UpdatedAt
+    DateTime UpdatedAt,
+    IReadOnlyList<MaintenanceRequestPhotoDto>? Photos = null
 );

--- a/backend/src/PropertyManager.Domain/Entities/MaintenanceRequest.cs
+++ b/backend/src/PropertyManager.Domain/Entities/MaintenanceRequest.cs
@@ -25,6 +25,7 @@ public class MaintenanceRequest : AuditableEntity, ITenantEntity, ISoftDeletable
     public Account Account { get; set; } = null!;
     public Property Property { get; set; } = null!;
     public WorkOrder? WorkOrder { get; set; }
+    public ICollection<MaintenanceRequestPhoto> Photos { get; set; } = new List<MaintenanceRequestPhoto>();
 
     /// <summary>
     /// Transitions the maintenance request to a new status.

--- a/backend/src/PropertyManager.Domain/Entities/MaintenanceRequestPhoto.cs
+++ b/backend/src/PropertyManager.Domain/Entities/MaintenanceRequestPhoto.cs
@@ -1,0 +1,25 @@
+using PropertyManager.Domain.Common;
+
+namespace PropertyManager.Domain.Entities;
+
+/// <summary>
+/// Maintenance request photo entity for storing photos attached to maintenance requests.
+/// Supports display ordering and primary photo designation.
+/// </summary>
+public class MaintenanceRequestPhoto : AuditableEntity, ITenantEntity
+{
+    public Guid AccountId { get; set; }
+    public Guid MaintenanceRequestId { get; set; }
+    public string StorageKey { get; set; } = string.Empty;
+    public string? ThumbnailStorageKey { get; set; }
+    public string? OriginalFileName { get; set; }
+    public string? ContentType { get; set; }
+    public long? FileSizeBytes { get; set; }
+    public int DisplayOrder { get; set; }
+    public bool IsPrimary { get; set; }
+    public Guid CreatedByUserId { get; set; }
+
+    // Navigation properties
+    public Account Account { get; set; } = null!;
+    public MaintenanceRequest MaintenanceRequest { get; set; } = null!;
+}

--- a/backend/src/PropertyManager.Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/PropertyManager.Infrastructure/Persistence/AppDbContext.cs
@@ -52,6 +52,7 @@ public class AppDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid
     public DbSet<Note> Notes => Set<Note>();
     public DbSet<VendorPhoto> VendorPhotos => Set<VendorPhoto>();
     public DbSet<MaintenanceRequest> MaintenanceRequests => Set<MaintenanceRequest>();
+    public DbSet<MaintenanceRequestPhoto> MaintenanceRequestPhotos => Set<MaintenanceRequestPhoto>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -154,6 +155,10 @@ public class AppDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid
         modelBuilder.Entity<MaintenanceRequest>()
             .HasQueryFilter(e => (CurrentAccountId == null || e.AccountId == CurrentAccountId)
                                  && e.DeletedAt == null);
+
+        // Apply tenant filter to MaintenanceRequestPhoto (no soft delete)
+        modelBuilder.Entity<MaintenanceRequestPhoto>()
+            .HasQueryFilter(e => CurrentAccountId == null || e.AccountId == CurrentAccountId);
     }
 
     private void ConfigureSoftDeleteFilters(ModelBuilder modelBuilder)

--- a/backend/src/PropertyManager.Infrastructure/Persistence/Configurations/MaintenanceRequestPhotoConfiguration.cs
+++ b/backend/src/PropertyManager.Infrastructure/Persistence/Configurations/MaintenanceRequestPhotoConfiguration.cs
@@ -1,0 +1,86 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using PropertyManager.Domain.Entities;
+
+namespace PropertyManager.Infrastructure.Persistence.Configurations;
+
+/// <summary>
+/// EF Core configuration for MaintenanceRequestPhoto entity.
+/// Supports display ordering and primary photo designation (symmetric with WorkOrderPhoto).
+/// </summary>
+public class MaintenanceRequestPhotoConfiguration : IEntityTypeConfiguration<MaintenanceRequestPhoto>
+{
+    public void Configure(EntityTypeBuilder<MaintenanceRequestPhoto> builder)
+    {
+        builder.ToTable("MaintenanceRequestPhotos");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasDefaultValueSql("gen_random_uuid()");
+
+        builder.Property(e => e.AccountId)
+            .IsRequired();
+
+        builder.Property(e => e.MaintenanceRequestId)
+            .IsRequired();
+
+        builder.Property(e => e.StorageKey)
+            .HasMaxLength(500)
+            .IsRequired();
+
+        builder.Property(e => e.ThumbnailStorageKey)
+            .HasMaxLength(500);
+
+        builder.Property(e => e.OriginalFileName)
+            .HasMaxLength(255);
+
+        builder.Property(e => e.ContentType)
+            .HasMaxLength(100);
+
+        builder.Property(e => e.DisplayOrder)
+            .IsRequired();
+
+        builder.Property(e => e.IsPrimary)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedByUserId)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        builder.Property(e => e.UpdatedAt)
+            .IsRequired();
+
+        // Index on AccountId for tenant isolation queries
+        builder.HasIndex(e => e.AccountId)
+            .HasDatabaseName("IX_MaintenanceRequestPhotos_AccountId");
+
+        // Index on (MaintenanceRequestId, DisplayOrder) for efficient ordering
+        builder.HasIndex(e => new { e.MaintenanceRequestId, e.DisplayOrder })
+            .HasDatabaseName("IX_MaintenanceRequestPhotos_MaintenanceRequestId_DisplayOrder");
+
+        // Unique filtered index: only one primary photo per maintenance request
+        builder.HasIndex(e => new { e.MaintenanceRequestId, e.IsPrimary })
+            .HasDatabaseName("IX_MaintenanceRequestPhotos_MaintenanceRequestId_IsPrimary_Unique")
+            .IsUnique()
+            .HasFilter("\"IsPrimary\" = true");
+
+        // Index on CreatedByUserId for audit/reporting queries
+        builder.HasIndex(e => e.CreatedByUserId)
+            .HasDatabaseName("IX_MaintenanceRequestPhotos_CreatedByUserId");
+
+        // Relationship to Account
+        builder.HasOne(e => e.Account)
+            .WithMany()
+            .HasForeignKey(e => e.AccountId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Relationship to MaintenanceRequest with cascade delete
+        builder.HasOne(e => e.MaintenanceRequest)
+            .WithMany(mr => mr.Photos)
+            .HasForeignKey(e => e.MaintenanceRequestId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260414112725_AddMaintenanceRequestPhotos.Designer.cs
+++ b/backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260414112725_AddMaintenanceRequestPhotos.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PropertyManager.Domain.ValueObjects;
@@ -13,9 +14,11 @@ using PropertyManager.Infrastructure.Persistence;
 namespace PropertyManager.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414112725_AddMaintenanceRequestPhotos")]
+    partial class AddMaintenanceRequestPhotos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260414112725_AddMaintenanceRequestPhotos.cs
+++ b/backend/src/PropertyManager.Infrastructure/Persistence/Migrations/20260414112725_AddMaintenanceRequestPhotos.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PropertyManager.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMaintenanceRequestPhotos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MaintenanceRequestPhotos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    AccountId = table.Column<Guid>(type: "uuid", nullable: false),
+                    MaintenanceRequestId = table.Column<Guid>(type: "uuid", nullable: false),
+                    StorageKey = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    ThumbnailStorageKey = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    OriginalFileName = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    ContentType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: true),
+                    DisplayOrder = table.Column<int>(type: "integer", nullable: false),
+                    IsPrimary = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedByUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MaintenanceRequestPhotos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MaintenanceRequestPhotos_Accounts_AccountId",
+                        column: x => x.AccountId,
+                        principalTable: "Accounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_MaintenanceRequestPhotos_MaintenanceRequests_MaintenanceReq~",
+                        column: x => x.MaintenanceRequestId,
+                        principalTable: "MaintenanceRequests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MaintenanceRequestPhotos_AccountId",
+                table: "MaintenanceRequestPhotos",
+                column: "AccountId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MaintenanceRequestPhotos_CreatedByUserId",
+                table: "MaintenanceRequestPhotos",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MaintenanceRequestPhotos_MaintenanceRequestId_DisplayOrder",
+                table: "MaintenanceRequestPhotos",
+                columns: new[] { "MaintenanceRequestId", "DisplayOrder" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MaintenanceRequestPhotos_MaintenanceRequestId_IsPrimary_Unique",
+                table: "MaintenanceRequestPhotos",
+                columns: new[] { "MaintenanceRequestId", "IsPrimary" },
+                unique: true,
+                filter: "\"IsPrimary\" = true");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MaintenanceRequestPhotos");
+        }
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUploadHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUploadHandlerTests.cs
@@ -1,0 +1,316 @@
+using FluentAssertions;
+using MockQueryable.Moq;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.MaintenanceRequestPhotos;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Enums;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Unit tests for ConfirmMaintenanceRequestPhotoUploadHandler (AC #3).
+/// Tests auto-primary logic for first photo.
+/// </summary>
+public class ConfirmMaintenanceRequestPhotoUploadHandlerTests
+{
+    private readonly Mock<IAppDbContext> _dbContextMock;
+    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly Mock<IPhotoService> _photoServiceMock;
+    private readonly ConfirmMaintenanceRequestPhotoUploadHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+    private readonly Guid _testUserId = Guid.NewGuid();
+    private readonly Guid _testPropertyId = Guid.NewGuid();
+    private readonly Guid _testRequestId = Guid.NewGuid();
+
+    public ConfirmMaintenanceRequestPhotoUploadHandlerTests()
+    {
+        _dbContextMock = new Mock<IAppDbContext>();
+        _currentUserMock = new Mock<ICurrentUser>();
+        _photoServiceMock = new Mock<IPhotoService>();
+
+        _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
+        _currentUserMock.Setup(x => x.UserId).Returns(_testUserId);
+        _currentUserMock.Setup(x => x.IsAuthenticated).Returns(true);
+        _currentUserMock.Setup(x => x.Role).Returns("Owner");
+        _currentUserMock.Setup(x => x.PropertyId).Returns((Guid?)null);
+
+        _handler = new ConfirmMaintenanceRequestPhotoUploadHandler(
+            _photoServiceMock.Object,
+            _dbContextMock.Object,
+            _currentUserMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidConfirm_CreatesPhotoRecordAndReturnsIdWithUrls()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        var storageKey = $"{_testAccountId}/maintenancerequests/2026/test-photo.jpg";
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupMaintenanceRequestPhotosDbSet(new List<MaintenanceRequestPhoto>());
+        SetupPhotoServiceMock(storageKey);
+        SetupPhotosAdd();
+
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            request.Id,
+            storageKey,
+            $"{_testAccountId}/maintenancerequests/2026/thumbnails/test-photo.jpg",
+            "image/jpeg",
+            1024,
+            "test-photo.jpg");
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.ViewUrl.Should().Be("https://example.com/photo.jpg");
+        result.ThumbnailUrl.Should().Be("https://example.com/thumbnail.jpg");
+    }
+
+    [Fact]
+    public async Task Handle_FirstPhotoForRequest_SetsIsPrimaryTrue()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        var storageKey = $"{_testAccountId}/maintenancerequests/2026/test-photo.jpg";
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupMaintenanceRequestPhotosDbSet(new List<MaintenanceRequestPhoto>());
+        SetupPhotoServiceMock(storageKey);
+        SetupPhotosAdd();
+
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            request.Id,
+            storageKey,
+            $"{_testAccountId}/maintenancerequests/2026/thumbnails/test-photo.jpg",
+            "image/jpeg",
+            1024,
+            "test-photo.jpg");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _dbContextMock.Verify(x => x.MaintenanceRequestPhotos.Add(It.Is<MaintenanceRequestPhoto>(
+            p => p.IsPrimary == true && p.DisplayOrder == 0
+        )), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SubsequentPhotos_SetsIsPrimaryFalse()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        var existingPhoto = CreatePhoto(_testAccountId, request.Id, isPrimary: true, displayOrder: 0);
+        var storageKey = $"{_testAccountId}/maintenancerequests/2026/test-photo.jpg";
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupMaintenanceRequestPhotosDbSet(new List<MaintenanceRequestPhoto> { existingPhoto });
+        SetupPhotoServiceMock(storageKey);
+        SetupPhotosAdd();
+
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            request.Id,
+            storageKey,
+            $"{_testAccountId}/maintenancerequests/2026/thumbnails/test-photo.jpg",
+            "image/jpeg",
+            1024,
+            "test-photo-2.jpg");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _dbContextMock.Verify(x => x.MaintenanceRequestPhotos.Add(It.Is<MaintenanceRequestPhoto>(
+            p => p.IsPrimary == false && p.DisplayOrder == 1
+        )), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleExistingPhotos_SetsCorrectDisplayOrder()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        var existingPhotos = new List<MaintenanceRequestPhoto>
+        {
+            CreatePhoto(_testAccountId, request.Id, isPrimary: true, displayOrder: 0),
+            CreatePhoto(_testAccountId, request.Id, isPrimary: false, displayOrder: 1),
+            CreatePhoto(_testAccountId, request.Id, isPrimary: false, displayOrder: 2)
+        };
+        var storageKey = $"{_testAccountId}/maintenancerequests/2026/test-photo.jpg";
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupMaintenanceRequestPhotosDbSet(existingPhotos);
+        SetupPhotoServiceMock(storageKey);
+        SetupPhotosAdd();
+
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            request.Id,
+            storageKey,
+            $"{_testAccountId}/maintenancerequests/2026/thumbnails/test-photo.jpg",
+            "image/jpeg",
+            1024,
+            "test-photo-4.jpg");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _dbContextMock.Verify(x => x.MaintenanceRequestPhotos.Add(It.Is<MaintenanceRequestPhoto>(
+            p => p.DisplayOrder == 3
+        )), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidStorageKeyFormat_ThrowsArgumentException()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        var storageKey = "invalid-storage-key";
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupMaintenanceRequestPhotosDbSet(new List<MaintenanceRequestPhoto>());
+
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            request.Id,
+            storageKey,
+            "invalid-thumbnail-key",
+            "image/jpeg",
+            1024,
+            "test-photo.jpg");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_StorageKeyForDifferentAccount_ThrowsUnauthorizedAccessException()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        var otherAccountId = Guid.NewGuid();
+        var storageKey = $"{otherAccountId}/maintenancerequests/2026/test-photo.jpg";
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupMaintenanceRequestPhotosDbSet(new List<MaintenanceRequestPhoto>());
+
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            request.Id,
+            storageKey,
+            $"{otherAccountId}/maintenancerequests/2026/thumbnails/test-photo.jpg",
+            "image/jpeg",
+            1024,
+            "test-photo.jpg");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_MaintenanceRequestNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        var storageKey = $"{_testAccountId}/maintenancerequests/2026/test-photo.jpg";
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest>());
+        SetupMaintenanceRequestPhotosDbSet(new List<MaintenanceRequestPhoto>());
+
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            Guid.NewGuid(),
+            storageKey,
+            $"{_testAccountId}/maintenancerequests/2026/thumbnails/test-photo.jpg",
+            "image/jpeg",
+            1024,
+            "test-photo.jpg");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    private MaintenanceRequest CreateMaintenanceRequest(Guid accountId, Guid propertyId)
+    {
+        return new MaintenanceRequest
+        {
+            Id = _testRequestId,
+            AccountId = accountId,
+            PropertyId = propertyId,
+            SubmittedByUserId = Guid.NewGuid(),
+            Description = "Test request",
+            Status = MaintenanceRequestStatus.Submitted,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    private MaintenanceRequestPhoto CreatePhoto(Guid accountId, Guid requestId, bool isPrimary, int displayOrder)
+    {
+        return new MaintenanceRequestPhoto
+        {
+            Id = Guid.NewGuid(),
+            AccountId = accountId,
+            MaintenanceRequestId = requestId,
+            StorageKey = $"{accountId}/maintenancerequests/2026/{Guid.NewGuid()}.jpg",
+            ThumbnailStorageKey = $"{accountId}/maintenancerequests/2026/thumbnails/{Guid.NewGuid()}.jpg",
+            OriginalFileName = "photo.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024,
+            DisplayOrder = displayOrder,
+            IsPrimary = isPrimary,
+            CreatedByUserId = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    private void SetupMaintenanceRequestsDbSet(List<MaintenanceRequest> requests)
+    {
+        var filtered = requests
+            .Where(r => r.AccountId == _testAccountId && r.DeletedAt == null)
+            .ToList();
+        var mockDbSet = filtered.BuildMockDbSet();
+        _dbContextMock.Setup(x => x.MaintenanceRequests).Returns(mockDbSet.Object);
+    }
+
+    private void SetupMaintenanceRequestPhotosDbSet(List<MaintenanceRequestPhoto> photos)
+    {
+        var mockDbSet = photos.BuildMockDbSet();
+        _dbContextMock.Setup(x => x.MaintenanceRequestPhotos).Returns(mockDbSet.Object);
+    }
+
+    private void SetupPhotosAdd()
+    {
+        _dbContextMock.Setup(x => x.MaintenanceRequestPhotos.Add(It.IsAny<MaintenanceRequestPhoto>()));
+        _dbContextMock.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+    }
+
+    private void SetupPhotoServiceMock(string storageKey)
+    {
+        _photoServiceMock.Setup(x => x.ConfirmUploadAsync(
+                It.IsAny<ConfirmPhotoUploadRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PhotoRecord(
+                storageKey,
+                $"{_testAccountId}/maintenancerequests/2026/thumbnails/test.jpg",
+                "image/jpeg",
+                1024));
+
+        _photoServiceMock.Setup(x => x.GetPhotoUrlAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://example.com/photo.jpg");
+
+        _photoServiceMock.Setup(x => x.GetThumbnailUrlAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://example.com/thumbnail.jpg");
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhotoHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhotoHandlerTests.cs
@@ -1,0 +1,225 @@
+using FluentAssertions;
+using MockQueryable.Moq;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.MaintenanceRequestPhotos;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Enums;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Unit tests for DeleteMaintenanceRequestPhotoHandler (AC #6, #8).
+/// Tests primary promotion when primary photo is deleted.
+/// Tests tenant property scoping on delete.
+/// </summary>
+public class DeleteMaintenanceRequestPhotoHandlerTests
+{
+    private readonly Mock<IAppDbContext> _dbContextMock;
+    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly Mock<IPhotoService> _photoServiceMock;
+    private readonly DeleteMaintenanceRequestPhotoHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+    private readonly Guid _testPropertyId = Guid.NewGuid();
+    private readonly Guid _testRequestId = Guid.NewGuid();
+    private List<MaintenanceRequestPhoto> _photos = new();
+
+    public DeleteMaintenanceRequestPhotoHandlerTests()
+    {
+        _dbContextMock = new Mock<IAppDbContext>();
+        _currentUserMock = new Mock<ICurrentUser>();
+        _photoServiceMock = new Mock<IPhotoService>();
+
+        _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
+        _currentUserMock.Setup(x => x.IsAuthenticated).Returns(true);
+        _currentUserMock.Setup(x => x.Role).Returns("Owner");
+        _currentUserMock.Setup(x => x.PropertyId).Returns((Guid?)null);
+
+        _photoServiceMock.Setup(x => x.DeletePhotoAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new DeleteMaintenanceRequestPhotoHandler(
+            _photoServiceMock.Object,
+            _dbContextMock.Object,
+            _currentUserMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_DeletesPhotoFromDbAndCallsDeletePhotoAsync()
+    {
+        // Arrange
+        var photo = CreatePhoto(_testAccountId, _testRequestId, isPrimary: true, displayOrder: 0);
+
+        _photos = new List<MaintenanceRequestPhoto> { photo };
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { CreateMaintenanceRequest(_testAccountId, _testPropertyId) });
+        SetupPhotosDbSet(_photos);
+        SetupSaveChanges();
+
+        var command = new DeleteMaintenanceRequestPhotoCommand(_testRequestId, photo.Id);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _photoServiceMock.Verify(x => x.DeletePhotoAsync(
+            photo.StorageKey,
+            photo.ThumbnailStorageKey,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_PhotoNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        _photos = new List<MaintenanceRequestPhoto>();
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { CreateMaintenanceRequest(_testAccountId, _testPropertyId) });
+        SetupPhotosDbSet(_photos);
+
+        var command = new DeleteMaintenanceRequestPhotoCommand(_testRequestId, Guid.NewGuid());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_DeletePrimaryPhoto_PromotesNextPhotoByDisplayOrder()
+    {
+        // Arrange
+        var photo1 = CreatePhoto(_testAccountId, _testRequestId, isPrimary: true, displayOrder: 0);
+        var photo2 = CreatePhoto(_testAccountId, _testRequestId, isPrimary: false, displayOrder: 1);
+        var photo3 = CreatePhoto(_testAccountId, _testRequestId, isPrimary: false, displayOrder: 2);
+
+        _photos = new List<MaintenanceRequestPhoto> { photo1, photo2, photo3 };
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { CreateMaintenanceRequest(_testAccountId, _testPropertyId) });
+        SetupPhotosDbSet(_photos);
+        SetupSaveChanges();
+
+        var command = new DeleteMaintenanceRequestPhotoCommand(_testRequestId, photo1.Id);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        photo2.IsPrimary.Should().BeTrue();
+        _dbContextMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Handle_DeleteOnlyPhoto_NoPromotionNeeded()
+    {
+        // Arrange
+        var photo1 = CreatePhoto(_testAccountId, _testRequestId, isPrimary: true, displayOrder: 0);
+
+        _photos = new List<MaintenanceRequestPhoto> { photo1 };
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { CreateMaintenanceRequest(_testAccountId, _testPropertyId) });
+        SetupPhotosDbSet(_photos);
+        SetupSaveChanges();
+
+        var command = new DeleteMaintenanceRequestPhotoCommand(_testRequestId, photo1.Id);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _dbContextMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TenantAccessingRequestOnDifferentProperty_ThrowsNotFoundException()
+    {
+        // Arrange
+        var tenantPropertyId = Guid.NewGuid();
+        _currentUserMock.Setup(x => x.Role).Returns("Tenant");
+        _currentUserMock.Setup(x => x.PropertyId).Returns(tenantPropertyId);
+
+        var photo = CreatePhoto(_testAccountId, _testRequestId, isPrimary: true, displayOrder: 0);
+        _photos = new List<MaintenanceRequestPhoto> { photo };
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { CreateMaintenanceRequest(_testAccountId, _testPropertyId) });
+        SetupPhotosDbSet(_photos);
+
+        var command = new DeleteMaintenanceRequestPhotoCommand(_testRequestId, photo.Id);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_MaintenanceRequestNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest>());
+
+        var command = new DeleteMaintenanceRequestPhotoCommand(Guid.NewGuid(), Guid.NewGuid());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    private MaintenanceRequest CreateMaintenanceRequest(Guid accountId, Guid propertyId)
+    {
+        return new MaintenanceRequest
+        {
+            Id = _testRequestId,
+            AccountId = accountId,
+            PropertyId = propertyId,
+            SubmittedByUserId = Guid.NewGuid(),
+            Description = "Test request",
+            Status = MaintenanceRequestStatus.Submitted,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    private MaintenanceRequestPhoto CreatePhoto(Guid accountId, Guid requestId, bool isPrimary, int displayOrder)
+    {
+        return new MaintenanceRequestPhoto
+        {
+            Id = Guid.NewGuid(),
+            AccountId = accountId,
+            MaintenanceRequestId = requestId,
+            StorageKey = $"{accountId}/maintenancerequests/2026/{Guid.NewGuid()}.jpg",
+            ThumbnailStorageKey = $"{accountId}/maintenancerequests/2026/thumbnails/{Guid.NewGuid()}.jpg",
+            OriginalFileName = "photo.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024,
+            DisplayOrder = displayOrder,
+            IsPrimary = isPrimary,
+            CreatedByUserId = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    private void SetupMaintenanceRequestsDbSet(List<MaintenanceRequest> requests)
+    {
+        var filtered = requests
+            .Where(r => r.AccountId == _testAccountId && r.DeletedAt == null)
+            .ToList();
+        var mockDbSet = filtered.BuildMockDbSet();
+        _dbContextMock.Setup(x => x.MaintenanceRequests).Returns(mockDbSet.Object);
+    }
+
+    private void SetupPhotosDbSet(List<MaintenanceRequestPhoto> photos)
+    {
+        var mockDbSet = photos.BuildMockDbSet();
+
+        mockDbSet.Setup(m => m.Remove(It.IsAny<MaintenanceRequestPhoto>()))
+            .Callback<MaintenanceRequestPhoto>(p => _photos.Remove(p));
+
+        _dbContextMock.Setup(x => x.MaintenanceRequestPhotos).Returns(mockDbSet.Object);
+    }
+
+    private void SetupSaveChanges()
+    {
+        _dbContextMock.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrlHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrlHandlerTests.cs
@@ -1,0 +1,203 @@
+using FluentAssertions;
+using MockQueryable.Moq;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.MaintenanceRequestPhotos;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Enums;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Unit tests for GenerateMaintenanceRequestPhotoUploadUrlHandler (AC #2, #8).
+/// Tests presigned URL generation for maintenance request photo uploads.
+/// </summary>
+public class GenerateMaintenanceRequestPhotoUploadUrlHandlerTests
+{
+    private readonly Mock<IAppDbContext> _dbContextMock;
+    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly Mock<IPhotoService> _photoServiceMock;
+    private readonly GenerateMaintenanceRequestPhotoUploadUrlHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+    private readonly Guid _testPropertyId = Guid.NewGuid();
+    private readonly Guid _testRequestId = Guid.NewGuid();
+
+    public GenerateMaintenanceRequestPhotoUploadUrlHandlerTests()
+    {
+        _dbContextMock = new Mock<IAppDbContext>();
+        _currentUserMock = new Mock<ICurrentUser>();
+        _photoServiceMock = new Mock<IPhotoService>();
+
+        _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
+        _currentUserMock.Setup(x => x.IsAuthenticated).Returns(true);
+        _currentUserMock.Setup(x => x.Role).Returns("Owner");
+        _currentUserMock.Setup(x => x.PropertyId).Returns((Guid?)null);
+
+        _handler = new GenerateMaintenanceRequestPhotoUploadUrlHandler(
+            _photoServiceMock.Object,
+            _dbContextMock.Object,
+            _currentUserMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsUploadUrlDetails()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        var expectedStorageKey = $"{_testAccountId}/maintenancerequests/2026/test.jpg";
+        var expectedThumbnailKey = $"{_testAccountId}/maintenancerequests/2026/thumbnails/test.jpg";
+        var expectedUploadUrl = "https://s3.amazonaws.com/bucket/presigned-url";
+        var expectedExpiresAt = DateTime.UtcNow.AddMinutes(15);
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupPhotoServiceMock(expectedUploadUrl, expectedStorageKey, expectedThumbnailKey, expectedExpiresAt);
+
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(
+            _testRequestId,
+            "image/jpeg",
+            1024,
+            "test.jpg");
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.UploadUrl.Should().Be(expectedUploadUrl);
+        result.StorageKey.Should().Be(expectedStorageKey);
+        result.ThumbnailStorageKey.Should().Be(expectedThumbnailKey);
+        result.ExpiresAt.Should().Be(expectedExpiresAt);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_CallsPhotoServiceWithMaintenanceRequestsEntityType()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupPhotoServiceMock();
+
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(
+            _testRequestId,
+            "image/png",
+            2048,
+            "screenshot.png");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _photoServiceMock.Verify(x => x.GenerateUploadUrlAsync(
+            _testAccountId,
+            It.Is<PhotoUploadRequest>(r =>
+                r.EntityType == PhotoEntityType.MaintenanceRequests &&
+                r.EntityId == _testRequestId &&
+                r.ContentType == "image/png" &&
+                r.FileSizeBytes == 2048 &&
+                r.OriginalFileName == "screenshot.png"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_MaintenanceRequestNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest>());
+
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(
+            Guid.NewGuid(),
+            "image/jpeg",
+            1024,
+            "test.jpg");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_DeletedMaintenanceRequest_ThrowsNotFoundException()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        request.DeletedAt = DateTime.UtcNow;
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(
+            _testRequestId,
+            "image/jpeg",
+            1024,
+            "test.jpg");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_TenantAccessingRequestOnDifferentProperty_ThrowsNotFoundException()
+    {
+        // Arrange
+        var tenantPropertyId = Guid.NewGuid();
+        _currentUserMock.Setup(x => x.Role).Returns("Tenant");
+        _currentUserMock.Setup(x => x.PropertyId).Returns(tenantPropertyId);
+
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId); // Different property
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(
+            _testRequestId,
+            "image/jpeg",
+            1024,
+            "test.jpg");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    private MaintenanceRequest CreateMaintenanceRequest(Guid accountId, Guid propertyId)
+    {
+        return new MaintenanceRequest
+        {
+            Id = _testRequestId,
+            AccountId = accountId,
+            PropertyId = propertyId,
+            SubmittedByUserId = Guid.NewGuid(),
+            Description = "Test request",
+            Status = MaintenanceRequestStatus.Submitted,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    private void SetupMaintenanceRequestsDbSet(List<MaintenanceRequest> requests)
+    {
+        var filtered = requests
+            .Where(r => r.AccountId == _testAccountId && r.DeletedAt == null)
+            .ToList();
+        var mockDbSet = filtered.BuildMockDbSet();
+        _dbContextMock.Setup(x => x.MaintenanceRequests).Returns(mockDbSet.Object);
+    }
+
+    private void SetupPhotoServiceMock(
+        string uploadUrl = "https://s3.amazonaws.com/bucket/presigned-url",
+        string storageKey = "account/maintenancerequests/2026/test.jpg",
+        string thumbnailKey = "account/maintenancerequests/2026/thumbnails/test.jpg",
+        DateTime? expiresAt = null)
+    {
+        var expires = expiresAt ?? DateTime.UtcNow.AddMinutes(15);
+
+        _photoServiceMock.Setup(x => x.GenerateUploadUrlAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<PhotoUploadRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PhotoUploadResult(
+                uploadUrl,
+                storageKey,
+                thumbnailKey,
+                expires));
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/GetMaintenanceRequestPhotosHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/GetMaintenanceRequestPhotosHandlerTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using MockQueryable.Moq;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.MaintenanceRequestPhotos;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Enums;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Unit tests for GetMaintenanceRequestPhotosHandler (AC #5).
+/// Tests photo retrieval with presigned URLs.
+/// </summary>
+public class GetMaintenanceRequestPhotosHandlerTests
+{
+    private readonly Mock<IAppDbContext> _dbContextMock;
+    private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly Mock<IPhotoService> _photoServiceMock;
+    private readonly GetMaintenanceRequestPhotosHandler _handler;
+    private readonly Guid _testAccountId = Guid.NewGuid();
+    private readonly Guid _testPropertyId = Guid.NewGuid();
+    private readonly Guid _testRequestId = Guid.NewGuid();
+
+    public GetMaintenanceRequestPhotosHandlerTests()
+    {
+        _dbContextMock = new Mock<IAppDbContext>();
+        _currentUserMock = new Mock<ICurrentUser>();
+        _photoServiceMock = new Mock<IPhotoService>();
+
+        _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
+        _currentUserMock.Setup(x => x.IsAuthenticated).Returns(true);
+        _currentUserMock.Setup(x => x.Role).Returns("Owner");
+        _currentUserMock.Setup(x => x.PropertyId).Returns((Guid?)null);
+
+        _photoServiceMock.Setup(x => x.GetPhotoUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://example.com/photo.jpg");
+        _photoServiceMock.Setup(x => x.GetThumbnailUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://example.com/thumbnail.jpg");
+
+        _handler = new GetMaintenanceRequestPhotosHandler(
+            _photoServiceMock.Object,
+            _dbContextMock.Object,
+            _currentUserMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_RequestWithPhotos_ReturnsPhotosOrderedByDisplayOrder()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        var photos = new List<MaintenanceRequestPhoto>
+        {
+            CreatePhoto(_testAccountId, _testRequestId, isPrimary: false, displayOrder: 2),
+            CreatePhoto(_testAccountId, _testRequestId, isPrimary: true, displayOrder: 0),
+            CreatePhoto(_testAccountId, _testRequestId, isPrimary: false, displayOrder: 1)
+        };
+
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupMaintenanceRequestPhotosDbSet(photos);
+
+        var query = new GetMaintenanceRequestPhotosQuery(_testRequestId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Items.Should().HaveCount(3);
+        result.Items[0].DisplayOrder.Should().Be(0);
+        result.Items[1].DisplayOrder.Should().Be(1);
+        result.Items[2].DisplayOrder.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_MaintenanceRequestNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest>());
+        SetupMaintenanceRequestPhotosDbSet(new List<MaintenanceRequestPhoto>());
+
+        var query = new GetMaintenanceRequestPhotosQuery(Guid.NewGuid());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(query, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_TenantAccessingRequestOnDifferentProperty_ThrowsNotFoundException()
+    {
+        // Arrange
+        var tenantPropertyId = Guid.NewGuid();
+        _currentUserMock.Setup(x => x.Role).Returns("Tenant");
+        _currentUserMock.Setup(x => x.PropertyId).Returns(tenantPropertyId);
+
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId); // Different property
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupMaintenanceRequestPhotosDbSet(new List<MaintenanceRequestPhoto>());
+
+        var query = new GetMaintenanceRequestPhotosQuery(_testRequestId);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(query, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_EmptyPhotoList_ReturnsEmptyItems()
+    {
+        // Arrange
+        var request = CreateMaintenanceRequest(_testAccountId, _testPropertyId);
+        SetupMaintenanceRequestsDbSet(new List<MaintenanceRequest> { request });
+        SetupMaintenanceRequestPhotosDbSet(new List<MaintenanceRequestPhoto>());
+
+        var query = new GetMaintenanceRequestPhotosQuery(_testRequestId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Items.Should().BeEmpty();
+    }
+
+    private MaintenanceRequest CreateMaintenanceRequest(Guid accountId, Guid propertyId)
+    {
+        return new MaintenanceRequest
+        {
+            Id = _testRequestId,
+            AccountId = accountId,
+            PropertyId = propertyId,
+            SubmittedByUserId = Guid.NewGuid(),
+            Description = "Test request",
+            Status = MaintenanceRequestStatus.Submitted,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    private MaintenanceRequestPhoto CreatePhoto(Guid accountId, Guid requestId, bool isPrimary, int displayOrder)
+    {
+        return new MaintenanceRequestPhoto
+        {
+            Id = Guid.NewGuid(),
+            AccountId = accountId,
+            MaintenanceRequestId = requestId,
+            StorageKey = $"{accountId}/maintenancerequests/2026/{Guid.NewGuid()}.jpg",
+            ThumbnailStorageKey = $"{accountId}/maintenancerequests/2026/thumbnails/{Guid.NewGuid()}.jpg",
+            OriginalFileName = "photo.jpg",
+            ContentType = "image/jpeg",
+            FileSizeBytes = 1024,
+            DisplayOrder = displayOrder,
+            IsPrimary = isPrimary,
+            CreatedByUserId = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    private void SetupMaintenanceRequestsDbSet(List<MaintenanceRequest> requests)
+    {
+        var filtered = requests
+            .Where(r => r.AccountId == _testAccountId && r.DeletedAt == null)
+            .ToList();
+        var mockDbSet = filtered.BuildMockDbSet();
+        _dbContextMock.Setup(x => x.MaintenanceRequests).Returns(mockDbSet.Object);
+    }
+
+    private void SetupMaintenanceRequestPhotosDbSet(List<MaintenanceRequestPhoto> photos)
+    {
+        var mockDbSet = photos.BuildMockDbSet();
+        _dbContextMock.Setup(x => x.MaintenanceRequestPhotos).Returns(mockDbSet.Object);
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ValidatorTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using PropertyManager.Application.MaintenanceRequestPhotos;
+
+namespace PropertyManager.Application.Tests.MaintenanceRequestPhotos;
+
+/// <summary>
+/// Unit tests for MaintenanceRequestPhoto validators (AC #2, #3, #6).
+/// </summary>
+public class ValidatorTests
+{
+    #region GenerateMaintenanceRequestPhotoUploadUrlValidator Tests
+
+    [Fact]
+    public void GenerateUploadUrlValidator_ValidRequest_Passes()
+    {
+        var validator = new GenerateMaintenanceRequestPhotoUploadUrlValidator();
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(Guid.NewGuid(), "image/jpeg", 1024, "test.jpg");
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GenerateUploadUrlValidator_EmptyMaintenanceRequestId_Fails()
+    {
+        var validator = new GenerateMaintenanceRequestPhotoUploadUrlValidator();
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(Guid.Empty, "image/jpeg", 1024, "test.jpg");
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "MaintenanceRequestId");
+    }
+
+    [Fact]
+    public void GenerateUploadUrlValidator_InvalidContentType_Fails()
+    {
+        var validator = new GenerateMaintenanceRequestPhotoUploadUrlValidator();
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(Guid.NewGuid(), "application/pdf", 1024, "test.pdf");
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "ContentType");
+    }
+
+    [Fact]
+    public void GenerateUploadUrlValidator_FileSizeExceedsMax_Fails()
+    {
+        var validator = new GenerateMaintenanceRequestPhotoUploadUrlValidator();
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(Guid.NewGuid(), "image/jpeg", 20 * 1024 * 1024, "test.jpg");
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "FileSizeBytes");
+    }
+
+    [Fact]
+    public void GenerateUploadUrlValidator_EmptyFileName_Fails()
+    {
+        var validator = new GenerateMaintenanceRequestPhotoUploadUrlValidator();
+        var command = new GenerateMaintenanceRequestPhotoUploadUrlCommand(Guid.NewGuid(), "image/jpeg", 1024, "");
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "OriginalFileName");
+    }
+
+    #endregion
+
+    #region ConfirmMaintenanceRequestPhotoUploadValidator Tests
+
+    [Fact]
+    public void ConfirmUploadValidator_ValidRequest_Passes()
+    {
+        var validator = new ConfirmMaintenanceRequestPhotoUploadValidator();
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            Guid.NewGuid(), "account-id/maintenancerequests/2026/test.jpg",
+            "account-id/maintenancerequests/2026/thumbnails/test.jpg",
+            "image/jpeg", 1024, "test.jpg");
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConfirmUploadValidator_EmptyStorageKey_Fails()
+    {
+        var validator = new ConfirmMaintenanceRequestPhotoUploadValidator();
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            Guid.NewGuid(), "",
+            "account-id/maintenancerequests/2026/thumbnails/test.jpg",
+            "image/jpeg", 1024, "test.jpg");
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "StorageKey");
+    }
+
+    [Fact]
+    public void ConfirmUploadValidator_EmptyThumbnailStorageKey_Fails()
+    {
+        var validator = new ConfirmMaintenanceRequestPhotoUploadValidator();
+        var command = new ConfirmMaintenanceRequestPhotoUploadCommand(
+            Guid.NewGuid(), "account-id/maintenancerequests/2026/test.jpg", "",
+            "image/jpeg", 1024, "test.jpg");
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "ThumbnailStorageKey");
+    }
+
+    #endregion
+
+    #region DeleteMaintenanceRequestPhotoValidator Tests
+
+    [Fact]
+    public void DeleteValidator_ValidRequest_Passes()
+    {
+        var validator = new DeleteMaintenanceRequestPhotoValidator();
+        var command = new DeleteMaintenanceRequestPhotoCommand(Guid.NewGuid(), Guid.NewGuid());
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeleteValidator_EmptyMaintenanceRequestId_Fails()
+    {
+        var validator = new DeleteMaintenanceRequestPhotoValidator();
+        var command = new DeleteMaintenanceRequestPhotoCommand(Guid.Empty, Guid.NewGuid());
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "MaintenanceRequestId");
+    }
+
+    [Fact]
+    public void DeleteValidator_EmptyPhotoId_Fails()
+    {
+        var validator = new DeleteMaintenanceRequestPhotoValidator();
+        var command = new DeleteMaintenanceRequestPhotoCommand(Guid.NewGuid(), Guid.Empty);
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "PhotoId");
+    }
+
+    #endregion
+}

--- a/backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/GetMaintenanceRequestByIdHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/GetMaintenanceRequestByIdHandlerTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using MockQueryable.Moq;
 using Moq;
 using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.MaintenanceRequestPhotos;
 using PropertyManager.Application.MaintenanceRequests;
 using PropertyManager.Domain.Entities;
 using PropertyManager.Domain.Enums;
@@ -17,6 +18,7 @@ public class GetMaintenanceRequestByIdHandlerTests
     private readonly Mock<IAppDbContext> _dbContextMock;
     private readonly Mock<ICurrentUser> _currentUserMock;
     private readonly Mock<IIdentityService> _identityServiceMock;
+    private readonly Mock<IPhotoService> _photoServiceMock;
     private readonly Guid _testAccountId = Guid.NewGuid();
     private readonly Guid _testUserId = Guid.NewGuid();
     private readonly Guid _property1Id = Guid.NewGuid();
@@ -27,16 +29,22 @@ public class GetMaintenanceRequestByIdHandlerTests
         _dbContextMock = new Mock<IAppDbContext>();
         _currentUserMock = new Mock<ICurrentUser>();
         _identityServiceMock = new Mock<IIdentityService>();
+        _photoServiceMock = new Mock<IPhotoService>();
 
         _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
         _currentUserMock.Setup(x => x.UserId).Returns(_testUserId);
         _currentUserMock.Setup(x => x.IsAuthenticated).Returns(true);
+
+        _photoServiceMock.Setup(x => x.GetPhotoUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://example.com/photo.jpg");
+        _photoServiceMock.Setup(x => x.GetThumbnailUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://example.com/thumbnail.jpg");
     }
 
     private GetMaintenanceRequestByIdQueryHandler CreateHandler()
     {
         return new GetMaintenanceRequestByIdQueryHandler(
-            _dbContextMock.Object, _currentUserMock.Object, _identityServiceMock.Object);
+            _dbContextMock.Object, _currentUserMock.Object, _identityServiceMock.Object, _photoServiceMock.Object);
     }
 
     private void SetupDbSet(List<MaintenanceRequest> requests)
@@ -211,5 +219,125 @@ public class GetMaintenanceRequestByIdHandlerTests
         // Assert
         result.Id.Should().Be(requestId);
         result.PropertyId.Should().Be(_property2Id);
+    }
+
+    [Fact]
+    public async Task Handle_DetailResponseIncludesPhotosWithPresignedUrls()
+    {
+        // Arrange
+        _currentUserMock.Setup(x => x.Role).Returns("Owner");
+        _currentUserMock.Setup(x => x.PropertyId).Returns((Guid?)null);
+
+        var requestId = Guid.NewGuid();
+        var property = new Property
+        {
+            Id = _property1Id,
+            AccountId = _testAccountId,
+            Name = "Test Property",
+            Street = "123 Main St",
+            City = "Austin",
+            State = "TX",
+            ZipCode = "78701"
+        };
+
+        var photos = new List<MaintenanceRequestPhoto>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                AccountId = _testAccountId,
+                MaintenanceRequestId = requestId,
+                StorageKey = $"{_testAccountId}/maintenancerequests/2026/photo1.jpg",
+                ThumbnailStorageKey = $"{_testAccountId}/maintenancerequests/2026/thumbnails/photo1.jpg",
+                OriginalFileName = "photo1.jpg",
+                ContentType = "image/jpeg",
+                FileSizeBytes = 1024,
+                DisplayOrder = 0,
+                IsPrimary = true,
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        };
+
+        var maintenanceRequest = new MaintenanceRequest
+        {
+            Id = requestId,
+            AccountId = _testAccountId,
+            PropertyId = _property1Id,
+            Property = property,
+            SubmittedByUserId = Guid.NewGuid(),
+            Description = "Broken window",
+            Status = MaintenanceRequestStatus.Submitted,
+            Photos = photos,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        SetupDbSet(new List<MaintenanceRequest> { maintenanceRequest });
+
+        _identityServiceMock
+            .Setup(x => x.GetUserDisplayNamesAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string>());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetMaintenanceRequestByIdQuery(requestId), CancellationToken.None);
+
+        // Assert
+        result.Photos.Should().NotBeNull();
+        result.Photos.Should().HaveCount(1);
+        result.Photos![0].ViewUrl.Should().Be("https://example.com/photo.jpg");
+        result.Photos[0].ThumbnailUrl.Should().Be("https://example.com/thumbnail.jpg");
+        result.Photos[0].IsPrimary.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_DetailResponseWithNoPhotos_ReturnsEmptyList()
+    {
+        // Arrange
+        _currentUserMock.Setup(x => x.Role).Returns("Owner");
+        _currentUserMock.Setup(x => x.PropertyId).Returns((Guid?)null);
+
+        var requestId = Guid.NewGuid();
+        var property = new Property
+        {
+            Id = _property1Id,
+            AccountId = _testAccountId,
+            Name = "Test Property",
+            Street = "123 Main St",
+            City = "Austin",
+            State = "TX",
+            ZipCode = "78701"
+        };
+
+        var maintenanceRequest = new MaintenanceRequest
+        {
+            Id = requestId,
+            AccountId = _testAccountId,
+            PropertyId = _property1Id,
+            Property = property,
+            SubmittedByUserId = Guid.NewGuid(),
+            Description = "Broken window",
+            Status = MaintenanceRequestStatus.Submitted,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        SetupDbSet(new List<MaintenanceRequest> { maintenanceRequest });
+
+        _identityServiceMock
+            .Setup(x => x.GetUserDisplayNamesAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string>());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetMaintenanceRequestByIdQuery(requestId), CancellationToken.None);
+
+        // Assert
+        result.Photos.Should().NotBeNull();
+        result.Photos.Should().BeEmpty();
     }
 }

--- a/docs/project/sprint-status.yaml
+++ b/docs/project/sprint-status.yaml
@@ -326,3 +326,4 @@ development_status:
   20-1-tenant-role-property-association: done    # FR-TP2, FR-TP3, FR-TP10, NFR-TP3 - Size 5
   20-2-tenant-invitation-flow: done    # FR-TP1, FR-TP4, FR-TP5, NFR-TP4 - Size 5
   20-3-maintenance-request-entity-api: done    # FR-TP18, FR-TP19, FR-TP20, NFR-TP6 - Size 5
+  20-4-maintenance-request-photos: done    # FR-TP21 - Size 5

--- a/docs/project/stories/epic-20/20-4-maintenance-request-photos.md
+++ b/docs/project/stories/epic-20/20-4-maintenance-request-photos.md
@@ -1,0 +1,359 @@
+# Story 20.4: Maintenance Request Photos
+
+Status: done
+
+## Story
+
+As a tenant,
+I want to attach photos to my maintenance request,
+so that the landlord can see what's wrong before visiting.
+
+## Acceptance Criteria
+
+1. **Given** the domain layer,
+   **When** the MaintenanceRequestPhoto entity is defined,
+   **Then** it has: Id, MaintenanceRequestId, AccountId, StorageKey, ThumbnailStorageKey, OriginalFileName, ContentType, FileSizeBytes, DisplayOrder, IsPrimary, CreatedByUserId, CreatedAt, UpdatedAt
+
+2. **Given** a maintenance request,
+   **When** a user requests a presigned upload URL with content type, file size, and file name,
+   **Then** the system returns an S3 presigned URL, storage key, thumbnail storage key, and expiration time scoped to maintenance request photos
+
+3. **Given** a photo uploaded to S3,
+   **When** the user confirms the upload with storage keys and metadata,
+   **Then** a MaintenanceRequestPhoto record is created linking the photo to the request with auto-primary logic for the first photo
+
+4. **Given** a maintenance request with photos,
+   **When** anyone views the request detail (GetMaintenanceRequestById),
+   **Then** presigned download URLs (thumbnail and full-size) are returned for each photo ordered by DisplayOrder
+
+5. **Given** a maintenance request with photos,
+   **When** photos are queried via the GET photos endpoint,
+   **Then** they are returned ordered by DisplayOrder with presigned URLs
+
+6. **Given** a maintenance request photo,
+   **When** a user deletes the photo,
+   **Then** the photo is removed from the database and S3 (original + thumbnail), and if it was primary, the next photo by DisplayOrder is promoted
+
+7. **Given** the EF Core configuration,
+   **When** the migration runs,
+   **Then** the MaintenanceRequestPhotos table is created with proper FKs, indexes, and AccountId for multi-tenancy
+
+8. **Given** a tenant user,
+   **When** they upload or view photos,
+   **Then** they can only access photos for maintenance requests on their assigned property
+
+## Tasks / Subtasks
+
+- [x] Task 1: Create MaintenanceRequestPhoto domain entity (AC: #1)
+  - [x] 1.1 Create `MaintenanceRequestPhoto.cs` in `backend/src/PropertyManager.Domain/Entities/` extending `AuditableEntity` and implementing `ITenantEntity`
+  - [x] 1.2 Define properties: `AccountId`, `MaintenanceRequestId`, `StorageKey`, `ThumbnailStorageKey` (nullable), `OriginalFileName` (nullable), `ContentType` (nullable), `FileSizeBytes` (nullable long), `DisplayOrder` (int), `IsPrimary` (bool), `CreatedByUserId` (Guid)
+  - [x] 1.3 Add navigation properties: `Account` (Account), `MaintenanceRequest` (MaintenanceRequest)
+  - [x] 1.4 Add `ICollection<MaintenanceRequestPhoto> Photos` navigation property to `MaintenanceRequest` entity
+
+- [x] Task 2: Add `MaintenanceRequests` to `PhotoEntityType` enum (AC: #2)
+  - [x] 2.1 Add `MaintenanceRequests` value to `PhotoEntityType` enum in `IPhotoService.cs`
+
+- [x] Task 3: Create EF Core configuration and migration (AC: #7)
+  - [x] 3.1 Create `MaintenanceRequestPhotoConfiguration.cs` in `backend/src/PropertyManager.Infrastructure/Persistence/Configurations/`
+  - [x] 3.2 Configure table `MaintenanceRequestPhotos`, PK, Id with `gen_random_uuid()` default
+  - [x] 3.3 Configure `AccountId` (required), `MaintenanceRequestId` (required), `CreatedByUserId` (required)
+  - [x] 3.4 Configure `StorageKey` as required, max 500; `ThumbnailStorageKey` optional, max 500
+  - [x] 3.5 Configure `OriginalFileName` optional, max 255; `ContentType` optional, max 100
+  - [x] 3.6 Configure `DisplayOrder` required, `IsPrimary` required
+  - [x] 3.7 Configure FK to Account with `DeleteBehavior.Restrict`
+  - [x] 3.8 Configure FK to MaintenanceRequest with `DeleteBehavior.Cascade` via `WithMany(mr => mr.Photos)`
+  - [x] 3.9 Add indexes: `IX_MaintenanceRequestPhotos_AccountId`, `IX_MaintenanceRequestPhotos_MaintenanceRequestId_DisplayOrder`, unique filtered index `IX_MaintenanceRequestPhotos_MaintenanceRequestId_IsPrimary_Unique` where `IsPrimary = true`, `IX_MaintenanceRequestPhotos_CreatedByUserId`
+  - [x] 3.10 Add `DbSet<MaintenanceRequestPhoto> MaintenanceRequestPhotos` to `IAppDbContext` and `AppDbContext`
+  - [x] 3.11 Add global query filter in `AppDbContext.OnModelCreating`: `HasQueryFilter(e => CurrentAccountId == null || e.AccountId == CurrentAccountId)`
+  - [x] 3.12 Create and apply migration
+
+- [x] Task 4: Create GenerateMaintenanceRequestPhotoUploadUrl command + handler (AC: #2, #8)
+  - [x] 4.1 Create `GenerateMaintenanceRequestPhotoUploadUrl.cs` in `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/`
+  - [x] 4.2 Command: `GenerateMaintenanceRequestPhotoUploadUrlCommand(Guid MaintenanceRequestId, string ContentType, long FileSizeBytes, string OriginalFileName) : IRequest<GenerateMaintenanceRequestPhotoUploadUrlResponse>`
+  - [x] 4.3 Response: `GenerateMaintenanceRequestPhotoUploadUrlResponse(string UploadUrl, string StorageKey, string ThumbnailStorageKey, DateTime ExpiresAt)`
+  - [x] 4.4 Handler: verify maintenance request exists (AccountId + DeletedAt check). For tenant users, verify request is on their PropertyId. Use `IPhotoService.GenerateUploadUrlAsync` with `PhotoEntityType.MaintenanceRequests`.
+
+- [x] Task 5: Create GenerateMaintenanceRequestPhotoUploadUrl validator (AC: #2)
+  - [x] 5.1 Create `GenerateMaintenanceRequestPhotoUploadUrlValidator.cs` — validate MaintenanceRequestId NotEmpty, ContentType NotEmpty + allowed type, FileSizeBytes > 0 and <= 10MB, OriginalFileName NotEmpty + max 255
+
+- [x] Task 6: Create ConfirmMaintenanceRequestPhotoUpload command + handler (AC: #3)
+  - [x] 6.1 Create `ConfirmMaintenanceRequestPhotoUpload.cs` in `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/`
+  - [x] 6.2 Command: `ConfirmMaintenanceRequestPhotoUploadCommand(Guid MaintenanceRequestId, string StorageKey, string ThumbnailStorageKey, string ContentType, long FileSizeBytes, string OriginalFileName) : IRequest<ConfirmMaintenanceRequestPhotoUploadResponse>`
+  - [x] 6.3 Response: `ConfirmMaintenanceRequestPhotoUploadResponse(Guid Id, string? ThumbnailUrl, string? ViewUrl)`
+  - [x] 6.4 Handler: verify request exists + account ownership + tenant property scoping. Validate storage key belongs to current account. Call `IPhotoService.ConfirmUploadAsync` for thumbnail generation. Auto-set `IsPrimary = true` if first photo. Calculate DisplayOrder as max + 1. Create `MaintenanceRequestPhoto` entity.
+
+- [x] Task 7: Create ConfirmMaintenanceRequestPhotoUpload validator (AC: #3)
+  - [x] 7.1 Create `ConfirmMaintenanceRequestPhotoUploadValidator.cs` — validate MaintenanceRequestId, StorageKey, ThumbnailStorageKey, ContentType, FileSizeBytes, OriginalFileName (same pattern as ConfirmVendorPhotoUploadValidator)
+
+- [x] Task 8: Create GetMaintenanceRequestPhotos query + handler (AC: #5)
+  - [x] 8.1 Create `GetMaintenanceRequestPhotos.cs` in `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/`
+  - [x] 8.2 Query: `GetMaintenanceRequestPhotosQuery(Guid MaintenanceRequestId) : IRequest<GetMaintenanceRequestPhotosResponse>`
+  - [x] 8.3 DTO: `MaintenanceRequestPhotoDto(Guid Id, string? ThumbnailUrl, string? ViewUrl, bool IsPrimary, int DisplayOrder, string OriginalFileName, long FileSizeBytes, DateTime CreatedAt)`
+  - [x] 8.4 Response: `GetMaintenanceRequestPhotosResponse(IReadOnlyList<MaintenanceRequestPhotoDto> Items)`
+  - [x] 8.5 Handler: verify request exists + account ownership + tenant property scoping. Query photos ordered by DisplayOrder. Generate presigned URLs in parallel.
+
+- [x] Task 9: Create DeleteMaintenanceRequestPhoto command + handler (AC: #6)
+  - [x] 9.1 Create `DeleteMaintenanceRequestPhoto.cs` in `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/`
+  - [x] 9.2 Command: `DeleteMaintenanceRequestPhotoCommand(Guid MaintenanceRequestId, Guid PhotoId) : IRequest`
+  - [x] 9.3 Handler: verify photo exists, belongs to request and account. Delete from S3 via `IPhotoService.DeletePhotoAsync`. Remove from DB. If deleted photo was primary, promote next photo by DisplayOrder.
+
+- [x] Task 10: Create DeleteMaintenanceRequestPhoto validator (AC: #6)
+  - [x] 10.1 Create `DeleteMaintenanceRequestPhotoValidator.cs` — validate MaintenanceRequestId NotEmpty, PhotoId NotEmpty
+
+- [x] Task 11: Create MaintenanceRequestPhotosController (AC: #2, #3, #5, #6, #8)
+  - [x] 11.1 Create `MaintenanceRequestPhotosController.cs` in `backend/src/PropertyManager.Api/Controllers/`
+  - [x] 11.2 Route: `api/v1/maintenance-requests/{maintenanceRequestId:guid}/photos`
+  - [x] 11.3 Class-level: `[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]` (no policy — both tenants and landlords can manage photos on their accessible requests, handler enforces scoping)
+  - [x] 11.4 POST `upload-url` endpoint: accepts `MaintenanceRequestPhotoUploadUrlRequest(ContentType, FileSizeBytes, OriginalFileName)`, returns 200 with upload URL details
+  - [x] 11.5 POST endpoint: accepts `MaintenanceRequestPhotoConfirmRequest(StorageKey, ThumbnailStorageKey, ContentType, FileSizeBytes, OriginalFileName)`, returns 201 with photo ID and URLs
+  - [x] 11.6 GET endpoint: returns list of photos with presigned URLs
+  - [x] 11.7 DELETE `{photoId:guid}` endpoint: returns 204
+  - [x] 11.8 Define Request records at bottom of controller file
+  - [x] 11.9 Inject IMediator, validators (upload URL, confirm, delete), ILogger
+
+- [x] Task 12: Include photos in GetMaintenanceRequestById response (AC: #4)
+  - [x] 12.1 Add `IReadOnlyList<MaintenanceRequestPhotoDto>? Photos` field to `MaintenanceRequestDto` (make it optional to avoid breaking existing list endpoint which does not need photos)
+  - [x] 12.2 In `GetMaintenanceRequestByIdQueryHandler`, include `Photos` navigation, generate presigned URLs for each photo, populate the DTO field
+  - [x] 12.3 Inject `IPhotoService` into `GetMaintenanceRequestByIdQueryHandler`
+
+- [x] Task 13: Backend unit tests — GenerateMaintenanceRequestPhotoUploadUrl handler (AC: #2, #8)
+  - [x] 13.1 Test: valid request returns upload URL details
+  - [x] 13.2 Test: calls IPhotoService with PhotoEntityType.MaintenanceRequests and correct entity ID
+  - [x] 13.3 Test: maintenance request not found throws NotFoundException
+  - [x] 13.4 Test: deleted maintenance request throws NotFoundException
+  - [x] 13.5 Test: tenant accessing request on different property throws NotFoundException
+
+- [x] Task 14: Backend unit tests — ConfirmMaintenanceRequestPhotoUpload handler (AC: #3)
+  - [x] 14.1 Test: valid confirm creates photo record and returns ID + URLs
+  - [x] 14.2 Test: first photo gets IsPrimary = true
+  - [x] 14.3 Test: subsequent photos get IsPrimary = false
+  - [x] 14.4 Test: DisplayOrder increments correctly
+  - [x] 14.5 Test: invalid storage key format throws ArgumentException
+  - [x] 14.6 Test: storage key for different account throws UnauthorizedAccessException
+  - [x] 14.7 Test: maintenance request not found throws NotFoundException
+
+- [x] Task 15: Backend unit tests — GetMaintenanceRequestPhotos handler (AC: #5)
+  - [x] 15.1 Test: returns photos ordered by DisplayOrder with presigned URLs
+  - [x] 15.2 Test: maintenance request not found throws NotFoundException
+  - [x] 15.3 Test: tenant accessing request on different property throws NotFoundException
+  - [x] 15.4 Test: empty photo list returns empty Items
+
+- [x] Task 16: Backend unit tests — DeleteMaintenanceRequestPhoto handler (AC: #6)
+  - [x] 16.1 Test: deletes photo from DB and calls IPhotoService.DeletePhotoAsync
+  - [x] 16.2 Test: photo not found throws NotFoundException
+  - [x] 16.3 Test: if deleted photo was primary, promotes next photo
+  - [x] 16.4 Test: if deleted photo was the only photo, no promotion needed
+
+- [x] Task 17: Backend unit tests — Validators (AC: #2, #3, #6)
+  - [x] 17.1 Test: GenerateUploadUrl validator — empty fields fail, valid passes
+  - [x] 17.2 Test: ConfirmUpload validator — empty fields fail, valid passes
+  - [x] 17.3 Test: Delete validator — empty IDs fail, valid passes
+
+- [x] Task 18: Backend unit tests — GetMaintenanceRequestById with photos (AC: #4)
+  - [x] 18.1 Test: detail response includes photos with presigned URLs
+  - [x] 18.2 Test: detail response with no photos returns empty list
+
+- [x] Task 19: Verify all existing tests pass (AC: all)
+  - [x] 19.1 Run `dotnet test` — all backend tests pass
+  - [x] 19.2 Run `dotnet build` — compiles without errors
+
+## Dev Notes
+
+### Architecture: Backend-Only Photo CRUD API
+
+This is a backend-only story following the exact same pattern as VendorPhotos (Epic 17, Story 17-13) and WorkOrderPhotos (Epic 10). No frontend changes. The `MaintenanceRequestPhoto` entity is symmetric with `WorkOrderPhoto` and `VendorPhoto` — same fields, same `IPhotoService` integration, same controller structure.
+
+### Key Pattern: Copy VendorPhotos, Replace "Vendor" with "MaintenanceRequest"
+
+The vendor photo implementation is the most recent and cleanest reference. The story involves:
+
+1. **Domain entity** (`MaintenanceRequestPhoto`) — mirrors `VendorPhoto` exactly
+2. **EF Core config** (`MaintenanceRequestPhotoConfiguration`) — mirrors `WorkOrderPhotoConfiguration`
+3. **Application handlers** — mirrors `VendorPhotos/` folder structure
+4. **Controller** — mirrors `VendorPhotosController` with route `api/v1/maintenance-requests/{maintenanceRequestId}/photos`
+5. **Tests** — mirrors `VendorPhotos/` test structure
+
+### S3 Key Pattern
+
+The `IPhotoService` generates storage keys automatically based on `PhotoEntityType` and entity ID. Add `MaintenanceRequests` to the `PhotoEntityType` enum. The resulting S3 key pattern will be: `{accountId}/maintenancerequests/{year}/{guid}.{ext}` (the photo service lowercases and removes spaces from the entity type name).
+
+### PhotoEntityType Enum Addition
+
+Add `MaintenanceRequests` to `PhotoEntityType` in `IPhotoService.cs`. This is the only change needed for the S3 key generation to work — the `IPhotoService` implementation uses the enum name in the storage key path.
+
+### Authorization: Role-Based Scoping in Handlers
+
+Both tenants and landlords can upload/view/delete photos on maintenance requests they can access:
+- **Tenant:** can access photos on requests for their assigned property (PropertyId match)
+- **Landlord (Owner/Contributor):** can access photos on any request in their account
+
+The controller has no policy attribute beyond JWT auth. Handlers enforce scoping by:
+1. Verifying the maintenance request exists with `AccountId == _currentUser.AccountId && DeletedAt == null`
+2. For tenant users, additionally checking `maintenanceRequest.PropertyId == _currentUser.PropertyId`
+
+This matches the existing pattern in `GetMaintenanceRequestByIdQueryHandler`.
+
+### Including Photos in Detail Response
+
+Modify `MaintenanceRequestDto` to include an optional `Photos` field. The `GetMaintenanceRequestByIdQueryHandler` will be updated to include photos with presigned URLs. The list endpoint (`GetMaintenanceRequests`) does NOT include photos — only the detail endpoint does (performance consideration for list views).
+
+### Key Files to Create
+
+**Domain Layer:**
+- `backend/src/PropertyManager.Domain/Entities/MaintenanceRequestPhoto.cs`
+
+**Application Layer (new folder `MaintenanceRequestPhotos/`):**
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrl.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrlValidator.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUpload.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUploadValidator.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GetMaintenanceRequestPhotos.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhoto.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhotoValidator.cs`
+
+**Infrastructure Layer:**
+- `backend/src/PropertyManager.Infrastructure/Persistence/Configurations/MaintenanceRequestPhotoConfiguration.cs`
+- New migration files (auto-generated)
+
+**API Layer:**
+- `backend/src/PropertyManager.Api/Controllers/MaintenanceRequestPhotosController.cs`
+
+### Key Files to Modify
+
+- `backend/src/PropertyManager.Domain/Entities/MaintenanceRequest.cs` — add `Photos` navigation collection
+- `backend/src/PropertyManager.Application/Common/Interfaces/IPhotoService.cs` — add `MaintenanceRequests` to `PhotoEntityType` enum
+- `backend/src/PropertyManager.Application/Common/Interfaces/IAppDbContext.cs` — add `DbSet<MaintenanceRequestPhoto>`
+- `backend/src/PropertyManager.Infrastructure/Persistence/AppDbContext.cs` — add DbSet + global query filter
+- `backend/src/PropertyManager.Application/MaintenanceRequests/MaintenanceRequestDto.cs` — add optional Photos field
+- `backend/src/PropertyManager.Application/MaintenanceRequests/GetMaintenanceRequestById.cs` — include photos, inject IPhotoService
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GetMaintenanceRequestPhotos.cs` — photo DTO (reused in detail)
+
+### Critical Patterns to Follow
+
+1. **Entity extends `AuditableEntity` + implements `ITenantEntity`.** No `ISoftDeletable` — photo entities are hard-deleted (matching WorkOrderPhoto and VendorPhoto patterns).
+
+2. **Global query filter on AccountId only** (no soft delete filter since photos are hard-deleted). Pattern: `HasQueryFilter(e => CurrentAccountId == null || e.AccountId == CurrentAccountId)`.
+
+3. **No repository pattern.** Handlers use `IAppDbContext` directly.
+
+4. **Validators injected into controllers and called explicitly** before `_mediator.Send()`.
+
+5. **Request/Response records at bottom of controller file.** Follow `VendorPhotosController` pattern.
+
+6. **Controller route:** `api/v1/maintenance-requests/{maintenanceRequestId:guid}/photos` — nested under maintenance requests.
+
+7. **Auto-primary logic:** First photo uploaded for a maintenance request gets `IsPrimary = true`. Subsequent photos get `IsPrimary = false`.
+
+8. **Delete with primary promotion:** When deleting a primary photo, promote the next photo by DisplayOrder to primary.
+
+9. **DisplayOrder calculation:** `maxDisplayOrder + 1` for new photos, starting from 0.
+
+10. **Presigned URL generation in parallel:** Use `Task.WhenAll` pattern from `GetVendorPhotosHandler`.
+
+11. **Storage key validation on confirm:** Validate that the storage key's account prefix matches `_currentUser.AccountId`.
+
+12. **Photo DTO reuse:** The `MaintenanceRequestPhotoDto` defined in `GetMaintenanceRequestPhotos.cs` should be reused by the detail endpoint.
+
+### Previous Story Intelligence
+
+From Story 20.3:
+- `MaintenanceRequest` entity is in place with `AuditableEntity`, `ITenantEntity`, `ISoftDeletable`
+- `MaintenanceRequestsController` exists at `api/v1/maintenance-requests`
+- `GetMaintenanceRequestByIdQueryHandler` does explicit account + tenant property scoping — same pattern needed for photo handlers
+- `BusinessRuleException` was created and mapped to 400 in middleware
+- Backend baseline: 1150 tests passing
+- Frontend baseline: 2703 tests passing
+- NSwag generation may fail with .NET 10 — manual API client update is acceptable
+
+From VendorPhotos (reference implementation):
+- Full CRUD: GenerateUploadUrl, ConfirmUpload, GetPhotos, Delete, SetPrimary, Reorder
+- For this story: only GenerateUploadUrl, ConfirmUpload, GetPhotos, Delete (no SetPrimary or Reorder — keep it minimal for tenant use case)
+- Test pattern: mock `IPhotoService`, `IAppDbContext`, `ICurrentUser`; use `MockQueryable.Moq`'s `BuildMockDbSet()`
+
+### Testing Strategy
+
+- **Backend unit tests** for:
+  - GenerateUploadUrl handler (valid request, entity type, not found, deleted, tenant scoping)
+  - ConfirmUpload handler (creates record, auto-primary, display order, key validation, not found)
+  - GetPhotos handler (ordered list, not found, tenant scoping, empty list)
+  - Delete handler (removes + S3 cleanup, primary promotion, not found)
+  - All validators (required fields, constraints)
+  - GetMaintenanceRequestById with photos (includes photos, empty photos)
+- **No frontend tests** — backend-only story
+- **No E2E tests** — tenant photo UI comes in Story 20.5 (tenant dashboard)
+
+### References
+
+- Epic file: `docs/project/stories/epic-20/epic-20-tenant-portal.md` (Story 20.4)
+- Previous story: `docs/project/stories/epic-20/20-3-maintenance-request-entity-api.md`
+- Tenant Portal PRD: `docs/project/prd-tenant-portal.md` (FR-TP21, MaintenanceRequestPhoto data model)
+- Reference implementation (VendorPhotos — most recent, cleanest):
+  - Entity: `backend/src/PropertyManager.Domain/Entities/VendorPhoto.cs`
+  - Generate URL: `backend/src/PropertyManager.Application/VendorPhotos/GenerateVendorPhotoUploadUrl.cs`
+  - Generate URL validator: `backend/src/PropertyManager.Application/VendorPhotos/GenerateVendorPhotoUploadUrlValidator.cs`
+  - Confirm upload: `backend/src/PropertyManager.Application/VendorPhotos/ConfirmVendorPhotoUpload.cs`
+  - Confirm validator: `backend/src/PropertyManager.Application/VendorPhotos/ConfirmVendorPhotoUploadValidator.cs`
+  - Get photos: `backend/src/PropertyManager.Application/VendorPhotos/GetVendorPhotos.cs`
+  - Delete: `backend/src/PropertyManager.Application/VendorPhotos/DeleteVendorPhoto.cs`
+  - Controller: `backend/src/PropertyManager.Api/Controllers/VendorPhotosController.cs`
+  - Tests: `backend/tests/PropertyManager.Application.Tests/VendorPhotos/`
+- Reference implementation (WorkOrderPhotos — EF Config):
+  - Config: `backend/src/PropertyManager.Infrastructure/Persistence/Configurations/WorkOrderPhotoConfiguration.cs`
+  - Entity: `backend/src/PropertyManager.Domain/Entities/WorkOrderPhoto.cs`
+- IPhotoService: `backend/src/PropertyManager.Application/Common/Interfaces/IPhotoService.cs`
+- IAppDbContext: `backend/src/PropertyManager.Application/Common/Interfaces/IAppDbContext.cs`
+- AppDbContext: `backend/src/PropertyManager.Infrastructure/Persistence/AppDbContext.cs`
+- MaintenanceRequest entity: `backend/src/PropertyManager.Domain/Entities/MaintenanceRequest.cs`
+- MaintenanceRequestDto: `backend/src/PropertyManager.Application/MaintenanceRequests/MaintenanceRequestDto.cs`
+- GetMaintenanceRequestById: `backend/src/PropertyManager.Application/MaintenanceRequests/GetMaintenanceRequestById.cs`
+- ICurrentUser: `backend/src/PropertyManager.Application/Common/Interfaces/ICurrentUser.cs`
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Opus 4.6 (1M context)
+
+### Debug Log References
+- Build succeeded with 0 errors, 0 warnings (relevant)
+- All 1,812 backend tests pass (1183 Application + 98 Infrastructure + 531 Api)
+- 31 new MaintenanceRequestPhotos tests + 2 new GetMaintenanceRequestById photo tests = 33 new tests
+
+### Completion Notes List
+- Tasks 1-3: Domain entity, PhotoEntityType enum, EF Core config + migration created and applied
+- Tasks 4-10: All CQRS handlers, validators created following VendorPhotos pattern exactly
+- Task 11: Controller created with 4 endpoints (upload-url, confirm, get, delete)
+- Task 12: GetMaintenanceRequestById now includes Photos with presigned URLs
+- Tasks 13-18: All unit tests written and passing (33 new tests total)
+- Task 19: Full test suite passes with zero regressions
+- Pattern: Symmetric with VendorPhotos — same handler structure, same test patterns, same controller layout
+- Authorization: Both tenants and landlords can manage photos; tenant scoping enforced in handlers via PropertyId check
+
+### File List
+
+**New Files:**
+- `backend/src/PropertyManager.Domain/Entities/MaintenanceRequestPhoto.cs`
+- `backend/src/PropertyManager.Infrastructure/Persistence/Configurations/MaintenanceRequestPhotoConfiguration.cs`
+- `backend/src/PropertyManager.Infrastructure/Persistence/Migrations/*AddMaintenanceRequestPhotos*` (migration files)
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrl.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrlValidator.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUpload.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUploadValidator.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/GetMaintenanceRequestPhotos.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhoto.cs`
+- `backend/src/PropertyManager.Application/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhotoValidator.cs`
+- `backend/src/PropertyManager.Api/Controllers/MaintenanceRequestPhotosController.cs`
+- `backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/GenerateMaintenanceRequestPhotoUploadUrlHandlerTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ConfirmMaintenanceRequestPhotoUploadHandlerTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/GetMaintenanceRequestPhotosHandlerTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/DeleteMaintenanceRequestPhotoHandlerTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ValidatorTests.cs`
+
+**Modified Files:**
+- `backend/src/PropertyManager.Domain/Entities/MaintenanceRequest.cs` — added Photos navigation collection
+- `backend/src/PropertyManager.Application/Common/Interfaces/IPhotoService.cs` — added MaintenanceRequests to PhotoEntityType enum
+- `backend/src/PropertyManager.Application/Common/Interfaces/IAppDbContext.cs` — added DbSet<MaintenanceRequestPhoto>
+- `backend/src/PropertyManager.Infrastructure/Persistence/AppDbContext.cs` — added DbSet + global query filter
+- `backend/src/PropertyManager.Application/MaintenanceRequests/MaintenanceRequestDto.cs` — added optional Photos field
+- `backend/src/PropertyManager.Application/MaintenanceRequests/GetMaintenanceRequestById.cs` — included Photos, injected IPhotoService
+- `backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/GetMaintenanceRequestByIdHandlerTests.cs` — added IPhotoService mock + 2 photo tests
+- `docs/project/sprint-status.yaml` — updated story status


### PR DESCRIPTION
## Summary
- Add `MaintenanceRequestPhoto` domain entity with S3 presigned URL support for tenant maintenance request photos
- Implement 4 CQRS endpoints: generate upload URL, confirm upload, get photos, delete photo (with primary promotion)
- Tenant property scoping enforced on all handlers — tenants can only manage photos for their assigned property's requests
- 35 unit tests covering happy paths, validation, error cases, and tenant isolation

## Acceptance Criteria
- [x] AC-20.4.1: Presigned upload URL scoped to maintenance request photos
- [x] AC-20.4.2: Confirm upload creates MaintenanceRequestPhoto record
- [x] AC-20.4.3: View request returns presigned download URLs for photos
- [x] AC-20.4.4: Entity has required fields (Id, MaintenanceRequestId, S3Key, FileName, ContentType, FileSize, DisplayOrder)
- [x] AC-20.4.5: Photos ordered by DisplayOrder
- [x] AC-20.4.6: Delete removes from S3 and DB, promotes next photo to primary
- [x] AC-20.4.7: EF Core migration with proper FKs and indexes
- [x] AC-20.4.8: Tenant scoping on all endpoints

## Test Results
- Backend: 1,814 tests passing (0 failures)
- Frontend: 2,703 tests passing (0 failures)
- E2E: 212/213 passing (1 pre-existing failure, unrelated)

## Test plan
- [ ] CI passes (backend build + test, frontend build + test)
- [ ] Verify new migration applies cleanly on fresh database
- [ ] Verify Swagger shows 4 new endpoints under /api/v1/maintenance-requests/{id}/photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)