### PR TITLE
test: tighten validation message assertions (Story 21.11)

### DIFF
--- a/backend/tests/PropertyManager.Application.Tests/Expenses/LinkReceiptToExpenseValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Expenses/LinkReceiptToExpenseValidatorTests.cs
@@ -27,7 +27,7 @@ public class LinkReceiptToExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "ExpenseId");
+        result.Errors.Should().Contain(e => e.PropertyName == "ExpenseId" && e.ErrorMessage == "'Expense Id' must not be empty.");
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public class LinkReceiptToExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "ReceiptId");
+        result.Errors.Should().Contain(e => e.PropertyName == "ReceiptId" && e.ErrorMessage == "'Receipt Id' must not be empty.");
     }
 
     [Fact]

--- a/backend/tests/PropertyManager.Application.Tests/Expenses/UpdateExpenseValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Expenses/UpdateExpenseValidatorTests.cs
@@ -51,7 +51,7 @@ public class UpdateExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Id");
+        result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage == "Expense ID is required");
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public class UpdateExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "CategoryId");
+        result.Errors.Should().Contain(e => e.PropertyName == "CategoryId" && e.ErrorMessage == "Category is required");
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class UpdateExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Amount" && e.ErrorMessage.Contains("greater than"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Amount" && e.ErrorMessage == "Amount must be greater than $0");
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class UpdateExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Amount");
+        result.Errors.Should().Contain(e => e.PropertyName == "Amount" && e.ErrorMessage == "Amount must be greater than $0");
     }
 
     [Fact]
@@ -127,7 +127,7 @@ public class UpdateExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Amount" && e.ErrorMessage.Contains("maximum"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Amount" && e.ErrorMessage == "Amount exceeds maximum of $9,999,999.99");
     }
 
     [Fact]
@@ -146,7 +146,7 @@ public class UpdateExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Amount" && e.ErrorMessage.Contains("decimal"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Amount" && e.ErrorMessage == "Amount can have at most 2 decimal places");
     }
 
     [Fact]
@@ -165,7 +165,7 @@ public class UpdateExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Date" && e.ErrorMessage.Contains("future"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Date" && e.ErrorMessage == "Date cannot be in the future");
     }
 
     [Fact]
@@ -221,7 +221,7 @@ public class UpdateExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Description" && e.ErrorMessage.Contains("500"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Description" && e.ErrorMessage == "Description must be 500 characters or less");
     }
 
     [Fact]
@@ -259,7 +259,7 @@ public class UpdateExpenseValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Description" && e.ErrorMessage.Contains("HTML"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Description" && e.ErrorMessage == "Description cannot contain HTML");
     }
 
     [Fact]

--- a/backend/tests/PropertyManager.Application.Tests/Income/UpdateIncomeValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Income/UpdateIncomeValidatorTests.cs
@@ -50,7 +50,7 @@ public class UpdateIncomeValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Id");
+        result.Errors.Should().Contain(e => e.PropertyName == "Id" && e.ErrorMessage == "Income ID is required.");
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class UpdateIncomeValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e =>
             e.PropertyName == "Amount" &&
-            e.ErrorMessage.Contains("greater than"));
+            e.ErrorMessage == "Amount must be greater than $0");
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class UpdateIncomeValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e =>
             e.PropertyName == "Amount" &&
-            e.ErrorMessage.Contains("greater than"));
+            e.ErrorMessage == "Amount must be greater than $0");
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public class UpdateIncomeValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Date");
+        result.Errors.Should().Contain(e => e.PropertyName == "Date" && e.ErrorMessage == "Date is required.");
     }
 
     [Fact]
@@ -224,6 +224,6 @@ public class UpdateIncomeValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId");
+        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId" && e.ErrorMessage == "Property ID must be a valid GUID when provided.");
     }
 }

--- a/backend/tests/PropertyManager.Application.Tests/Invitations/CreateInvitationTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Invitations/CreateInvitationTests.cs
@@ -220,7 +220,7 @@ public class CreateInvitationTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Email");
+        result.Errors.Should().Contain(e => e.PropertyName == "Email" && e.ErrorMessage == "Email is required");
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public class CreateInvitationTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Email" && e.ErrorMessage.Contains("Invalid email"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Email" && e.ErrorMessage == "Invalid email format");
     }
 
     [Fact]
@@ -264,7 +264,7 @@ public class CreateInvitationTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Role");
+        result.Errors.Should().Contain(e => e.PropertyName == "Role" && e.ErrorMessage == "Role must be 'Owner', 'Contributor', or 'Tenant'");
     }
 
     [Theory]
@@ -281,7 +281,7 @@ public class CreateInvitationTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Role");
+        result.Errors.Should().Contain(e => e.PropertyName == "Role" && e.ErrorMessage == "Role is required");
     }
 
     [Theory]
@@ -477,7 +477,7 @@ public class CreateInvitationTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId" && e.ErrorMessage.Contains("required"));
+        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId" && e.ErrorMessage == "PropertyId is required for Tenant invitations");
     }
 
     [Fact]
@@ -492,6 +492,6 @@ public class CreateInvitationTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId" && e.ErrorMessage.Contains("only be set for Tenant"));
+        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId" && e.ErrorMessage == "PropertyId should only be set for Tenant invitations");
     }
 }

--- a/backend/tests/PropertyManager.Application.Tests/Invitations/ResendInvitationTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Invitations/ResendInvitationTests.cs
@@ -337,6 +337,6 @@ public class ResendInvitationValidatorTests
         var command = new ResendInvitationCommand(Guid.Empty);
         var result = validator.Validate(command);
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "InvitationId");
+        result.Errors.Should().Contain(e => e.PropertyName == "InvitationId" && e.ErrorMessage == "Invitation ID is required");
     }
 }

--- a/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ValidatorTests.cs
@@ -30,7 +30,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "MaintenanceRequestId");
+        result.Errors.Should().Contain(e => e.PropertyName == "MaintenanceRequestId" && e.ErrorMessage == "Maintenance request ID is required");
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "ContentType");
+        result.Errors.Should().Contain(e => e.PropertyName == "ContentType" && e.ErrorMessage == "Content type must be one of: image/jpeg, image/png, image/gif, image/webp, image/bmp, image/tiff");
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "FileSizeBytes");
+        result.Errors.Should().Contain(e => e.PropertyName == "FileSizeBytes" && e.ErrorMessage == "File size must not exceed 10MB");
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "OriginalFileName");
+        result.Errors.Should().Contain(e => e.PropertyName == "OriginalFileName" && e.ErrorMessage == "Original file name is required");
     }
 
     #endregion
@@ -99,7 +99,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "StorageKey");
+        result.Errors.Should().Contain(e => e.PropertyName == "StorageKey" && e.ErrorMessage == "Storage key is required");
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "ThumbnailStorageKey");
+        result.Errors.Should().Contain(e => e.PropertyName == "ThumbnailStorageKey" && e.ErrorMessage == "Thumbnail storage key is required");
     }
 
     #endregion
@@ -140,7 +140,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "MaintenanceRequestId");
+        result.Errors.Should().Contain(e => e.PropertyName == "MaintenanceRequestId" && e.ErrorMessage == "Maintenance request ID is required");
     }
 
     [Fact]
@@ -152,7 +152,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PhotoId");
+        result.Errors.Should().Contain(e => e.PropertyName == "PhotoId" && e.ErrorMessage == "Photo ID is required");
     }
 
     #endregion

--- a/backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/CreateMaintenanceRequestValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/CreateMaintenanceRequestValidatorTests.cs
@@ -18,7 +18,7 @@ public class CreateMaintenanceRequestValidatorTests
         var result = await _validator.ValidateAsync(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.ErrorMessage == "Description is required");
+        result.Errors.Should().Contain(e => e.PropertyName == "Description" && e.ErrorMessage == "Description is required");
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class CreateMaintenanceRequestValidatorTests
         var result = await _validator.ValidateAsync(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.ErrorMessage == "Description must be 5000 characters or less");
+        result.Errors.Should().Contain(e => e.PropertyName == "Description" && e.ErrorMessage == "Description must be 5000 characters or less");
     }
 
     [Fact]

--- a/backend/tests/PropertyManager.Application.Tests/Notes/CreateNoteCommandValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Notes/CreateNoteCommandValidatorTests.cs
@@ -40,7 +40,7 @@ public class CreateNoteCommandValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Content" && e.ErrorMessage.Contains("required"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Content" && e.ErrorMessage == "Content is required");
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class CreateNoteCommandValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Content");
+        result.Errors.Should().Contain(e => e.PropertyName == "Content" && e.ErrorMessage == "Content is required");
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public class CreateNoteCommandValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e =>
             e.PropertyName == "EntityType" &&
-            e.ErrorMessage.Contains("must be one of"));
+            e.ErrorMessage == "EntityType must be one of: WorkOrder, Vendor, Property");
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class CreateNoteCommandValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "EntityType");
+        result.Errors.Should().Contain(e => e.PropertyName == "EntityType" && e.ErrorMessage == "EntityType is required");
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class CreateNoteCommandValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "EntityId");
+        result.Errors.Should().Contain(e => e.PropertyName == "EntityId" && e.ErrorMessage == "EntityId is required");
     }
 
     [Theory]
@@ -131,6 +131,6 @@ public class CreateNoteCommandValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "EntityType");
+        result.Errors.Should().Contain(e => e.PropertyName == "EntityType" && e.ErrorMessage == "EntityType must be one of: WorkOrder, Vendor, Property");
     }
 }

--- a/backend/tests/PropertyManager.Application.Tests/Properties/CreatePropertyValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Properties/CreatePropertyValidatorTests.cs
@@ -145,7 +145,7 @@ public class CreatePropertyValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "State");
+        result.Errors.Should().Contain(e => e.PropertyName == "State" && e.ErrorMessage == "State is required");
     }
 
     [Theory]
@@ -186,7 +186,7 @@ public class CreatePropertyValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "ZipCode");
+        result.Errors.Should().Contain(e => e.PropertyName == "ZipCode" && e.ErrorMessage == "ZIP Code is required");
     }
 
     [Theory]

--- a/backend/tests/PropertyManager.Application.Tests/PropertyPhotos/ValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/PropertyPhotos/ValidatorTests.cs
@@ -44,7 +44,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId");
+        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId" && e.ErrorMessage == "Property ID is required");
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "ContentType");
+        result.Errors.Should().Contain(e => e.PropertyName == "ContentType" && e.ErrorMessage == "Content type must be one of: image/jpeg, image/png, image/gif, image/webp, image/bmp, image/tiff");
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "FileSizeBytes");
+        result.Errors.Should().Contain(e => e.PropertyName == "FileSizeBytes" && e.ErrorMessage == "File size must not exceed 10MB");
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "OriginalFileName");
+        result.Errors.Should().Contain(e => e.PropertyName == "OriginalFileName" && e.ErrorMessage == "Original file name is required");
     }
 
     #endregion
@@ -146,7 +146,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "StorageKey");
+        result.Errors.Should().Contain(e => e.PropertyName == "StorageKey" && e.ErrorMessage == "Storage key is required");
     }
 
     [Fact]
@@ -167,7 +167,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "ThumbnailStorageKey");
+        result.Errors.Should().Contain(e => e.PropertyName == "ThumbnailStorageKey" && e.ErrorMessage == "Thumbnail storage key is required");
     }
 
     #endregion
@@ -204,7 +204,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId");
+        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId" && e.ErrorMessage == "Property ID is required");
     }
 
     [Fact]
@@ -221,7 +221,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PhotoId");
+        result.Errors.Should().Contain(e => e.PropertyName == "PhotoId" && e.ErrorMessage == "Photo ID is required");
     }
 
     #endregion
@@ -258,7 +258,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId");
+        result.Errors.Should().Contain(e => e.PropertyName == "PropertyId" && e.ErrorMessage == "Property ID is required");
     }
 
     #endregion
@@ -295,7 +295,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PhotoIds");
+        result.Errors.Should().Contain(e => e.PropertyName == "PhotoIds" && e.ErrorMessage == "Photo IDs cannot be empty");
     }
 
     [Fact]
@@ -312,7 +312,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PhotoIds");
+        result.Errors.Should().Contain(e => e.PropertyName == "PhotoIds" && e.ErrorMessage == "Photo IDs are required");
     }
 
     [Fact]
@@ -329,6 +329,7 @@ public class ValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Photo ID cannot be empty");
     }
 
     #endregion

--- a/backend/tests/PropertyManager.Application.Tests/VendorPhotos/ValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/VendorPhotos/ValidatorTests.cs
@@ -30,7 +30,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "VendorId");
+        result.Errors.Should().Contain(e => e.PropertyName == "VendorId" && e.ErrorMessage == "Vendor ID is required");
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "ContentType");
+        result.Errors.Should().Contain(e => e.PropertyName == "ContentType" && e.ErrorMessage == "Content type must be one of: image/jpeg, image/png, image/gif, image/webp, image/bmp, image/tiff");
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "FileSizeBytes");
+        result.Errors.Should().Contain(e => e.PropertyName == "FileSizeBytes" && e.ErrorMessage == "File size must not exceed 10MB");
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "OriginalFileName");
+        result.Errors.Should().Contain(e => e.PropertyName == "OriginalFileName" && e.ErrorMessage == "Original file name is required");
     }
 
     #endregion
@@ -97,7 +97,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "StorageKey");
+        result.Errors.Should().Contain(e => e.PropertyName == "StorageKey" && e.ErrorMessage == "Storage key is required");
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "ThumbnailStorageKey");
+        result.Errors.Should().Contain(e => e.PropertyName == "ThumbnailStorageKey" && e.ErrorMessage == "Thumbnail storage key is required");
     }
 
     #endregion
@@ -138,7 +138,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "VendorId");
+        result.Errors.Should().Contain(e => e.PropertyName == "VendorId" && e.ErrorMessage == "Vendor ID is required");
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PhotoId");
+        result.Errors.Should().Contain(e => e.PropertyName == "PhotoId" && e.ErrorMessage == "Photo ID is required");
     }
 
     #endregion
@@ -177,7 +177,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "VendorId");
+        result.Errors.Should().Contain(e => e.PropertyName == "VendorId" && e.ErrorMessage == "Vendor ID is required");
     }
 
     #endregion
@@ -204,7 +204,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PhotoIds");
+        result.Errors.Should().Contain(e => e.PropertyName == "PhotoIds" && e.ErrorMessage == "Photo IDs cannot be empty");
     }
 
     [Fact]
@@ -216,7 +216,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "PhotoIds");
+        result.Errors.Should().Contain(e => e.PropertyName == "PhotoIds" && e.ErrorMessage == "Photo IDs are required");
     }
 
     [Fact]
@@ -228,6 +228,7 @@ public class ValidatorTests
         var result = validator.Validate(command);
 
         result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Photo ID cannot be empty");
     }
 
     #endregion

--- a/backend/tests/PropertyManager.Application.Tests/VendorTradeTags/CreateVendorTradeTagValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/VendorTradeTags/CreateVendorTradeTagValidatorTests.cs
@@ -37,7 +37,7 @@ public class CreateVendorTradeTagValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Name");
+        result.Errors.Should().Contain(e => e.PropertyName == "Name" && e.ErrorMessage == "Name is required");
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class CreateVendorTradeTagValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Name" && e.ErrorMessage.Contains("100"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Name" && e.ErrorMessage == "Name must be 100 characters or less");
     }
 
     [Fact]

--- a/backend/tests/PropertyManager.Application.Tests/WorkOrderTags/CreateWorkOrderTagValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/WorkOrderTags/CreateWorkOrderTagValidatorTests.cs
@@ -37,7 +37,7 @@ public class CreateWorkOrderTagValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Name");
+        result.Errors.Should().Contain(e => e.PropertyName == "Name" && e.ErrorMessage == "Name is required");
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class CreateWorkOrderTagValidatorTests
 
         // Assert
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == "Name" && e.ErrorMessage.Contains("100"));
+        result.Errors.Should().Contain(e => e.PropertyName == "Name" && e.ErrorMessage == "Name must be 100 characters or less");
     }
 
     [Fact]

--- a/backend/tests/PropertyManager.Application.Tests/WorkOrders/GetAllWorkOrdersValidatorTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/WorkOrders/GetAllWorkOrdersValidatorTests.cs
@@ -105,9 +105,7 @@ public class GetAllWorkOrdersValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainSingle();
         result.Errors[0].PropertyName.Should().Be("Status");
-        result.Errors[0].ErrorMessage.Should().Contain("Reported");
-        result.Errors[0].ErrorMessage.Should().Contain("Assigned");
-        result.Errors[0].ErrorMessage.Should().Contain("Completed");
+        result.Errors[0].ErrorMessage.Should().Be("Status must be one of: Reported, Assigned, Completed");
     }
 
     [Fact]

--- a/docs/project/sprint-status.yaml
+++ b/docs/project/sprint-status.yaml
@@ -353,6 +353,6 @@ development_status:
   21-8-work-orders-e2e: done    # P2 - L - Issue #371
   21-9-auth-handler-unit-tests: done    # P3 - M - Issue #371
   21-10-dashboard-unit-and-e2e-tests: done    # P3 - M - Issue #371
-  21-11-validation-message-assertion-improvements: backlog    # P3 - S - Issue #371
+  21-11-validation-message-assertion-improvements: done    # P3 - S - Issue #371
   21-12-pagination-edge-case-tests: backlog    # P3 - S - Issue #371
   epic-21-retrospective: optional

--- a/docs/project/stories/epic-21/21-11-validation-message-assertion-improvements.md
+++ b/docs/project/stories/epic-21/21-11-validation-message-assertion-improvements.md
@@ -1,0 +1,465 @@
+# Story 21.11: Validation Message Assertion Improvements
+
+Status: done
+
+## Story
+
+As a developer,
+I want existing FluentValidation unit tests and Angular reactive form component tests to assert the **exact validation error message text** (not just "validation failed" or `form.invalid === true`),
+so that a future edit to a validator's `.WithMessage(...)` string or to a control's error template surfaces as a failing test instead of silently slipping past CI.
+
+## Acceptance Criteria
+
+> **Reality check (epic vs. shipped tests) — read this before changing any assertion.**
+>
+> The epic spec at `epic-21-epics-test-coverage.md` § Story 21.11 says "existing tests often assert 'validation fails' without asserting the specific message" and that this story tightens those assertions across the existing corpus with **no new test files or test cases** (epic AC-3). A repo-wide audit (April 2026) of every `*ValidatorTests.cs` and every component spec referencing `hasError(...)`, `form.invalid`, or `mat-error` was completed during story creation. The findings:
+>
+> 1. **Backend validator tests fall into three buckets** based on assertion strength:
+>    - **Strong (already use `WithErrorMessage` via `FluentValidation.TestHelper.TestValidate(...)` extension):** `Vendors/CreateVendorValidatorTests.cs`, `Vendors/UpdateVendorValidatorTests.cs`, `Vendors/DeleteVendorValidatorTests.cs`, `Receipts/GenerateUploadUrlValidatorTests.cs`, `Income/CreateIncomeValidatorTests.cs`, `WorkOrders/CreateWorkOrderValidatorTests.cs`, `WorkOrders/UpdateWorkOrderValidatorTests.cs`, `WorkOrders/ReorderWorkOrderPhotosValidatorTests.cs`, `Photos/ConfirmPhotoUploadValidatorTests.cs`, `Photos/GeneratePhotoUploadUrlValidatorTests.cs`, `AccountUsers/UpdateUserRoleValidatorTests.cs`. **Out of scope for this story** — already meet the bar.
+>    - **Mixed (strong on some `[Fact]`s; weak — `PropertyName`-only or `ErrorMessage.Contains("...")` substring — on others):** `Properties/CreatePropertyValidatorTests.cs`, `Expenses/UpdateExpenseValidatorTests.cs`, `Income/UpdateIncomeValidatorTests.cs`, `MaintenanceRequests/CreateMaintenanceRequestValidatorTests.cs`, `Notes/CreateNoteCommandValidatorTests.cs`, `Invitations/CreateInvitationTests.cs`, `Invitations/ValidateInvitationTests.cs`, `Invitations/ResendInvitationTests.cs`, `WorkOrderTags/CreateWorkOrderTagValidatorTests.cs`, `VendorTradeTags/CreateVendorTradeTagValidatorTests.cs`, `WorkOrders/GetAllWorkOrdersValidatorTests.cs`, `Expenses/LinkReceiptToExpenseValidatorTests.cs`. **In scope.**
+>    - **Weak across the whole file (every "fails" assertion is `PropertyName`-only):** `MaintenanceRequestPhotos/ValidatorTests.cs`, `PropertyPhotos/ValidatorTests.cs`, `VendorPhotos/ValidatorTests.cs`. **In scope.**
+>
+> 2. **Frontend component specs fall into two buckets:**
+>    - **Strong (already query `mat-error` and assert on `nativeElement.textContent`):** `work-orders/components/work-order-form/work-order-form.component.spec.ts`, `vendors/components/inline-vendor-dialog/inline-vendor-dialog.component.spec.ts`, `tenant-dashboard/components/submit-request/submit-request.component.spec.ts`. **Out of scope.**
+>    - **Weak (`hasError('xxx')` or `form.invalid` only, no DOM-rendered error text assertion):** `auth/login/login.component.spec.ts`, `auth/forgot-password/forgot-password.component.spec.ts`, `auth/reset-password/reset-password.component.spec.ts`, `auth/accept-invitation/accept-invitation.component.spec.ts`, `expenses/components/expense-form/expense-form.component.spec.ts`, `expenses/components/create-expense-from-wo-dialog/create-expense-from-wo-dialog.component.spec.ts`, `income/components/income-form/income-form.component.spec.ts`, `properties/property-form/property-form.component.spec.ts`, `properties/property-edit/property-edit.component.spec.ts`, `properties/components/invite-tenant-dialog/invite-tenant-dialog.component.spec.ts`, `vendors/components/vendor-form/vendor-form.component.spec.ts`, `vendors/components/vendor-edit/vendor-edit.component.spec.ts`, `work-orders/components/create-wo-from-expense-dialog/create-wo-from-expense-dialog.component.spec.ts`, `receipts/components/receipt-expense-form/receipt-expense-form.component.spec.ts`. **In scope.**
+>
+> 3. **Per epic AC-3, this story adds NO new test files and NO new `[Fact]`/`it(...)` blocks.** Every change is a *strengthened assertion within an existing test*. If during the work the dev finds a validator/template where the rendered error text doesn't match the expected message (or where no `mat-error` actually renders for a control flagged invalid), the validator/template is fixed (not the test) — **don't assert wrong behavior just to make the test pass.**
+>
+> 4. **The "fix the validator if it's wrong" rule has a corollary: don't change a validator message in a way that breaks any currently-passing test that's already asserting on the exact text.** Read the validator's `.WithMessage("...")` string (or the template's `<mat-error>` text) and use that exact text in the new assertion. The strong-bucket files above are the source of truth for the canonical strings on backend (e.g. `"First name is required"`, `"Phone number is required"`, `"Amount must be greater than $0"`).
+
+### AC-1: Backend FluentValidation tests assert the exact error message on every "fails" assertion
+
+For every validator test file in the **mixed** and **weak** buckets above, every `[Fact]`/`[Theory]` whose assertion currently looks like:
+
+```csharp
+result.IsValid.Should().BeFalse();
+result.Errors.Should().Contain(e => e.PropertyName == "X");
+```
+
+OR
+
+```csharp
+result.IsValid.Should().BeFalse();
+result.Errors.Should().Contain(e => e.PropertyName == "X" && e.ErrorMessage.Contains("substring"));
+```
+
+…must be tightened to one of the following two equivalent strict forms (pick whichever keeps the test file's existing style consistent — do not mix styles within a single file):
+
+**Form A — keep `.ValidateAsync` / `.Validate`, tighten the predicate to full-equality:**
+
+```csharp
+result.IsValid.Should().BeFalse();
+result.Errors.Should().Contain(e =>
+    e.PropertyName == "X" &&
+    e.ErrorMessage == "<exact message from validator's .WithMessage(...) call>");
+```
+
+**Form B — switch to `FluentValidation.TestHelper.TestValidate` extension:**
+
+```csharp
+using FluentValidation.TestHelper;
+// ...
+var result = _validator.TestValidate(command);
+result.ShouldHaveValidationErrorFor(x => x.X)
+    .WithErrorMessage("<exact message from validator's .WithMessage(...) call>");
+```
+
+- **AC-1.1:** For every "fails" `[Fact]`/`[Theory]` in the in-scope files, the assertion includes the **exact** expected error message (string equality, not `.Contains(...)`) — sourced from reading the corresponding validator's `.WithMessage(...)` calls.
+- **AC-1.2:** No `result.Errors.Should().Contain(e => e.ErrorMessage.Contains("..."))` substring-style assertions remain in any in-scope file. (Substring matching is the explicit anti-pattern this story removes.)
+- **AC-1.3:** `[Theory]` cases that produce the **same** message across all rows still get exact-message assertions; cases that produce **different** messages across rows are split into separate `[Fact]`s OR the `[Theory]` adds an `expectedMessage` `InlineData` column. Choose whichever pattern matches the file's neighboring tests.
+- **AC-1.4:** "Passes" assertions (`result.IsValid.Should().BeTrue()` and `result.Errors.Should().BeEmpty()`) are **not changed** — the story scope is "fails" assertions only. Strengthening positive paths is out of scope.
+- **AC-1.5:** If a validator test exercises a rule that has **no `.WithMessage(...)` override** in the validator (i.e., FluentValidation's default localized message), the dev resolves this by reading the FluentValidation default for the rule (e.g., `"'Property X' must not be empty."`) and asserts that exact default. **Don't add a `.WithMessage(...)` to the validator just to satisfy a test** — that's a behavior change, not a test improvement.
+- **AC-1.6:** If a validator's actual `.WithMessage(...)` text contains a **typo** or **inconsistency** (e.g., `"Description must be 500 characters or less"` vs. `"Maximum 500 characters"`), the validator is the source of truth — **fix the validator only if the typo is genuinely wrong** (per epic technical-notes guidance). Document any validator change in the Dev Agent Record File List.
+
+### AC-2: Frontend reactive form component tests assert displayed `mat-error` text on every form-validation assertion
+
+For every component spec in the **weak** bucket above, every `it(...)` whose assertion currently looks like:
+
+```typescript
+expect(control?.hasError('required')).toBe(true);
+// or
+expect(form.invalid).toBe(true);
+```
+
+…must additionally assert on the rendered `<mat-error>` text in the DOM. The control must be marked-as-touched and `fixture.detectChanges()` called so the `<mat-error>` actually projects. The canonical pattern (already used by the strong-bucket files) is:
+
+```typescript
+import { By } from '@angular/platform-browser';
+
+it('should show "X is required" error', () => {
+  const control = component['form'].get('x');
+  control?.markAsTouched();
+  control?.setValue('');
+  fixture.detectChanges();
+
+  const error = fixture.debugElement.query(By.css('mat-error'));
+  expect(error?.nativeElement.textContent).toContain('X is required');
+});
+```
+
+When multiple `<mat-error>`s render simultaneously (e.g., several invalid fields), use `queryAll` + `find`:
+
+```typescript
+const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+const target = errors.find(e => e.nativeElement.textContent.includes('X is required'));
+expect(target).toBeTruthy();
+```
+
+- **AC-2.1:** For every form-validation `it(...)` in the in-scope frontend specs, the assertion verifies the rendered `<mat-error>` text (via `By.css('mat-error')` query + `nativeElement.textContent`) **in addition to** the existing `hasError(...)` / `form.invalid` assertion. Both assertions stay — the `hasError` check is kept as a fast control-state check; the `mat-error` check pins the user-visible text.
+- **AC-2.2:** The expected error text is sourced from the component's `.html` template — read the template's `<mat-error>` blocks to confirm the literal string before writing the assertion.
+- **AC-2.3:** If the component template renders error text via `{{ ... }}` interpolation against a localization key or a getter (e.g., `{{ getErrorMessage('email') }}`), assert on the **resolved string** (what the user sees), not the template syntax. Read the getter's source to find the literal.
+- **AC-2.4:** If a control is invalid but the template has **no `<mat-error>` block** for that error type (i.e., the control is invalid but the user sees nothing), the gap is a UI defect — **add the `<mat-error>` block to the template** and document in Dev Agent Record. Don't write a test that asserts on missing UI.
+- **AC-2.5:** Existing `hasError(...)` assertions are kept — they verify the form-control state. The new `mat-error` assertion is additive (asserts the DOM rendering), not replacement.
+- **AC-2.6:** "Pristine/untouched" tests (i.e., tests that confirm errors do **not** show before user interaction) are out of scope — do not change them.
+
+### AC-3: Scope is bounded — no new tests, only tightening existing ones (epic AC-3)
+
+- **AC-3.1:** No new `*ValidatorTests.cs` files are created.
+- **AC-3.2:** No new `[Fact]` or `[Theory]` methods are added to existing validator test files. (The number of tests per file stays the same; the assertions inside them get tighter.)
+- **AC-3.3:** No new `*.spec.ts` files are created on the frontend.
+- **AC-3.4:** No new `it(...)` blocks are added to existing component specs. (The number of tests per file stays the same.)
+- **AC-3.5:** No new `describe(...)` blocks are added.
+- **AC-3.6:** Validator source files (`backend/src/PropertyManager.Application/**/*Validator.cs`) are **read-only** unless AC-1.6 applies (genuine validator typo found). Same for frontend component templates — read-only unless AC-2.4 applies (missing `<mat-error>` block). Any production-code change is documented in Dev Agent Record File List with a one-line rationale.
+
+### AC-4: All tests still pass after the tightening
+
+- **AC-4.1 (backend filtered run):** `cd backend && dotnet test --filter "FullyQualifiedName~Validator"` passes 100% (no test in any in-scope file fails).
+- **AC-4.2 (backend full suite):** `cd backend && dotnet test` — no regression in any non-validator test (allowing for the documented pre-existing `TestControllerTests.Reset_WithAuth_DeletesAllEntityTypes_ReturnsCorrectCounts` failure noted in Story 21.10).
+- **AC-4.3 (frontend full Vitest suite):** `cd frontend && npm test` passes — no regression. Tests that previously asserted on `form.invalid`/`hasError` plus a new `mat-error` query still pass.
+- **AC-4.4 (build + lint):** `cd backend && dotnet build` clean (no new warnings). Frontend Prettier formatting preserved.
+
+### AC-5: Test scope justification (process AC — addressed in Dev Notes, not implemented as a test)
+
+- **AC-5.1:** This story is intrinsically a **test-quality** story. Per epic AC-3, **no new tests** are added; only existing assertions are tightened. Therefore:
+  - **Unit tests:** REQUIRED — but as **modifications**, not additions. Every change happens inside an existing `[Fact]` / `it(...)`.
+  - **Integration tests:** NOT REQUIRED — there is no new or changed API endpoint, no new handler, no new EF Core query path. The story does not modify production behavior; the integration test surface is unchanged.
+  - **E2E tests:** NOT REQUIRED — there is no new user-facing flow. The user's experience of the app is identical before and after this story; the only change is that the test suite catches a different class of regression (validator message drift).
+
+## Tasks / Subtasks
+
+- [x] **Task 1: Audit and tighten the 12 mixed-bucket backend validator tests (AC-1, AC-3, AC-4.1)**
+  - [x] 1.1 `backend/tests/PropertyManager.Application.Tests/Properties/CreatePropertyValidatorTests.cs` — already strong on most facts; tighten the 2 `PropertyName`-only assertions (`Validate_MissingState_ReturnsValidationError` line 148 → assert exact message; `Validate_MissingZipCode_ReturnsValidationError` line 189 → assert exact message). Read `CreatePropertyCommandValidator.cs` for the `.WithMessage(...)` text on State and ZipCode `NotEmpty`.
+  - [x] 1.2 `backend/tests/PropertyManager.Application.Tests/Expenses/UpdateExpenseValidatorTests.cs` — tighten the 8 `ErrorMessage.Contains(...)` substring assertions and `PropertyName`-only assertions to exact-string equality. Validator messages source: `backend/src/PropertyManager.Application/Expenses/UpdateExpenseValidator.cs` lines 13-39 (each `.WithMessage(...)`).
+  - [x] 1.3 `backend/tests/PropertyManager.Application.Tests/Income/UpdateIncomeValidatorTests.cs` — tighten all 11 weak assertions. Validator: `backend/src/PropertyManager.Application/Income/UpdateIncomeValidator.cs`.
+  - [x] 1.4 `backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/CreateMaintenanceRequestValidatorTests.cs` — currently mostly strong (3 weak assertions at the `PropertyName`-only level). Tighten the remaining 3.
+  - [x] 1.5 `backend/tests/PropertyManager.Application.Tests/Notes/CreateNoteCommandValidatorTests.cs` — tighten the 8 weak assertions (mix of `PropertyName`-only and `Contains("required")` / `Contains("must be one of")`). Validator: `backend/src/PropertyManager.Application/Notes/CreateNoteCommandValidator.cs`.
+  - [x] 1.6 `backend/tests/PropertyManager.Application.Tests/Invitations/CreateInvitationTests.cs` — tighten the 9 weak assertions (mix of `PropertyName`-only and `Contains("Invalid email")` / `Contains("required")` / `Contains("only be set for Tenant")`). Validator: `backend/src/PropertyManager.Application/Invitations/CreateInvitationValidator.cs`.
+  - [x] 1.7 `backend/tests/PropertyManager.Application.Tests/Invitations/ValidateInvitationTests.cs` — tighten the 2 weak assertions. (No-op: file contains only positive `IsValid.BeTrue()` handler tests; no validator-failure assertions to tighten. Documented in Dev Agent Record.)
+  - [x] 1.8 `backend/tests/PropertyManager.Application.Tests/Invitations/ResendInvitationTests.cs` — tighten the 2 weak assertions.
+  - [x] 1.9 `backend/tests/PropertyManager.Application.Tests/WorkOrderTags/CreateWorkOrderTagValidatorTests.cs` — tighten the 5 weak assertions.
+  - [x] 1.10 `backend/tests/PropertyManager.Application.Tests/VendorTradeTags/CreateVendorTradeTagValidatorTests.cs` — tighten the 5 weak assertions.
+  - [x] 1.11 `backend/tests/PropertyManager.Application.Tests/WorkOrders/GetAllWorkOrdersValidatorTests.cs` — tighten the 1 `Errors.Should().ContainSingle()` weak assertion (line 106 — needs to additionally assert the exact error message).
+  - [x] 1.12 `backend/tests/PropertyManager.Application.Tests/Expenses/LinkReceiptToExpenseValidatorTests.cs` — tighten the 3 weak assertions.
+  - [x] 1.13 Run `cd backend && dotnet test --filter "FullyQualifiedName~Validator"` — confirm green.
+
+- [x] **Task 2: Tighten the 3 fully-weak photo validator tests (AC-1, AC-3, AC-4.1)**
+  - [x] 2.1 `backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ValidatorTests.cs` — every "fails" assertion (~11 occurrences) is `PropertyName`-only. Tighten all to exact-message equality.
+  - [x] 2.2 `backend/tests/PropertyManager.Application.Tests/PropertyPhotos/ValidatorTests.cs` — same pattern (~17 occurrences). Tighten all.
+  - [x] 2.3 `backend/tests/PropertyManager.Application.Tests/VendorPhotos/ValidatorTests.cs` — same pattern (~17 occurrences). Tighten all.
+  - [x] 2.4 Run `dotnet test --filter "FullyQualifiedName~Validator"` — confirm green.
+
+- [x] **Task 3: Tighten the 14 frontend reactive-form component specs (AC-2, AC-3, AC-4.3)**
+  - [x] 3.1 `frontend/src/app/features/auth/login/login.component.spec.ts` — 4 `hasError(...)` assertions. Add corresponding `mat-error` text assertions. Source error text from `login.component.html`.
+  - [x] 3.2 `frontend/src/app/features/auth/forgot-password/forgot-password.component.spec.ts` — 2 `hasError(...)` assertions. Template: `forgot-password.component.html`.
+  - [x] 3.3 `frontend/src/app/features/auth/reset-password/reset-password.component.spec.ts` — 4 `hasError(...)` assertions. Template: `reset-password.component.html`.
+  - [x] 3.4 `frontend/src/app/features/auth/accept-invitation/accept-invitation.component.spec.ts` — 3 `hasError(...)` assertions. Template: `accept-invitation.component.html`.
+  - [x] 3.5 `frontend/src/app/features/expenses/components/expense-form/expense-form.component.spec.ts` — 6 `hasError(...)` assertions. Template: `expense-form.component.html`.
+  - [x] 3.6 `frontend/src/app/features/expenses/components/create-expense-from-wo-dialog/create-expense-from-wo-dialog.component.spec.ts` — 4 `hasError(...)` assertions. Template: corresponding `.html`.
+  - [x] 3.7 `frontend/src/app/features/income/components/income-form/income-form.component.spec.ts` — 5 `hasError(...)` assertions. Template: `income-form.component.html`.
+  - [x] 3.8 `frontend/src/app/features/properties/property-form/property-form.component.spec.ts` — 5 `hasError(...)` assertions. Template: `property-form.component.html`.
+  - [x] 3.9 `frontend/src/app/features/properties/property-edit/property-edit.component.spec.ts` — 5 `hasError(...)` assertions. Template: `property-edit.component.html`.
+  - [x] 3.10 `frontend/src/app/features/properties/components/invite-tenant-dialog/invite-tenant-dialog.component.spec.ts` — 2 `hasError(...)` assertions. Template: corresponding `.html`.
+  - [x] 3.11 `frontend/src/app/features/vendors/components/vendor-form/vendor-form.component.spec.ts` — 5 `hasError(...)` assertions (note: existing file already mixes `mat-error` queries with `hasError` — keep the strong patterns and ADD `mat-error` queries to the weak ones). Template: `vendor-form.component.html`.
+  - [x] 3.12 `frontend/src/app/features/vendors/components/vendor-edit/vendor-edit.component.spec.ts` — 3 `hasError(...)` assertions. Template: `vendor-edit.component.html`.
+  - [x] 3.13 `frontend/src/app/features/work-orders/components/create-wo-from-expense-dialog/create-wo-from-expense-dialog.component.spec.ts` — 1 `hasError` + 1 `form.invalid` assertion. Template: corresponding `.html`.
+  - [x] 3.14 `frontend/src/app/features/receipts/components/receipt-expense-form/receipt-expense-form.component.spec.ts` — 5 `hasError(...)` assertions. Template: `receipt-expense-form.component.html`.
+  - [x] 3.15 Run `cd frontend && npm test` — confirm full suite green.
+
+- [x] **Task 4: Verify, no regressions, no scope creep (AC-3, AC-4)**
+  - [x] 4.1 `cd backend && dotnet build` — clean (zero new warnings).
+  - [x] 4.2 `cd backend && dotnet test --filter "FullyQualifiedName~Validator"` — all green; the test count per file is **exactly the same** as on `main` (verify with `git diff --stat main -- backend/tests` and `dotnet test --list-tests --filter ...`).
+  - [x] 4.3 `cd backend && dotnet test` — full suite green except documented pre-existing failure.
+  - [x] 4.4 `cd frontend && npm test` — full Vitest suite green; the test count per file is **exactly the same** as on `main` (verify via `git diff --stat main -- frontend/src` and a `grep -c "  it(" <spec>` snapshot before/after).
+  - [x] 4.5 `git diff --stat main -- backend/src frontend/src` — should be **empty** unless AC-1.6 or AC-2.4 triggered a documented production-code fix. If non-empty, document each touched production file in Dev Agent Record File List with the fix rationale.
+
+- [x] **Task 5: Sprint status + story status update (process)**
+  - [x] 5.1 Update `docs/project/sprint-status.yaml`: `21-11-validation-message-assertion-improvements: review` (preserve `# P3 - S - Issue #371` comment).
+  - [x] 5.2 Set this story's `Status:` line to `review`.
+  - [x] 5.3 Fill out Dev Agent Record below (Agent Model Used, Debug Log References, Completion Notes, File List).
+
+## Dev Notes
+
+### Test Scope
+
+| Layer | Required? | Justification |
+|---|---|---|
+| **Unit tests (xUnit + Moq + FluentAssertions / Vitest)** | **Required — as MODIFICATIONS to existing tests, not additions** | Per epic AC-3, no new tests are added; existing assertions are tightened. 15 backend validator test files in scope (12 mixed + 3 weak); 14 frontend component specs in scope. Each existing `[Fact]` / `it(...)` gets a strict assertion replacing the loose one (backend) or an additional `mat-error` DOM query (frontend). |
+| **Integration tests (.NET WebApplicationFactory)** | **Not required** | This story is a test-quality refactor. There is no new or changed API endpoint, no new handler, no new EF Core query path, no new validation rule. Production code is read-only (except the narrowly-scoped exceptions in AC-1.6 / AC-2.4). The integration test surface is unchanged — therefore no integration test work is in scope. |
+| **E2E tests (Playwright)** | **Not required** | There is no new user-facing flow. The user's UX of the app is identical before and after this story; the only change is that the test suite now catches a class of regression (validator message drift / mat-error template drift) that previously slipped past CI. E2E coverage is therefore neither sufficient nor necessary to verify the story's value. |
+
+### Pattern References — mirror these existing files
+
+1. **Backend strong pattern A — `result.Errors.Should().Contain(e => ... && e.ErrorMessage == "...")`:**
+   - `backend/tests/PropertyManager.Application.Tests/Properties/CreatePropertyValidatorTests.cs` lines 53, 72, 91, 110, 129, 170, 213 — exact-string-equality predicate inside `.Contain(...)`. Most economical pattern when the file already uses `ValidateAsync(...)` and doesn't import `FluentValidation.TestHelper`.
+   - `backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/CreateMaintenanceRequestValidatorTests.cs` lines 21, 32 — `e.ErrorMessage == "Description is required"`.
+2. **Backend strong pattern B — `FluentValidation.TestHelper`'s `ShouldHaveValidationErrorFor(...).WithErrorMessage(...)` chain:**
+   - `backend/tests/PropertyManager.Application.Tests/Vendors/CreateVendorValidatorTests.cs` lines 51-57 — `_validator.TestValidate(command); result.ShouldHaveValidationErrorFor(x => x.FirstName).WithErrorMessage("First name is required");`. Most economical when the file is converting from `Validate` to `TestValidate` for the whole pass-through.
+   - `backend/tests/PropertyManager.Application.Tests/Vendors/UpdateVendorValidatorTests.cs` and `Receipts/GenerateUploadUrlValidatorTests.cs` — same pattern.
+3. **Frontend strong pattern — `By.css('mat-error')` + `nativeElement.textContent`:**
+   - `frontend/src/app/features/work-orders/components/work-order-form/work-order-form.component.spec.ts` lines 258-281 — `markAsTouched()` → `setValue('')` → `fixture.detectChanges()` → `query(By.css('mat-error'))` → `expect(error?.nativeElement.textContent).toContain('Property is required')`. The canonical pattern for single-error visibility.
+   - `frontend/src/app/features/vendors/components/inline-vendor-dialog/inline-vendor-dialog.component.spec.ts` lines 90-118 — `queryAll(By.css('mat-error'))` + `find(...)` for multi-error scenarios.
+   - `frontend/src/app/features/tenant-dashboard/components/submit-request/submit-request.component.spec.ts` lines 90-99 — minimal `markAsTouched` + `query(By.css('mat-error'))` + `toContain('...')` pattern.
+
+### How to choose between Form A and Form B (backend)
+
+- **Form A (`Errors.Should().Contain(e => ... && e.ErrorMessage == "...")`):** Use when the test file already uses `_validator.ValidateAsync(...)` or `_validator.Validate(...)` and the rest of the file follows that style. **Lower-friction migration** — change the predicate inside `.Contain(...)`, no other restructure.
+- **Form B (`TestValidate(...).ShouldHaveValidationErrorFor(...).WithErrorMessage(...)`):** Use when the test file is being more fully reorganized OR when the assertion needs to chain `.WithSeverity(...)` / `.WithErrorCode(...)` / `.Only()` (rare in this codebase). **More idiomatic** for FluentValidation, but requires `using FluentValidation.TestHelper;` and a switch from `Validate(Async)` to `TestValidate(Async)`.
+
+**Default to Form A.** Only use Form B if the file already uses `TestValidate` (e.g., `CreateVendorValidatorTests.cs`) or if the file's tests are getting heavily restructured for unrelated reasons (which they shouldn't be — see AC-3.2).
+
+### Worked example — `CreateVendorTradeTagValidatorTests.cs::Validate_NameTooLong_Fails`
+
+Before (line 54-55):
+```csharp
+result.IsValid.Should().BeFalse();
+result.Errors.Should().Contain(e => e.PropertyName == "Name" && e.ErrorMessage.Contains("100"));
+```
+
+After (Form A — read `CreateVendorTradeTagValidator.cs` to find the `.WithMessage(...)` text, e.g. `"Trade tag name must be 100 characters or less"`):
+```csharp
+result.IsValid.Should().BeFalse();
+result.Errors.Should().Contain(e =>
+    e.PropertyName == "Name" &&
+    e.ErrorMessage == "Trade tag name must be 100 characters or less");
+```
+
+### Worked example — `expense-form.component.spec.ts` `hasError('required')`
+
+Before:
+```typescript
+expect(amountControl?.hasError('required')).toBe(true);
+```
+
+After (read `expense-form.component.html` for the literal `<mat-error>Amount is required</mat-error>` text):
+```typescript
+expect(amountControl?.hasError('required')).toBe(true);
+
+amountControl?.markAsTouched();
+fixture.detectChanges();
+
+const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+const requiredError = errors.find(e =>
+  e.nativeElement.textContent.includes('Amount is required')
+);
+expect(requiredError).toBeTruthy();
+```
+
+(If only one `<mat-error>` is rendered for that test, use `query(...)` + `.toContain(...)` per the work-order-form pattern.)
+
+### Anti-pitfalls (don't make these mistakes)
+
+1. **Don't add new `[Fact]` / `it(...)` blocks.** Every change is inside an existing test. The test count per file before and after must be identical (`grep -c "\[Fact\]" <file>` and `grep -c "  it(" <spec>`). Verified in Task 4.4.
+
+2. **Don't change `result.IsValid.Should().BeTrue()` "passes" assertions.** AC-1.4 is explicit: positive paths are out of scope. If a file has 5 `BeTrue()` and 5 `BeFalse()`, only the 5 `BeFalse()` are touched.
+
+3. **Don't replace `hasError(...)` with `mat-error` queries on the frontend — *add* the mat-error query.** AC-2.5: both assertions stay. The `hasError` is a fast control-state check; the `mat-error` is the user-visible-text pin. Removing one weakens the test.
+
+4. **Don't re-write the validator to make the message match what you "think" it should say.** The validator's `.WithMessage(...)` is the source of truth (or, if no override, the FluentValidation default — see AC-1.5). Read the validator first, copy the text exactly. Only edit the validator if AC-1.6 applies (genuine typo/inconsistency, documented in File List).
+
+5. **Don't assert on substring matches (`.Contains(...)` / `.toContain('partial')` against partial words).** That's the anti-pattern this story removes. **The one exception is `mat-error` `nativeElement.textContent.toContain(...)` on the frontend** — this is a string-search inside the DOM text node, which is the standard Angular DOM-testing idiom (per the strong-pattern files). The string passed to `toContain` is still the **complete user-visible message**, not a fragment.
+
+6. **Don't add `data-testid` to component templates.** Production code is read-only (except AC-2.4 missing-mat-error case). Use `By.css('mat-error')` and `formControlName` selectors that already exist in the template.
+
+7. **Don't break any currently-passing strong-bucket file.** The audit identified the strong files as "already meet the bar." Don't touch them — touching them is scope creep AND risks introducing a regression in tests that already work.
+
+8. **Don't introduce `using FluentValidation.TestHelper;` to a file that doesn't need it.** Only files migrating to Form B need that using-statement. Form A doesn't.
+
+9. **Don't run frontend tests with `npx vitest`.** Per CLAUDE.md memory note: use `npm test`. The test command in `package.json` is configured for the project's vitest setup (3-thread cap, etc.).
+
+10. **Don't strip pre-existing `// AC-X.Y.Z` comments from tests when tightening.** They reference the original story's acceptance criteria for traceability — keep them.
+
+11. **Don't mix Form A and Form B inside a single file.** AC-1's scope statement: pick one style per file and stay consistent. (Different files in the corpus can use different styles; that's already true today.)
+
+12. **Don't change snapshot tests, e2e tests, or non-validation specs.** Out of scope. The audit scope is exclusively `*ValidatorTests.cs` files in `Application.Tests/` (backend) and `*.spec.ts` files in `frontend/src/app/features/**` that contain `hasError(...)` or `form.invalid` (frontend).
+
+13. **Don't aggregate this work into a single mega-PR.** Per epic technical-notes: "If a test file has 20+ assertions to tighten, prefer a single-file PR rather than one mega-PR." With 15 backend + 14 frontend files in scope, the orchestrator's Ship phase decides PR granularity. The dev workflow prepares the changes; it does NOT bundle them prematurely.
+
+14. **Don't re-read the same validator twice.** Read each validator file once, capture the exact `.WithMessage(...)` strings, then apply across all corresponding test cases. (E.g., `UpdateExpenseValidator.cs` is read once for Task 1.2, even though it covers 8 assertion edits.)
+
+15. **Don't forget `markAsTouched()` + `fixture.detectChanges()` before querying `mat-error`.** Material's `<mat-error>` projection is gated on the form-field's "show error" state which requires `touched` + invalid. Without it, the `query(By.css('mat-error'))` returns `null` and the assertion silently passes-by-truthy-on-falsy in some patterns. Verified by reading the strong-pattern specs (`work-order-form.component.spec.ts` line 260, `submit-request.component.spec.ts` line 92).
+
+### Previous Story Intelligence
+
+**Story 21.10 (done — PR #396)** — Dashboard unit + E2E tests. Carried-over patterns:
+- "Reality check (epic vs. shipped code)" preamble convention — replicated above with the audit-finding bucket lists.
+- Anti-pitfall numbered list convention — replicated.
+- Test Scope table convention — replicated; this story marks Integration and E2E as "Not required" with explicit justification (per the create-story skill's Step 4.5 mandate).
+- "If tightening reveals incorrect or missing validator messages, fix the validator — don't assert wrong behavior" — this is the same discipline as 21.10's "if a future story adds percentage-change to the handler, those tests get added then" (don't bolt scope creep onto a tightening story).
+- Dev Agent Record structure (Agent Model, Debug Log, Completion Notes, File List) — replicated.
+
+**Story 21.9 (done — PR #395)** — Auth handler unit tests. Carried-over patterns:
+- The "no `ILogger` mock unless the SUT injects one" lesson — same applied here: don't add `using FluentValidation.TestHelper;` unless the file needs it (AC-1's Form B). Read the file, then act.
+
+**Story 21.7 (done — PR #386)** — Core frontend service unit tests for `api.service.ts` and `auth.interceptor.ts`. Carried-over patterns:
+- Vitest assertion conventions — `expect(...).toBe(...)`, `expect(...).toContain(...)`, `vi.fn()`, `vi.spyOn(...)`. The mat-error queries follow the same Angular `By.css` + `nativeElement.textContent` pattern that 21.7's interceptor tests use for HTTP-related assertions, applied here at the DOM layer.
+
+**Story 17.2 (done — PR #281)** — Form behavior fixes (vendor edit). The vendor-edit spec file is in this story's in-scope list (Task 3.12). 17.2 left the `hasError`-only assertions in place; this story is the follow-up that tightens them.
+
+**Story 18.1 (done — Issue #319)** — MockQueryable.Moq v10 upgrade. Not directly relevant (this story does no DbSet mocking) but confirms the project-wide rigor for keeping test infrastructure current — same rigor applies to assertion strength.
+
+### Files NOT to modify
+
+- **Backend strong-bucket validator test files** (already meet the bar — listed in the Reality Check):
+  - `Vendors/CreateVendorValidatorTests.cs`, `Vendors/UpdateVendorValidatorTests.cs`, `Vendors/DeleteVendorValidatorTests.cs`
+  - `Receipts/GenerateUploadUrlValidatorTests.cs`
+  - `Income/CreateIncomeValidatorTests.cs`
+  - `WorkOrders/CreateWorkOrderValidatorTests.cs`, `WorkOrders/UpdateWorkOrderValidatorTests.cs`, `WorkOrders/ReorderWorkOrderPhotosValidatorTests.cs`
+  - `Photos/ConfirmPhotoUploadValidatorTests.cs`, `Photos/GeneratePhotoUploadUrlValidatorTests.cs`
+  - `AccountUsers/UpdateUserRoleValidatorTests.cs`
+- **Frontend strong-bucket spec files**:
+  - `work-orders/components/work-order-form/work-order-form.component.spec.ts`
+  - `vendors/components/inline-vendor-dialog/inline-vendor-dialog.component.spec.ts`
+  - `tenant-dashboard/components/submit-request/submit-request.component.spec.ts`
+- **All production code under `backend/src/PropertyManager.Application/**/*Validator.cs`** — read-only unless AC-1.6 applies.
+- **All production code under `frontend/src/app/features/**/*.component.html`** — read-only unless AC-2.4 applies.
+- **All non-validator backend test files** (handler tests, controller tests, etc.) — out of scope.
+- **All non-form-validation frontend tests** (store tests, service tests, snapshot tests, page-level tests) — out of scope.
+
+### Files in scope to modify (test files only — comprehensive enumeration)
+
+**Backend (15 files):**
+1. `backend/tests/PropertyManager.Application.Tests/Properties/CreatePropertyValidatorTests.cs`
+2. `backend/tests/PropertyManager.Application.Tests/Expenses/UpdateExpenseValidatorTests.cs`
+3. `backend/tests/PropertyManager.Application.Tests/Expenses/LinkReceiptToExpenseValidatorTests.cs`
+4. `backend/tests/PropertyManager.Application.Tests/Income/UpdateIncomeValidatorTests.cs`
+5. `backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/CreateMaintenanceRequestValidatorTests.cs`
+6. `backend/tests/PropertyManager.Application.Tests/Notes/CreateNoteCommandValidatorTests.cs`
+7. `backend/tests/PropertyManager.Application.Tests/Invitations/CreateInvitationTests.cs`
+8. `backend/tests/PropertyManager.Application.Tests/Invitations/ValidateInvitationTests.cs`
+9. `backend/tests/PropertyManager.Application.Tests/Invitations/ResendInvitationTests.cs`
+10. `backend/tests/PropertyManager.Application.Tests/WorkOrderTags/CreateWorkOrderTagValidatorTests.cs`
+11. `backend/tests/PropertyManager.Application.Tests/VendorTradeTags/CreateVendorTradeTagValidatorTests.cs`
+12. `backend/tests/PropertyManager.Application.Tests/WorkOrders/GetAllWorkOrdersValidatorTests.cs`
+13. `backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ValidatorTests.cs`
+14. `backend/tests/PropertyManager.Application.Tests/PropertyPhotos/ValidatorTests.cs`
+15. `backend/tests/PropertyManager.Application.Tests/VendorPhotos/ValidatorTests.cs`
+
+**Frontend (14 files):**
+1. `frontend/src/app/features/auth/login/login.component.spec.ts`
+2. `frontend/src/app/features/auth/forgot-password/forgot-password.component.spec.ts`
+3. `frontend/src/app/features/auth/reset-password/reset-password.component.spec.ts`
+4. `frontend/src/app/features/auth/accept-invitation/accept-invitation.component.spec.ts`
+5. `frontend/src/app/features/expenses/components/expense-form/expense-form.component.spec.ts`
+6. `frontend/src/app/features/expenses/components/create-expense-from-wo-dialog/create-expense-from-wo-dialog.component.spec.ts`
+7. `frontend/src/app/features/income/components/income-form/income-form.component.spec.ts`
+8. `frontend/src/app/features/properties/property-form/property-form.component.spec.ts`
+9. `frontend/src/app/features/properties/property-edit/property-edit.component.spec.ts`
+10. `frontend/src/app/features/properties/components/invite-tenant-dialog/invite-tenant-dialog.component.spec.ts`
+11. `frontend/src/app/features/vendors/components/vendor-form/vendor-form.component.spec.ts`
+12. `frontend/src/app/features/vendors/components/vendor-edit/vendor-edit.component.spec.ts`
+13. `frontend/src/app/features/work-orders/components/create-wo-from-expense-dialog/create-wo-from-expense-dialog.component.spec.ts`
+14. `frontend/src/app/features/receipts/components/receipt-expense-form/receipt-expense-form.component.spec.ts`
+
+**Process docs (2 files):**
+- `docs/project/sprint-status.yaml` — `21-11-validation-message-assertion-improvements: review` (Task 5.1)
+- `docs/project/stories/epic-21/21-11-validation-message-assertion-improvements.md` — Status + Dev Agent Record (Task 5.2, 5.3)
+
+### References
+
+- [FluentValidation Test Extensions documentation (verified April 2026 via Ref MCP)](https://github.com/fluentvalidation/fluentvalidation/blob/main/docs/testing.md) — confirms `result.ShouldHaveValidationErrorFor(x => x.Name).WithErrorMessage("'Name' must not be empty.")` chain syntax; confirms `WithErrorMessage`, `WithSeverity`, `WithErrorCode`, `Only()` chainables on the test result; confirms async `TestValidateAsync` parallel for async validators. Form B in this story is sourced from this doc.
+- [Angular DebugElement `By.css` documentation (verified April 2026 via Ref MCP)](https://angular.dev/guide/testing/components-basics#bycss) — confirms `fixture.debugElement.query(By.css(selector))` returns a `DebugElement`; `.nativeElement.textContent` is the standard way to read DOM text. Pattern A in this story is sourced from this.
+- [Epic 21](./epic-21-epics-test-coverage.md) — parent epic. Story 21.11 spec at lines 524-559. Epic AC-3 mandates "no new test files or test cases."
+- [Story 21.10 (done — most recent prior story in epic)](./21-10-dashboard-unit-and-e2e-tests.md) — pattern reference for "Reality check" preamble, anti-pitfall list, Test Scope table, Dev Agent Record structure.
+- [Story 21.9 (done)](./21-9-auth-handler-unit-tests.md) — handler unit-test patterns and import discipline.
+- [Story 21.7 (done — PR #386)](./21-7-core-frontend-service-unit-tests.md) — frontend Vitest + Angular TestBed conventions.
+- [project-context.md:106-141](../../project-context.md) — backend testing standards (xUnit + Moq + FluentAssertions); frontend testing standards (Vitest, `By.css` selectors).
+- [CLAUDE.md](../../../CLAUDE.md) — `npm test` not `npx vitest` rule; testing pyramid memory note.
+- GitHub Issue [#371](https://github.com/daveharmswebdev/property-manager/issues/371) — test-coverage audit that spawned this epic.
+- Pattern reference (Backend Form A — `Errors.Should().Contain(e => ... && e.ErrorMessage == "...")`):
+  - [`Properties/CreatePropertyValidatorTests.cs`](../../../../backend/tests/PropertyManager.Application.Tests/Properties/CreatePropertyValidatorTests.cs) lines 53, 72, 91, 110, 129, 170, 213
+  - [`MaintenanceRequests/CreateMaintenanceRequestValidatorTests.cs`](../../../../backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/CreateMaintenanceRequestValidatorTests.cs) lines 21, 32
+- Pattern reference (Backend Form B — `TestValidate(...).ShouldHaveValidationErrorFor(...).WithErrorMessage(...)`):
+  - [`Vendors/CreateVendorValidatorTests.cs`](../../../../backend/tests/PropertyManager.Application.Tests/Vendors/CreateVendorValidatorTests.cs) lines 51-57
+  - [`Vendors/UpdateVendorValidatorTests.cs`](../../../../backend/tests/PropertyManager.Application.Tests/Vendors/UpdateVendorValidatorTests.cs) — full file uses Form B
+  - [`Receipts/GenerateUploadUrlValidatorTests.cs`](../../../../backend/tests/PropertyManager.Application.Tests/Receipts/GenerateUploadUrlValidatorTests.cs) — full file uses Form B
+- Pattern reference (Frontend `By.css('mat-error')` + `nativeElement.textContent`):
+  - [`work-order-form.component.spec.ts`](../../../../frontend/src/app/features/work-orders/components/work-order-form/work-order-form.component.spec.ts) lines 258-281, 602
+  - [`inline-vendor-dialog.component.spec.ts`](../../../../frontend/src/app/features/vendors/components/inline-vendor-dialog/inline-vendor-dialog.component.spec.ts) lines 90-118
+  - [`submit-request.component.spec.ts`](../../../../frontend/src/app/features/tenant-dashboard/components/submit-request/submit-request.component.spec.ts) lines 90-99
+- Validator source files (read these to find the exact `.WithMessage(...)` strings — one read per validator):
+  - [`UpdateExpenseValidator.cs`](../../../../backend/src/PropertyManager.Application/Expenses/UpdateExpenseValidator.cs) — 7 explicit messages confirmed.
+  - All other validators in `backend/src/PropertyManager.Application/**/*Validator.cs`.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.7 (1M context) via /dev-story skill (orchestrator-driven).
+
+### Debug Log References
+
+- Backend filtered run (validators only): `dotnet test --filter "FullyQualifiedName~Validator"` — 330 passed.
+- Backend full suite: `dotnet test` — 2110 passed (Application.Tests 1221 + Infrastructure.Tests 98 + Api.Tests 791). Zero failures, zero regressions.
+- Backend build: `dotnet build` — 0 warnings, 0 errors.
+- Frontend full Vitest suite: `npm test` — 2768 passed across 123 files. Zero regressions.
+- AC-3 scope guard: `git diff main -- 'backend/tests/**/*Tests.cs' 'frontend/src/app/features/**/*.spec.ts' | grep -cE "^\\+[^+].*(\\[Fact\\]|\\[Theory\\]|  it\\()"` returned `0`. Net-new test count: 0.
+- Production-code scope guard: `git diff --stat main -- backend/src frontend/src/app/features` filtered for non-spec files — 0 changes.
+
+### Completion Notes List
+
+- **Form A used throughout backend** (per Dev Notes default). All tightened backend assertions use `result.Errors.Should().Contain(e => e.PropertyName == "X" && e.ErrorMessage == "...")` pattern. No file was migrated to Form B (`TestValidate`) because none of the in-scope mixed/weak files imported `FluentValidation.TestHelper`.
+- **Task 1.7 (`ValidateInvitationTests.cs`) was a no-op:** the file's only two `[Fact]`s are positive-path handler tests asserting `result.IsValid.Should().BeTrue()`. There are no `IsValid.BeFalse()` validator-failure assertions in the file. Per AC-1.4, positive paths are out of scope. Story audit overcounted; no tightening required.
+- **Task 1.4 (`CreateMaintenanceRequestValidatorTests.cs`) had only 2 fail assertions** (story said 3); both were already `e.ErrorMessage == "..."` exact-equality but did not check `PropertyName`. Strengthened both to also assert `PropertyName == "Description"` for symmetry with the canonical Form A pattern.
+- **`LinkReceiptToExpenseValidator.cs` has no `.WithMessage(...)` overrides** (AC-1.5 path). Used FluentValidation v12 default `NotEmpty()` message: `"'Expense Id' must not be empty."` and `"'Receipt Id' must not be empty."` (auto-formatted from camelCase by FluentValidation's default `PropertyNameResolver`). Did NOT add `.WithMessage(...)` to the validator — that would be a behavior change (forbidden by AC-1.5).
+- **`GetAllWorkOrdersValidatorTests.cs::Validate_InvalidStatus_IsInvalid`** had 3 separate `.Should().Contain(...)` substring assertions on the single error message (one per enum value). Replaced with a single `.Should().Be("Status must be one of: Reported, Assigned, Completed")` exact-match assertion. Net assertion count change for the test method: -2 (3 substring → 1 equality), but no `[Fact]`/`[Theory]` count change.
+- **Photo validator tests (Tasks 2.1–2.3)** asserted only `PropertyName`. Tightened all to `PropertyName + ErrorMessage` exact-equality. The dynamic `string.Join(", ", PhotoValidation.AllowedContentTypes)` message resolves to `"Content type must be one of: image/jpeg, image/png, image/gif, image/webp, image/bmp, image/tiff"` (HashSet iteration order is by insertion, deterministic).
+- **Frontend categoryId-required tests (`expense-form` Task 3.5, `receipt-expense-form` Task 3.14)** were left as `hasError`-only. The category control's error rendering is delegated to the `<app-category-select>` child component via `[error]="getCategoryError()"` binding — there is no `<mat-error>` block in the parent component for `categoryId`. Adding a `mat-error` query for these cases would test the wrong component. Per AC-2.5, the existing `hasError` assertion is preserved as a control-state check; the user-visible error text for categoryId is exercised in `category-select.component.spec.ts` (out of scope for this story).
+- **No production-code escape hatches were triggered.** No validator typos found (AC-1.6 not invoked); no missing `<mat-error>` blocks found (AC-2.4 not invoked). All template `<mat-error>` text matched what the component logic could render.
+- **AC-3 scope guard verified:** `git diff main` shows 0 net-new `[Fact]`/`[Theory]`/`it(...)` declarations. All changes are tightened assertions inside existing test cases.
+- **All 380 in-scope frontend spec tests pass** after tightening. **All 397 in-scope backend validator + invitation tests pass** after tightening.
+
+### File List
+
+**Backend test files modified (15):**
+- `backend/tests/PropertyManager.Application.Tests/Properties/CreatePropertyValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/Expenses/UpdateExpenseValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/Expenses/LinkReceiptToExpenseValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/Income/UpdateIncomeValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/MaintenanceRequests/CreateMaintenanceRequestValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/Notes/CreateNoteCommandValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/Invitations/CreateInvitationTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/Invitations/ResendInvitationTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/WorkOrderTags/CreateWorkOrderTagValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/VendorTradeTags/CreateVendorTradeTagValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/WorkOrders/GetAllWorkOrdersValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/MaintenanceRequestPhotos/ValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/PropertyPhotos/ValidatorTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/VendorPhotos/ValidatorTests.cs`
+
+**Backend test files NOT modified (Task 1.7 no-op — see Completion Notes):**
+- `backend/tests/PropertyManager.Application.Tests/Invitations/ValidateInvitationTests.cs` (no failure-path assertions; out of AC-1.4 scope)
+
+**Frontend spec files modified (13):**
+- `frontend/src/app/features/auth/login/login.component.spec.ts`
+- `frontend/src/app/features/auth/forgot-password/forgot-password.component.spec.ts`
+- `frontend/src/app/features/auth/reset-password/reset-password.component.spec.ts`
+- `frontend/src/app/features/auth/accept-invitation/accept-invitation.component.spec.ts`
+- `frontend/src/app/features/expenses/components/expense-form/expense-form.component.spec.ts`
+- `frontend/src/app/features/expenses/components/create-expense-from-wo-dialog/create-expense-from-wo-dialog.component.spec.ts`
+- `frontend/src/app/features/income/components/income-form/income-form.component.spec.ts`
+- `frontend/src/app/features/properties/property-form/property-form.component.spec.ts`
+- `frontend/src/app/features/properties/property-edit/property-edit.component.spec.ts`
+- `frontend/src/app/features/properties/components/invite-tenant-dialog/invite-tenant-dialog.component.spec.ts`
+- `frontend/src/app/features/vendors/components/vendor-form/vendor-form.component.spec.ts`
+- `frontend/src/app/features/vendors/components/vendor-edit/vendor-edit.component.spec.ts`
+- `frontend/src/app/features/work-orders/components/create-wo-from-expense-dialog/create-wo-from-expense-dialog.component.spec.ts`
+- `frontend/src/app/features/receipts/components/receipt-expense-form/receipt-expense-form.component.spec.ts`
+
+**Production source files modified:** NONE.
+- No validator `.WithMessage(...)` text was changed (AC-1.6 not triggered — no typos found).
+- No component template `<mat-error>` block was added (AC-2.4 not triggered — no missing-error UI defects found).
+- No `categoryId` mat-error was added to `expense-form` / `receipt-expense-form` (per AC-2.5 reasoning above; categoryId error rendering is delegated to `<app-category-select>` child component, which is out of scope).
+
+**Process docs (2):**
+- `docs/project/sprint-status.yaml` — status: in-progress → review
+- `docs/project/stories/epic-21/21-11-validation-message-assertion-improvements.md` — Status, all task checkboxes, Dev Agent Record

--- a/frontend/src/app/features/auth/accept-invitation/accept-invitation.component.spec.ts
+++ b/frontend/src/app/features/auth/accept-invitation/accept-invitation.component.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { of, throwError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AcceptInvitationComponent } from './accept-invitation.component';
@@ -131,19 +132,43 @@ describe('AcceptInvitationComponent', () => {
     it('should have password field with required validator', () => {
       const passwordControl = component['form'].get('password');
       passwordControl?.setValue('');
+      passwordControl?.markAsTouched();
+      fixture.detectChanges();
       expect(passwordControl?.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Password is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
 
     it('should require minimum 8 characters for password', () => {
       const passwordControl = component['form'].get('password');
       passwordControl?.setValue('Short1!');
+      passwordControl?.markAsTouched();
+      fixture.detectChanges();
       expect(passwordControl?.hasError('minlength')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const minlengthError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Password must be at least 8 characters'),
+      );
+      expect(minlengthError).toBeTruthy();
     });
 
     it('should have confirmPassword field with required validator', () => {
       const confirmControl = component['form'].get('confirmPassword');
       confirmControl?.setValue('');
+      confirmControl?.markAsTouched();
+      fixture.detectChanges();
       expect(confirmControl?.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Please confirm your password'),
+      );
+      expect(requiredError).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/features/auth/forgot-password/forgot-password.component.spec.ts
+++ b/frontend/src/app/features/auth/forgot-password/forgot-password.component.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { of, throwError, Subject } from 'rxjs';
 import { ForgotPasswordComponent } from './forgot-password.component';
 import { AuthService } from '../../../core/services/auth.service';
@@ -43,10 +44,23 @@ describe('ForgotPasswordComponent', () => {
       expect(emailControl).toBeTruthy();
 
       emailControl?.setValue('');
+      emailControl?.markAsTouched();
+      fixture.detectChanges();
       expect(emailControl?.hasError('required')).toBe(true);
+      const requiredErrors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = requiredErrors.find((el) =>
+        el.nativeElement.textContent.includes('Email is required'),
+      );
+      expect(requiredError).toBeTruthy();
 
       emailControl?.setValue('invalid-email');
+      fixture.detectChanges();
       expect(emailControl?.hasError('email')).toBe(true);
+      const emailErrors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const emailError = emailErrors.find((el) =>
+        el.nativeElement.textContent.includes('Please enter a valid email address'),
+      );
+      expect(emailError).toBeTruthy();
 
       emailControl?.setValue('valid@email.com');
       expect(emailControl?.valid).toBe(true);

--- a/frontend/src/app/features/auth/login/login.component.spec.ts
+++ b/frontend/src/app/features/auth/login/login.component.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, ActivatedRoute, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { of, throwError, Subject } from 'rxjs';
 import { signal } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -52,10 +53,23 @@ describe('LoginComponent', () => {
       expect(emailControl).toBeTruthy();
 
       emailControl?.setValue('');
+      emailControl?.markAsTouched();
+      fixture.detectChanges();
       expect(emailControl?.hasError('required')).toBe(true);
+      const requiredErrors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = requiredErrors.find((el) =>
+        el.nativeElement.textContent.includes('Email is required'),
+      );
+      expect(requiredError).toBeTruthy();
 
       emailControl?.setValue('invalid-email');
+      fixture.detectChanges();
       expect(emailControl?.hasError('email')).toBe(true);
+      const emailErrors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const emailError = emailErrors.find((el) =>
+        el.nativeElement.textContent.includes('Please enter a valid email address'),
+      );
+      expect(emailError).toBeTruthy();
 
       emailControl?.setValue('valid@email.com');
       expect(emailControl?.valid).toBe(true);
@@ -66,7 +80,14 @@ describe('LoginComponent', () => {
       expect(passwordControl).toBeTruthy();
 
       passwordControl?.setValue('');
+      passwordControl?.markAsTouched();
+      fixture.detectChanges();
       expect(passwordControl?.hasError('required')).toBe(true);
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const passwordError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Password is required'),
+      );
+      expect(passwordError).toBeTruthy();
 
       passwordControl?.setValue('anypassword');
       expect(passwordControl?.valid).toBe(true);
@@ -260,16 +281,32 @@ describe('LoginComponent', () => {
     it('should reject email without TLD (user@g) with pattern error', () => {
       const emailControl = component['form'].get('email');
       emailControl?.setValue('user@g');
+      emailControl?.markAsTouched();
+      fixture.detectChanges();
 
       expect(emailControl?.hasError('pattern')).toBe(true);
       expect(emailControl?.valid).toBe(false);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const patternError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Please enter a valid email address'),
+      );
+      expect(patternError).toBeTruthy();
     });
 
     it('should reject email with single-char TLD (user@domain.c) with pattern error', () => {
       const emailControl = component['form'].get('email');
       emailControl?.setValue('user@domain.c');
+      emailControl?.markAsTouched();
+      fixture.detectChanges();
 
       expect(emailControl?.hasError('pattern')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const patternError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Please enter a valid email address'),
+      );
+      expect(patternError).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/features/auth/reset-password/reset-password.component.spec.ts
+++ b/frontend/src/app/features/auth/reset-password/reset-password.component.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { of, throwError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ResetPasswordComponent } from './reset-password.component';
@@ -79,13 +80,29 @@ describe('ResetPasswordComponent', () => {
     it('should have password field with required validator', () => {
       const passwordControl = component['form'].get('password');
       passwordControl?.setValue('');
+      passwordControl?.markAsTouched();
+      fixture.detectChanges();
       expect(passwordControl?.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Password is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
 
     it('should require minimum 8 characters for password', () => {
       const passwordControl = component['form'].get('password');
       passwordControl?.setValue('Short1!');
+      passwordControl?.markAsTouched();
+      fixture.detectChanges();
       expect(passwordControl?.hasError('minlength')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const minlengthError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Password must be at least 8 characters'),
+      );
+      expect(minlengthError).toBeTruthy();
 
       passwordControl?.setValue('LongEnough1!');
       expect(passwordControl?.hasError('minlength')).toBe(false);
@@ -94,7 +111,15 @@ describe('ResetPasswordComponent', () => {
     it('should have confirmPassword field with required validator', () => {
       const confirmControl = component['form'].get('confirmPassword');
       confirmControl?.setValue('');
+      confirmControl?.markAsTouched();
+      fixture.detectChanges();
       expect(confirmControl?.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Please confirm your password'),
+      );
+      expect(requiredError).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/features/expenses/components/create-expense-from-wo-dialog/create-expense-from-wo-dialog.component.spec.ts
+++ b/frontend/src/app/features/expenses/components/create-expense-from-wo-dialog/create-expense-from-wo-dialog.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { signal } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { of, throwError } from 'rxjs';
 import { formatLocalDate } from '../../../../shared/utils/date.utils';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
@@ -116,13 +117,27 @@ describe('CreateExpenseFromWoDialogComponent', () => {
     it('should mark amount as required', () => {
       component.form.controls.amount.setValue(null);
       component.form.controls.amount.markAsTouched();
+      fixture.detectChanges();
       expect(component.form.controls.amount.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Amount is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
 
     it('should validate amount min 0.01', () => {
       component.form.controls.amount.setValue(0);
       component.form.controls.amount.markAsTouched();
+      fixture.detectChanges();
       expect(component.form.controls.amount.hasError('min')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const minError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Amount must be greater than 0'),
+      );
+      expect(minError).toBeTruthy();
     });
 
     it('should accept valid amount', () => {
@@ -133,13 +148,27 @@ describe('CreateExpenseFromWoDialogComponent', () => {
     it('should mark category as required', () => {
       component.form.controls.categoryId.setValue('');
       component.form.controls.categoryId.markAsTouched();
+      fixture.detectChanges();
       expect(component.form.controls.categoryId.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Category is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
 
     it('should mark date as required', () => {
       component.form.controls.date.setValue('');
       component.form.controls.date.markAsTouched();
+      fixture.detectChanges();
       expect(component.form.controls.date.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Date is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
 
     it('should have Create button disabled when form invalid', () => {

--- a/frontend/src/app/features/expenses/components/expense-form/expense-form.component.spec.ts
+++ b/frontend/src/app/features/expenses/components/expense-form/expense-form.component.spec.ts
@@ -187,13 +187,29 @@ describe('ExpenseFormComponent validation', () => {
 
   it('should require amount', () => {
     const amountControl = component['form'].get('amount');
+    amountControl?.markAsTouched();
+    fixture.detectChanges();
     expect(amountControl?.hasError('required')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Amount is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 
   it('should require amount greater than 0 (AC-3.1.2)', () => {
     const amountControl = component['form'].get('amount');
     amountControl?.setValue(0);
+    amountControl?.markAsTouched();
+    fixture.detectChanges();
     expect(amountControl?.hasError('min')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const minError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Amount must be greater than $0'),
+    );
+    expect(minError).toBeTruthy();
   });
 
   it('should accept valid amount', () => {
@@ -205,13 +221,29 @@ describe('ExpenseFormComponent validation', () => {
   it('should enforce max amount', () => {
     const amountControl = component['form'].get('amount');
     amountControl?.setValue(10000000);
+    amountControl?.markAsTouched();
+    fixture.detectChanges();
     expect(amountControl?.hasError('max')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const maxError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Amount exceeds maximum'),
+    );
+    expect(maxError).toBeTruthy();
   });
 
   it('should require date', () => {
     const dateControl = component['form'].get('date');
     dateControl?.setValue(null);
+    dateControl?.markAsTouched();
+    fixture.detectChanges();
     expect(dateControl?.hasError('required')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Date is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 
   it('should require category', () => {
@@ -222,7 +254,15 @@ describe('ExpenseFormComponent validation', () => {
   it('should limit description to 500 characters (AC-3.1.5)', () => {
     const descControl = component['form'].get('description');
     descControl?.setValue('a'.repeat(501));
+    descControl?.markAsTouched();
+    fixture.detectChanges();
     expect(descControl?.hasError('maxlength')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const maxlengthError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Description must be 500 characters or less'),
+    );
+    expect(maxlengthError).toBeTruthy();
   });
 
   it('should be invalid when required fields missing', () => {

--- a/frontend/src/app/features/income/components/income-form/income-form.component.spec.ts
+++ b/frontend/src/app/features/income/components/income-form/income-form.component.spec.ts
@@ -133,13 +133,29 @@ describe('IncomeFormComponent validation', () => {
 
   it('should require amount', () => {
     const amountControl = component['form'].get('amount');
+    amountControl?.markAsTouched();
+    fixture.detectChanges();
     expect(amountControl?.hasError('required')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Amount is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 
   it('should require amount greater than 0', () => {
     const amountControl = component['form'].get('amount');
     amountControl?.setValue(0);
+    amountControl?.markAsTouched();
+    fixture.detectChanges();
     expect(amountControl?.hasError('min')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const minError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Amount must be greater than $0'),
+    );
+    expect(minError).toBeTruthy();
   });
 
   it('should accept valid amount', () => {
@@ -151,19 +167,43 @@ describe('IncomeFormComponent validation', () => {
   it('should require date', () => {
     const dateControl = component['form'].get('date');
     dateControl?.setValue(null);
+    dateControl?.markAsTouched();
+    fixture.detectChanges();
     expect(dateControl?.hasError('required')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Date is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 
   it('should limit source to 255 characters', () => {
     const sourceControl = component['form'].get('source');
     sourceControl?.setValue('a'.repeat(256));
+    sourceControl?.markAsTouched();
+    fixture.detectChanges();
     expect(sourceControl?.hasError('maxlength')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const maxlengthError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Source must be 255 characters or less'),
+    );
+    expect(maxlengthError).toBeTruthy();
   });
 
   it('should limit description to 500 characters', () => {
     const descControl = component['form'].get('description');
     descControl?.setValue('a'.repeat(501));
+    descControl?.markAsTouched();
+    fixture.detectChanges();
     expect(descControl?.hasError('maxlength')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const maxlengthError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Description must be 500 characters or less'),
+    );
+    expect(maxlengthError).toBeTruthy();
   });
 
   it('should be invalid when amount is missing', () => {

--- a/frontend/src/app/features/properties/components/invite-tenant-dialog/invite-tenant-dialog.component.spec.ts
+++ b/frontend/src/app/features/properties/components/invite-tenant-dialog/invite-tenant-dialog.component.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import {
   InviteTenantDialogComponent,
@@ -44,13 +45,28 @@ describe('InviteTenantDialogComponent', () => {
     const emailControl = component.form.get('email');
     emailControl?.setValue('');
     emailControl?.markAsTouched();
+    fixture.detectChanges();
     expect(emailControl?.hasError('required')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Email is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 
   it('should validate email format', () => {
     const emailControl = component.form.get('email');
     emailControl?.setValue('not-an-email');
+    emailControl?.markAsTouched();
+    fixture.detectChanges();
     expect(emailControl?.hasError('email')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const emailError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Invalid email format'),
+    );
+    expect(emailError).toBeTruthy();
   });
 
   // AC: 20.2 Task 12.3

--- a/frontend/src/app/features/properties/property-edit/property-edit.component.spec.ts
+++ b/frontend/src/app/features/properties/property-edit/property-edit.component.spec.ts
@@ -230,7 +230,15 @@ describe('PropertyEditComponent', () => {
 
     const nameControl = component.form.get('name');
     nameControl?.setValue('');
+    nameControl?.markAsTouched();
+    fixture.detectChanges();
     expect(nameControl?.hasError('required')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Property name is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 
   it('should validate ZIP code format (AC-2.4.4)', async () => {
@@ -240,9 +248,18 @@ describe('PropertyEditComponent', () => {
     const zipControl = component.form.get('zipCode');
 
     zipControl?.setValue('1234');
+    zipControl?.markAsTouched();
+    fixture.detectChanges();
     expect(zipControl?.hasError('pattern')).toBe(true);
 
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const patternError = errors.find((el) =>
+      el.nativeElement.textContent.includes('ZIP Code must be exactly 5 digits'),
+    );
+    expect(patternError).toBeTruthy();
+
     zipControl?.setValue('ABCDE');
+    fixture.detectChanges();
     expect(zipControl?.hasError('pattern')).toBe(true);
 
     zipControl?.setValue('78701');
@@ -255,7 +272,15 @@ describe('PropertyEditComponent', () => {
 
     const stateControl = component.form.get('state');
     stateControl?.setValue('');
+    stateControl?.markAsTouched();
+    fixture.detectChanges();
     expect(stateControl?.hasError('required')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('State is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 
   it('should disable Save button when form is invalid (AC-2.4.4)', async () => {

--- a/frontend/src/app/features/properties/property-form/property-form.component.spec.ts
+++ b/frontend/src/app/features/properties/property-form/property-form.component.spec.ts
@@ -164,16 +164,33 @@ describe('PropertyFormComponent', () => {
   it('should validate name is required', () => {
     const nameControl = component.form.get('name');
     nameControl?.setValue('');
+    nameControl?.markAsTouched();
+    fixture.detectChanges();
     expect(nameControl?.hasError('required')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Property name is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 
   it('should validate ZIP code format', () => {
     const zipControl = component.form.get('zipCode');
 
     zipControl?.setValue('1234');
+    zipControl?.markAsTouched();
+    fixture.detectChanges();
     expect(zipControl?.hasError('pattern')).toBe(true);
 
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const patternError = errors.find((el) =>
+      el.nativeElement.textContent.includes('ZIP Code must be exactly 5 digits'),
+    );
+    expect(patternError).toBeTruthy();
+
     zipControl?.setValue('ABCDE');
+    fixture.detectChanges();
     expect(zipControl?.hasError('pattern')).toBe(true);
 
     zipControl?.setValue('78701');
@@ -183,6 +200,14 @@ describe('PropertyFormComponent', () => {
   it('should validate state is required', () => {
     const stateControl = component.form.get('state');
     stateControl?.setValue('');
+    stateControl?.markAsTouched();
+    fixture.detectChanges();
     expect(stateControl?.hasError('required')).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('State is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 });

--- a/frontend/src/app/features/receipts/components/receipt-expense-form/receipt-expense-form.component.spec.ts
+++ b/frontend/src/app/features/receipts/components/receipt-expense-form/receipt-expense-form.component.spec.ts
@@ -201,18 +201,42 @@ describe('ReceiptExpenseFormComponent', () => {
   describe('form validation', () => {
     it('should require property', () => {
       const control = component['form'].get('propertyId');
+      control?.markAsTouched();
+      fixture.detectChanges();
       expect(control?.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Property is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
 
     it('should require amount', () => {
       const control = component['form'].get('amount');
+      control?.markAsTouched();
+      fixture.detectChanges();
       expect(control?.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Amount is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
 
     it('should require amount greater than 0', () => {
       const control = component['form'].get('amount');
       control?.setValue(0);
+      control?.markAsTouched();
+      fixture.detectChanges();
       expect(control?.hasError('min')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const minError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Amount must be greater than $0'),
+      );
+      expect(minError).toBeTruthy();
     });
 
     it('should require category', () => {
@@ -223,7 +247,15 @@ describe('ReceiptExpenseFormComponent', () => {
     it('should enforce max description length', () => {
       const control = component['form'].get('description');
       control?.setValue('a'.repeat(501));
+      control?.markAsTouched();
+      fixture.detectChanges();
       expect(control?.hasError('maxlength')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const maxlengthError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Description must be 500 characters or less'),
+      );
+      expect(maxlengthError).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/features/vendors/components/vendor-edit/vendor-edit.component.spec.ts
+++ b/frontend/src/app/features/vendors/components/vendor-edit/vendor-edit.component.spec.ts
@@ -217,8 +217,17 @@ describe('VendorEditComponent', () => {
     it('should validate email format (AC #6)', () => {
       component['addEmail']();
       const lastIndex = component['emailsArray'].length - 1;
-      component['emailsArray'].at(lastIndex).setValue('invalid-email');
-      expect(component['emailsArray'].at(lastIndex).hasError('email')).toBe(true);
+      const emailControl = component['emailsArray'].at(lastIndex);
+      emailControl.setValue('invalid-email');
+      emailControl.markAsTouched();
+      fixture.detectChanges();
+      expect(emailControl.hasError('email')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const emailError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Invalid email format'),
+      );
+      expect(emailError).toBeTruthy();
     });
   });
 
@@ -328,13 +337,31 @@ describe('VendorEditComponent', () => {
     });
 
     it('should require first name', () => {
-      component['form'].get('firstName')?.setValue('');
-      expect(component['form'].get('firstName')?.hasError('required')).toBe(true);
+      const firstNameControl = component['form'].get('firstName');
+      firstNameControl?.setValue('');
+      firstNameControl?.markAsTouched();
+      fixture.detectChanges();
+      expect(firstNameControl?.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('First name is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
 
     it('should require last name', () => {
-      component['form'].get('lastName')?.setValue('');
-      expect(component['form'].get('lastName')?.hasError('required')).toBe(true);
+      const lastNameControl = component['form'].get('lastName');
+      lastNameControl?.setValue('');
+      lastNameControl?.markAsTouched();
+      fixture.detectChanges();
+      expect(lastNameControl?.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Last name is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
 
     it('should not require middle name', () => {

--- a/frontend/src/app/features/vendors/components/vendor-form/vendor-form.component.spec.ts
+++ b/frontend/src/app/features/vendors/components/vendor-form/vendor-form.component.spec.ts
@@ -153,7 +153,14 @@ describe('VendorFormComponent', () => {
       const phoneControl = component['phonesArray'].at(0).get('number');
       phoneControl?.markAsTouched();
       phoneControl?.setValue('');
+      fixture.detectChanges();
       expect(phoneControl?.hasError('required')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const requiredError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Phone number is required'),
+      );
+      expect(requiredError).toBeTruthy();
     });
   });
 
@@ -187,7 +194,15 @@ describe('VendorFormComponent', () => {
       component['addEmail']();
       const emailControl = component['emailsArray'].at(0);
       emailControl.setValue('not-an-email');
+      emailControl.markAsTouched();
+      fixture.detectChanges();
       expect(emailControl.hasError('email')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const emailError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Invalid email format'),
+      );
+      expect(emailError).toBeTruthy();
     });
   });
 
@@ -236,20 +251,47 @@ describe('VendorFormComponent', () => {
 
     it('should enforce maxLength on firstName (100 chars)', () => {
       const longName = 'A'.repeat(101);
-      component['form'].get('firstName')?.setValue(longName);
-      expect(component['form'].get('firstName')?.hasError('maxlength')).toBe(true);
+      const control = component['form'].get('firstName');
+      control?.setValue(longName);
+      control?.markAsTouched();
+      fixture.detectChanges();
+      expect(control?.hasError('maxlength')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const maxlengthError = errors.find((el) =>
+        el.nativeElement.textContent.includes('First name must be 100 characters or less'),
+      );
+      expect(maxlengthError).toBeTruthy();
     });
 
     it('should enforce maxLength on lastName (100 chars)', () => {
       const longName = 'A'.repeat(101);
-      component['form'].get('lastName')?.setValue(longName);
-      expect(component['form'].get('lastName')?.hasError('maxlength')).toBe(true);
+      const control = component['form'].get('lastName');
+      control?.setValue(longName);
+      control?.markAsTouched();
+      fixture.detectChanges();
+      expect(control?.hasError('maxlength')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const maxlengthError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Last name must be 100 characters or less'),
+      );
+      expect(maxlengthError).toBeTruthy();
     });
 
     it('should enforce maxLength on middleName (100 chars)', () => {
       const longName = 'A'.repeat(101);
-      component['form'].get('middleName')?.setValue(longName);
-      expect(component['form'].get('middleName')?.hasError('maxlength')).toBe(true);
+      const control = component['form'].get('middleName');
+      control?.setValue(longName);
+      control?.markAsTouched();
+      fixture.detectChanges();
+      expect(control?.hasError('maxlength')).toBe(true);
+
+      const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+      const maxlengthError = errors.find((el) =>
+        el.nativeElement.textContent.includes('Middle name must be 100 characters or less'),
+      );
+      expect(maxlengthError).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/features/work-orders/components/create-wo-from-expense-dialog/create-wo-from-expense-dialog.component.spec.ts
+++ b/frontend/src/app/features/work-orders/components/create-wo-from-expense-dialog/create-wo-from-expense-dialog.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { signal } from '@angular/core';
 import { of, throwError } from 'rxjs';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
@@ -117,8 +118,15 @@ describe('CreateWoFromExpenseDialogComponent', () => {
   it('should validate description as required (AC #5)', () => {
     component.form.controls.description.setValue('');
     component.form.controls.description.markAsTouched();
+    fixture.detectChanges();
     expect(component.form.controls.description.hasError('required')).toBe(true);
     expect(component.form.invalid).toBe(true);
+
+    const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+    const requiredError = errors.find((el) =>
+      el.nativeElement.textContent.includes('Description is required'),
+    );
+    expect(requiredError).toBeTruthy();
   });
 
   it('should disable "Create & Link" when form invalid (AC #5)', () => {


### PR DESCRIPTION
## Summary
- Strengthen ~80 backend FluentValidation assertions to check both `PropertyName` and exact `ErrorMessage` content (Form A: `e.PropertyName == "X" && e.ErrorMessage == "Y"`).
- Strengthen ~50 frontend reactive form assertions to query `<mat-error>` and assert rendered text alongside existing `hasError` checks.
- No new test files, no net-new test cases (AC-3 scope guard verified: `git diff main | grep -cE "^\+.*([Fact]|[Theory]|  it\()"` = 0). No production code changed.

## Scope (29 files modified)
- **Backend**: 14 `*ValidatorTests.cs` files across Properties, Expenses, Income, Maintenance, Notes, Invitations, WorkOrderTags, VendorTradeTags, WorkOrders, MaintenanceRequestPhotos, PropertyPhotos, VendorPhotos.
- **Frontend**: 14 `*.spec.ts` files across auth (login, forgot-password, reset-password, accept-invitation), expenses, income, properties, vendors, work-orders, receipts.

## Notable judgment calls
- `ValidateInvitationTests.cs` was a no-op (no failing-path assertions to tighten — only positive-path handler tests). Documented in Dev Agent Record.
- `categoryId` in expense-form / receipt-expense-form left as `hasError`-only — error rendering is delegated to `<app-category-select>` child component (per AC-2.5).
- `LinkReceiptToExpenseValidator` has no `.WithMessage()` overrides; tests assert against FluentValidation v12's default rendering. Validator NOT modified (would be out of scope per AC-1.5).

## Test plan
- [x] Backend `dotnet build` clean (0 warnings, 0 errors)
- [x] Frontend `ng build` clean
- [x] Backend full suite: 2110/2110 passed
- [x] Frontend Vitest: 2768/2768 passed across 123 files
- [x] AC-3 scope guard: 0 net-new test cases
- [x] AC-5 verified: all 14 "do not modify" files untouched
- [x] Live smoke: blank login form renders the now-asserted `<mat-error>` text

Closes #371 (Story 21.11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)