### PR TITLE
feat(20-7): landlord maintenance request inbox

### DIFF
--- a/docs/project/sprint-status.yaml
+++ b/docs/project/sprint-status.yaml
@@ -322,14 +322,20 @@ development_status:
 
   # Epic 20: Tenant Portal
   # User Outcome: "Tenants can submit maintenance requests and I can triage them into work orders"
-  # PAUSED 2026-04-17 — interrupted by Epic 21 (test coverage backfill, issue #371). Resume after 21 is done.
-  epic-20: paused
+  # PAUSED 2026-04-17 — interrupted by Epic 21 (test coverage backfill, issue #371).
+  # RESUMED 2026-05-06 after Epic 21 completed.
+  epic-20: in-progress
   20-1-tenant-role-property-association: done    # FR-TP2, FR-TP3, FR-TP10, NFR-TP3 - Size 5
   20-2-tenant-invitation-flow: done    # FR-TP1, FR-TP4, FR-TP5, NFR-TP4 - Size 5
   20-3-maintenance-request-entity-api: done    # FR-TP18, FR-TP19, FR-TP20, NFR-TP6 - Size 5
   20-4-maintenance-request-photos: done    # FR-TP21 - Size 5
   20-5-tenant-dashboard-role-routing: done    # FR-TP6, FR-TP8, FR-TP9, FR-TP11, NFR-TP5, NFR-TP7 - Size 5
   20-6-submit-maintenance-request-tenant-ui: done    # FR-TP7, NFR-TP7, NFR-TP8 - Size 5
+  20-7-landlord-maintenance-request-inbox: done    # FR-TP12 - Size 5
+  20-8-convert-request-to-work-order: backlog    # FR-TP13, FR-TP14, FR-TP16 - Size 5
+  20-9-dismiss-maintenance-request: backlog    # FR-TP15, FR-TP16 - Size 5
+  20-10-request-resolution-sync: backlog    # FR-TP17 - Size 3
+  20-11-tenant-authorization-lockdown: backlog    # NFR-TP1, NFR-TP2, NFR-TP3 - Size 5
 
   # ============================================================
   # INTERJECTION: TEST COVERAGE BACKFILL
@@ -342,7 +348,7 @@ development_status:
 
   # Epic 21: Test Coverage Backfill
   # User Outcome: "The test pyramid matches the feature surface — newer features have the same depth as older ones"
-  epic-21: in-progress
+  epic-21: done
   21-1-maintenance-requests-controller-integration-tests: done    # P1 - M - Issue #371
   21-2-maintenance-request-photos-controller-integration-tests: done    # P1 - M - Issue #371
   21-3-expenses-controller-integration-consolidation: done    # P1 - L - Issue #371
@@ -355,4 +361,4 @@ development_status:
   21-10-dashboard-unit-and-e2e-tests: done    # P3 - M - Issue #371
   21-11-validation-message-assertion-improvements: done    # P3 - S - Issue #371
   21-12-pagination-edge-case-tests: done    # P3 - S - Issue #371
-  epic-21-retrospective: optional
+  epic-21-retrospective: skipped    # Solo-dev — retro skipped per usual workflow

--- a/docs/project/stories/epic-20/20-7-landlord-maintenance-request-inbox.md
+++ b/docs/project/stories/epic-20/20-7-landlord-maintenance-request-inbox.md
@@ -1,0 +1,486 @@
+# Story 20.7: Landlord Maintenance Request Inbox
+
+Status: done
+
+## Story
+
+As a landlord,
+I want a single inbox showing all maintenance requests across my properties,
+so that I can triage them efficiently.
+
+## Acceptance Criteria
+
+1. **Given** a landlord user (Owner role),
+   **When** they navigate to the maintenance request inbox at `/maintenance-requests`,
+   **Then** they see all maintenance requests across all properties in their account, with the most-recently created first.
+
+2. **Given** the inbox list,
+   **When** requests are listed,
+   **Then** each row shows: status badge, description (truncated to ~100 chars), property name, submitter name (or fallback to email), and submission date.
+
+3. **Given** the inbox list,
+   **When** a landlord clicks a row,
+   **Then** they navigate to a detail view at `/maintenance-requests/:id` showing the full request: full description, status badge, dismissal reason (if dismissed), submitter info, property info, work order link badge (if linked), photos grid (with thumbnails opening full-size views), and submission/update timestamps.
+
+4. **Given** the inbox list,
+   **When** there are more than `pageSize` requests,
+   **Then** the list is paginated using `mat-paginator` with page-size options `[10, 20, 50]` and a default of `20`.
+
+5. **Given** the inbox list,
+   **When** requests exist in different statuses (Submitted, InProgress, Resolved, Dismissed),
+   **Then** each row shows a color-coded status chip distinguishable at a glance: Submitted = warning/amber, In Progress = primary/blue, Resolved = tertiary/green, Dismissed = warn/orange.
+
+6. **Given** the inbox list,
+   **When** the landlord uses the status filter chip-listbox,
+   **Then** the list reloads filtered by the selected statuses (multi-select). Default selection is all four statuses.
+
+7. **Given** the inbox list,
+   **When** the landlord uses the property filter dropdown,
+   **Then** the list reloads filtered to the selected property (or "All Properties" when none is selected).
+
+8. **Given** any active filters,
+   **When** the result set is empty,
+   **Then** a "No requests match your filters" empty state is shown with a Clear Filters button.
+
+9. **Given** no maintenance requests exist in the account,
+   **When** the landlord opens the inbox,
+   **Then** an "No maintenance requests yet" empty state is shown explaining that requests will appear here when tenants submit them.
+
+10. **Given** the landlord navigation (sidebar + bottom nav),
+    **When** the user has Owner role,
+    **Then** a "Maintenance Requests" item appears between "Work Orders" and "Reports" with the `inbox` Material icon.
+
+11. **Given** a user with the Tenant role,
+    **When** they attempt to navigate to `/maintenance-requests` directly,
+    **Then** the route guard redirects them to `/tenant` (no leakage of the landlord inbox to tenants).
+
+12. **Given** the inbox is loading,
+    **When** the request is in flight,
+    **Then** a loading spinner is visible. **And given** the request fails, **Then** an error card is shown with a retry button.
+
+13. **Given** the inbox on a small viewport (mobile width <= 768px),
+    **When** the landlord views rows,
+    **Then** each row stacks legibly (status + date on line 1, description on line 2, property + submitter on line 3) without horizontal overflow.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Frontend — Maintenance Request service (AC #1, #2, #3, #4, #6, #7)
+  - [x] 1.1 Create `frontend/src/app/features/maintenance-requests/services/maintenance-request.service.ts`
+  - [x] 1.2 Inject `HttpClient`. Methods:
+    - `getMaintenanceRequests(params: { status?: string; propertyId?: string; page?: number; pageSize?: number }): Observable<PaginatedMaintenanceRequests>` — GET `/api/v1/maintenance-requests` with query params (omit empty values; build via `HttpParams`)
+    - `getMaintenanceRequestById(id: string): Observable<MaintenanceRequestDto>` — GET `/api/v1/maintenance-requests/{id}`
+  - [x] 1.3 Define TypeScript interfaces locally OR re-export from existing `tenant.service.ts` types. **Decision: Define new local interfaces** to keep features decoupled. Mirror the backend response exactly:
+    - `MaintenanceRequestDto { id, propertyId, propertyName, propertyAddress, description, status, dismissalReason, submittedByUserId, submittedByUserName, workOrderId, createdAt, updatedAt, photos? }`
+    - `MaintenanceRequestPhotoDto { id, thumbnailUrl, viewUrl, isPrimary, displayOrder, originalFileName, fileSizeBytes, createdAt }`
+    - `PaginatedMaintenanceRequests { items, totalCount, page, pageSize, totalPages }`
+  - [x] 1.4 Build the query string with `HttpParams` — only set keys that have values (mirror existing service patterns).
+  - [x] 1.5 Spec file `maintenance-request.service.spec.ts`: 4 tests covering URL/params for each call (no params, status only, propertyId only, page+pageSize+both filters). **(7 tests written.)**
+
+- [x] Task 2: Frontend — Maintenance Request signal store (AC #1, #4, #6, #7, #12)
+  - [x] 2.1 Create `frontend/src/app/features/maintenance-requests/stores/maintenance-request.store.ts`
+  - [x] 2.2 Use `signalStore({ providedIn: 'root' })` with `withState`, `withComputed`, `withMethods`. Mirror the structure of `WorkOrderStore`.
+  - [x] 2.3 State:
+    ```ts
+    interface MaintenanceRequestState {
+      requests: MaintenanceRequestDto[];
+      selectedRequest: MaintenanceRequestDto | null;
+      isLoading: boolean;
+      isLoadingDetail: boolean;
+      error: string | null;
+      detailError: string | null;
+      // Filter state (AC #6, #7)
+      selectedStatuses: string[];   // default = all four
+      selectedPropertyId: string | null;
+      // Pagination (AC #4)
+      page: number;
+      pageSize: number;
+      totalCount: number;
+      totalPages: number;
+    }
+    ```
+    Constants: `const ALL_STATUSES = ['Submitted', 'InProgress', 'Resolved', 'Dismissed'];`. Initial state: all statuses selected, no property filter, `page = 1`, `pageSize = 20`.
+  - [x] 2.4 Computed signals:
+    - `isEmpty` — `!isLoading() && requests().length === 0` AND no filters active
+    - `isFilteredEmpty` — `!isLoading() && requests().length === 0` AND filters active (AC #8)
+    - `hasActiveFilters` — `selectedStatuses.length < ALL_STATUSES.length || selectedPropertyId !== null` (AC #8)
+  - [x] 2.5 Methods (use `rxMethod<...>(pipe(...))` with `tap` → `switchMap` → `tap` + `catchError` → `of(null)` pattern):
+    - `loadRequests(params?: { page?; pageSize? })` — calls `MaintenanceRequestService.getMaintenanceRequests({ status, propertyId, page, pageSize })` derived from current state. On success patches `requests`, `totalCount`, `page`, `pageSize`, `totalPages`. On error sets `error`.
+    - `loadRequestById(id: string)` — calls `getMaintenanceRequestById`. Patches `selectedRequest` / `detailError`. 404 → "Maintenance request not found"; other errors → generic message.
+    - `setStatusFilter(statuses: string[])` — patch state, reset to page 1, reload. **Refuse empty selection** (matches WorkOrderStore pattern).
+    - `setPropertyFilter(propertyId: string | null)` — patch state, reset to page 1, reload.
+    - `clearFilters()` — reset to defaults, reset to page 1, reload (AC #8).
+    - `setPage(page: number, pageSize: number)` — patch and reload (used by `mat-paginator`).
+    - `clearSelectedRequest()` — clears `selectedRequest` and `detailError` (use on detail page leave).
+  - [x] 2.6 Status filter encoding implemented per the "n=1 → status param, otherwise omit" rule (`encodeStatusParam` helper). The 0-selected case is rejected by `setStatusFilter` (refuse empty selection).
+  - [x] 2.7 Spec file `maintenance-request.store.spec.ts`: tests for
+    - `loadRequests` happy path patches state
+    - `loadRequests` error sets error message
+    - `setStatusFilter` patches state and triggers reload
+    - `setStatusFilter` rejects empty selection (no patch, no reload)
+    - `setPropertyFilter` patches state and triggers reload
+    - `clearFilters` resets state to defaults
+    - `setPage` patches and reloads
+    - `loadRequestById` happy path
+    - `loadRequestById` 404 sets `detailError = 'Maintenance request not found'`
+    - `clearSelectedRequest` clears both fields
+    - `hasActiveFilters` computed: false on defaults, true when status subset, true when property selected
+    - `isFilteredEmpty` computed: true when no requests AND filters active
+
+- [x] Task 3: Frontend — Inbox list component (AC #1, #2, #5, #6, #7, #8, #9, #12, #13)
+  - [x] 3.1 Create `frontend/src/app/features/maintenance-requests/maintenance-requests.component.ts` (standalone)
+  - [x] 3.2 Imports — `RouterLink` was removed from the imports list because the component navigates programmatically; the rest match the spec.
+  - [x] 3.3 Inject `MaintenanceRequestStore`, `PropertyStore`, `Router`. On init: `store.loadRequests()` and `propertyStore.loadProperties(undefined)` (matches `WorkOrdersComponent.ngOnInit`).
+  - [x] 3.4 Template structure:
+    - Page header: `<h1>Maintenance Requests</h1>` (no "New" button — landlords don't submit; tenants do)
+    - Filter section: `mat-chip-listbox multiple` for status (chip per status: Submitted / In Progress / Resolved / Dismissed), `mat-form-field outline` `mat-select` for property (`All Properties` + each property), Clear filters button when `store.hasActiveFilters()`
+    - Conditional content:
+      - `@if (store.isLoading())` — `<app-loading-spinner />`
+      - `@else if (store.error())` — `<app-error-card [message]="..." [showRetry]="true" (retry)="retry()" />`
+      - `@else if (store.isFilteredEmpty())` — filtered empty state with Clear Filters button (AC #8)
+      - `@else if (store.isEmpty())` — `<app-empty-state icon="inbox" title="No maintenance requests yet" message="When tenants submit maintenance requests for your properties, they will appear here." />` (AC #9)
+      - `@else` — list of rows + paginator
+    - Each row (use a similar two-line pattern to `WorkOrdersComponent`):
+      - Line 1: status chip + description (truncated, flex 1) + date (right-aligned)
+      - Line 2: property name (with home icon) + submitter name (with person icon) + work order link badge if `workOrderId !== null` (with `link` icon and label "Linked")
+      - Click row content → `router.navigate(['/maintenance-requests', request.id])`
+    - Paginator: `[length]="store.totalCount()"`, `[pageSize]="store.pageSize()"`, `[pageIndex]="store.page() - 1"`, `[pageSizeOptions]="[10, 20, 50]"`, `(page)="onPageChange($event)"`. Show only when `store.totalCount() > store.pageSize()`.
+  - [x] 3.5 Methods:
+    - `onStatusFilterChange(event: MatChipListboxChange)` — `store.setStatusFilter((event.value as string[]) ?? [])`
+    - `onPropertyFilterChange(propertyId: string | null)` — `store.setPropertyFilter(propertyId)`
+    - `clearFilters()` — `store.clearFilters()`
+    - `onPageChange(event: PageEvent)` — `store.setPage(event.pageIndex + 1, event.pageSize)`
+    - `retry()` — `store.loadRequests()`
+    - `getStatusLabel(status: string)` — returns `'In Progress'` for `'InProgress'`, otherwise the raw status (consistent with `tenant-dashboard.component.ts`)
+    - `truncateDescription(description: string, maxLength = 100)` — same helper as tenant dashboard
+  - [x] 3.6 SCSS: mobile-first using existing `--mat-sys-*` CSS custom properties. Status chip color classes: `.status-submitted` (warning container), `.status-in-progress` (primary container), `.status-resolved` (tertiary container), `.status-dismissed` (error container) — match the tenant-dashboard kebab-case names so the styles can be copied. Mobile breakpoint @ 768px: stacks lines vertically as described in AC #13.
+  - [x] 3.7 `data-testid` attributes for E2E:
+    - `data-testid="maintenance-requests-page"` on the root `<div>`
+    - `data-testid="status-filter"` on the chip listbox
+    - `data-testid="property-filter"` on the property `mat-select`
+    - `data-testid="request-row"` on each row
+    - `data-testid="request-row-${id}"` for individual rows (for stable row queries)
+    - `data-testid="empty-state"` and `data-testid="filtered-empty-state"` on the respective placeholders
+    - `data-testid="paginator"` on the paginator
+  - [x] 3.8 Spec file `maintenance-requests.component.spec.ts`: tests for
+    - Renders the page header
+    - Renders rows when `store.requests()` is non-empty
+    - Shows loading spinner when `store.isLoading()`
+    - Shows error card when `store.error()`
+    - Shows empty state when `store.isEmpty()`
+    - Shows filtered empty state when `store.isFilteredEmpty()`
+    - Status chip filter triggers `store.setStatusFilter`
+    - Property select triggers `store.setPropertyFilter`
+    - Paginator change triggers `store.setPage`
+    - Row click navigates to `/maintenance-requests/:id`
+    - `getStatusLabel('InProgress')` returns `'In Progress'`
+
+- [x] Task 4: Frontend — Inbox detail component (AC #3, #5, #12)
+  - [x] 4.1 Create `frontend/src/app/features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component.ts`
+  - [x] 4.2 Standalone, imports same Material modules as tenant-side `RequestDetailComponent` plus `RouterLink` for back-link/work-order link.
+  - [x] 4.3 On init: read `id` from `ActivatedRoute.paramMap` and call `store.loadRequestById(id)`. On destroy: `store.clearSelectedRequest()`.
+  - [x] 4.4 Template:
+    - Back button → `routerLink="/maintenance-requests"` with `arrow_back` icon
+    - Loading: spinner
+    - Error: error card with retry
+    - Loaded: `mat-card` containing
+      - Header: status chip (color-coded) + submission date
+      - Property block: name + address (with `home` icon)
+      - Submitter block: name (or "Unknown") + user ID for debugging (label hidden visually but available via `<small>` for now — keep simple)
+      - Description (full, `white-space: pre-wrap`)
+      - Dismissal reason (only when status is `Dismissed`)
+      - Linked Work Order badge with `routerLink="/work-orders/{workOrderId}"` (only when `workOrderId !== null`) — text "View linked work order"
+      - Photos grid (when `photos?.length > 0`): thumbnail tiles using `thumbnailUrl`; click opens `viewUrl` in a new tab. Reuse the photo grid pattern from `tenant-dashboard/components/request-detail/request-detail.component.html` (or extract to shared if straightforward — but **keep extraction out of scope for this story**; copy the pattern).
+      - Empty photos: not shown (no placeholder block)
+    - `data-testid="request-detail-page"` on root, `data-testid="status-chip"` on the chip, `data-testid="dismissal-reason"` on the reason block, `data-testid="linked-work-order"` on the badge, `data-testid="photo-grid"` on the gallery.
+  - [x] 4.5 No write actions in this story — convert/dismiss live in 20.8/20.9. Render the detail read-only.
+  - [x] 4.6 Spec file: tests for
+    - Calls `store.loadRequestById(id)` from the route param
+    - Shows status chip with correct class
+    - Shows dismissal reason only when status is `Dismissed`
+    - Hides dismissal reason when status is not `Dismissed`
+    - Shows linked work order badge only when `workOrderId !== null`
+    - Renders photos grid when photos array is non-empty
+    - Renders error card on `store.detailError()`
+
+- [x] Task 5: Add routes in `app.routes.ts` (AC #1, #3, #11)
+  - [x] 5.1 Added inside the shell children, after the `work-orders/:id/edit` block and before the tenant routes:
+    ```ts
+    {
+      path: 'maintenance-requests',
+      loadComponent: () =>
+        import('./features/maintenance-requests/maintenance-requests.component').then(
+          (m) => m.MaintenanceRequestsComponent,
+        ),
+      canActivate: [ownerGuard],
+    },
+    {
+      path: 'maintenance-requests/:id',
+      loadComponent: () =>
+        import('./features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component').then(
+          (m) => m.MaintenanceRequestDetailComponent,
+        ),
+      canActivate: [ownerGuard],
+    },
+    ```
+  - [x] 5.2 `ownerGuard` already redirects Tenant users to `/tenant` (Story 20.5), satisfying AC #11. Added a guard test for `/maintenance-requests` URL → `/tenant` redirect.
+
+- [x] Task 6: Update navigation (AC #10)
+  - [x] 6.1 Added `{ label: 'Maintenance Requests', route: '/maintenance-requests', icon: 'inbox' }` to `sidebar-nav.component.ts` `allItems`, between Work Orders and Reports. Owner sees it; Contributor's `contributorRoutes` allow-list excludes it; Tenant role returns its own hard-coded list.
+  - [x] 6.2 **Decision applied:** Owner bottom-nav currently has 5 items (Dashboard, Properties, Expenses, Income, Receipts). Per the story's "add only if ≤ 4" rule, bottom-nav is left unchanged. Maintenance Requests is reachable from sidebar (desktop) and direct URL on mobile.
+  - [x] 6.3 No `permission.service.ts` change needed — Owner falls through to `true` for non-Tenant routes.
+  - [x] 6.4 Updated `sidebar-nav.component.spec.ts` to assert the new item is present for Owner (count = 10, position between Work Orders and Reports) and absent for Tenant/Contributor.
+
+- [x] Task 7: Frontend — guard test for Tenant redirect (AC #11)
+  - [x] 7.1 Added a Tenant → `/tenant` redirect test for `/maintenance-requests` URL in `owner.guard.spec.ts`.
+
+- [x] Task 8: Frontend — Vitest run (AC: all)
+  - [x] 8.1 `npm test` — full suite: **127 files, 2835 tests passing.**
+  - [x] 8.2 `ng build` — clean production build. Initial bundle 579.70 kB (4.70 kB over 575 kB budget), matching the documented pre-existing 4.4 kB overage.
+
+- [x] Task 9: E2E — Landlord inbox happy path (AC #1, #2, #3, #5, #10)
+  - [x] 9.1 Created `frontend/e2e/pages/maintenance-requests-list.page.ts` extending `BasePage`. Locators for:
+    - `requestRows` (`[data-testid="request-row"]`)
+    - `statusFilter` (`[data-testid="status-filter"]`)
+    - `propertyFilter` (`[data-testid="property-filter"]`)
+    - `paginator` (`[data-testid="paginator"]`)
+    - `emptyState` and `filteredEmptyState`
+    - Methods: `goto()`, `getRowByDescription(text)`, `clickRow(text)`, `selectStatus(label)`, `selectProperty(name)`, `clearFilters()`, `expectRowVisible(text)`, `expectRowHidden(text)`, `expectStatusBadge(text, status)`, `expectEmptyState()`, `expectFilteredEmptyState()`
+  - [x] 9.2 Created `frontend/e2e/pages/maintenance-request-detail.page.ts`: locators for description, statusChip, dismissalReason, linkedWorkOrder, photoGrid; helper `goto(id)`.
+  - [x] 9.3 Created `frontend/e2e/tests/maintenance-requests/landlord-inbox.spec.ts` with the 6 specs. Added `loginAsLandlord` helper to `tenant.helper.ts` (mirrors `loginAsTenant` but waits for `/dashboard`).
+    - **Spec 1 — Inbox shows aggregated requests across properties (AC #1, #2):** landlord with 2 properties + 1 tenant per property + 1 request each → landlord opens `/maintenance-requests` → sees 2 rows, each with description + status chip + property name + submitter name.
+    - **Spec 2 — Row click opens detail (AC #3):** landlord clicks a row → `/maintenance-requests/:id` shows full description + property + submitter + status chip + photos block (empty when no photos).
+    - **Spec 3 — Status filter narrows results (AC #6):** seed 1 Submitted + 1 (manually-status-set if possible — otherwise just verify the filter UI calls the API by intercepting the request) → click "In Progress" chip → only matching requests shown. **If status mutation is not yet possible via API in this story (since 20.8/20.9 implement transitions), use `page.route()` to intercept the GET and assert the query string contains `status=InProgress`** instead of asserting on visible rows.
+    - **Spec 4 — Property filter narrows results (AC #7):** seed requests on two properties → select one in the property dropdown → only that property's rows are visible.
+    - **Spec 5 — Empty state when no requests exist (AC #9):** throwaway landlord with a property but no submitted requests → inbox shows the empty state.
+    - **Spec 6 — Tenant cannot access landlord inbox (AC #11):** log in as a tenant → navigate to `/maintenance-requests` → URL ends up at `/tenant` (guard redirect).
+  - [x] 9.4 Registered `maintenanceRequestsListPage` and `maintenanceRequestDetailPage` fixtures in `test-fixtures.ts`.
+  - [x] 9.5 Spec file leading comment documents the throwaway-landlord isolation pattern.
+
+- [x] Task 10: Sprint status (Process)
+  - [x] 10.1 Sprint status set to `review`.
+
+## Dev Notes
+
+### Architecture: Frontend-Only Story
+
+All backend APIs are already in place from Stories 20.3 and 20.4:
+
+| Endpoint | Behavior for Landlord (Owner) |
+|---|---|
+| `GET /api/v1/maintenance-requests?status=&propertyId=&page=&pageSize=` | Returns all requests across the account, filtered by query params, paginated. |
+| `GET /api/v1/maintenance-requests/{id}` | Returns full detail incl. photos with presigned URLs. |
+
+The handlers (`GetMaintenanceRequestsQueryHandler`, `GetMaintenanceRequestByIdQueryHandler`) already differentiate behavior by role: when `_currentUser.Role == "Tenant"` they restrict to the tenant's `PropertyId`; otherwise they return everything in the account. The frontend just calls the API as the logged-in landlord. **No backend changes, no new migrations, no NSwag regeneration.**
+
+Backend integration coverage for these endpoints already exists from Story 21.1 (`MaintenanceRequestsControllerTests.cs`): owner-aggregated list, cross-account isolation, ordering, status filter, property filter, pagination edge cases. This story does NOT need to add backend tests.
+
+### Why a Separate Feature Module
+
+Don't extend `tenant-dashboard/` for the landlord inbox. Two reasons:
+
+1. **Role-symmetry is misleading**: the tenant dashboard is mobile-first, single-property, and tenant-scoped. The landlord inbox is filter-driven, cross-property, and Owner-scoped. They share a backend but diverge on UX.
+2. **Folder boundaries match guard boundaries**: `features/tenant-dashboard/` is reached via `tenantGuard`; `features/maintenance-requests/` is reached via `ownerGuard`. Keeping them separate prevents accidental cross-leakage.
+
+The `MaintenanceRequestService` and `MaintenanceRequestStore` are new and Owner-scoped. The DTO interfaces duplicate what `tenant.service.ts` exports — accept the duplication for now. **Consolidating** them is a future tech-debt opportunity once the landlord views (20.7–20.10) are stable; do NOT premature-extract.
+
+### Status Filter Encoding (One-Status Constraint)
+
+The backend `GetMaintenanceRequestsQuery.Status` is a single string parsed via `Enum.TryParse<MaintenanceRequestStatus>`. It accepts ONE status. The work-orders front-end works around this by joining selected statuses with commas, but the backend silently ignores unparseable values (returning the unfiltered set). For maintenance requests we accept the same trade-off:
+
+- 0 selected: refuse (re-select default — same UX as work-orders)
+- 1 selected: send `status=<single>` and the backend filters
+- 2–3 selected: omit `status` (effectively shows all four — UX caveat documented here)
+- All 4 selected: omit `status`
+
+A future story can extend the backend to accept multi-status (`status=Submitted,InProgress`) and update the frontend to take advantage. For 20.7, single-status filtering is sufficient and matches the existing work-orders pattern. **Document this in the SubmitRequestComponent comment** so the next dev knows the limit is intentional.
+
+### File Locations (Pattern)
+
+```
+frontend/src/app/features/maintenance-requests/
+├── maintenance-requests.component.ts          # Inbox list (this story)
+├── maintenance-requests.component.spec.ts
+├── components/
+│   └── maintenance-request-detail/
+│       ├── maintenance-request-detail.component.ts
+│       └── maintenance-request-detail.component.spec.ts
+├── services/
+│   ├── maintenance-request.service.ts
+│   └── maintenance-request.service.spec.ts
+└── stores/
+    ├── maintenance-request.store.ts
+    └── maintenance-request.store.spec.ts
+```
+
+This mirrors the work-orders feature module (`features/work-orders/`).
+
+### Status Chip Colors (Match Tenant View)
+
+The tenant-side request list uses these classes (`tenant-dashboard.component.html`):
+- `.status-submitted` — neutral / amber (it currently has `[highlighted]="getStatusColor === 'primary'"` — i.e. only the In-Progress chip is highlighted)
+- `.status-in-progress` — primary blue
+- `.status-resolved` — green
+- `.status-dismissed` — orange
+
+Reuse the same color scheme so a tenant and a landlord looking at the same request see the same status visual. The CSS-variable system (`--mat-sys-*-container`) is the same one work-orders uses (`status-reported`, `status-assigned`, `status-completed`).
+
+**Note** the tenant component uses class names like `.status-in-progress` (kebab-case). For the landlord inbox use the same names so SCSS can be copied directly. The status enum value coming from the backend is `InProgress` (PascalCase concatenated). Translate via the helper:
+
+```ts
+function statusToClass(status: string): string {
+  return `status-${status.toLowerCase().replace(/inprogress/, 'in-progress')}`;
+}
+```
+
+Or keep the tenant-style approach with conditional class binding (`[class.status-in-progress]="request.status === 'InProgress'"`) — both work; the second is closer to existing code.
+
+### Pagination
+
+Use `MatPaginatorModule` and `PageEvent`. The store's `setPage(page, pageSize)` should send 1-based `page` to the backend (the backend's `GetMaintenanceRequestsQuery.Page` defaults to 1). The paginator's `pageIndex` is 0-based so the template binds `[pageIndex]="store.page() - 1"` and the handler does `store.setPage(event.pageIndex + 1, event.pageSize)`.
+
+Default page size: `20`. Options: `[10, 20, 50]` (tenant dashboard uses the same options).
+
+### Loading and Error States
+
+Use the existing shared components:
+- `frontend/src/app/shared/components/loading-spinner/loading-spinner.component.ts`
+- `frontend/src/app/shared/components/error-card/error-card.component.ts` (input `message`, output `retry`)
+- `frontend/src/app/shared/components/empty-state/empty-state.component.ts` (inputs `icon`, `title`, `message`)
+
+Tenant dashboard uses all three — copy the import block.
+
+### Property Filter Source
+
+Reuse `PropertyStore` — already loaded by the work-orders inbox via `propertyStore.loadProperties(undefined)` in `ngOnInit`. The store is `{ providedIn: 'root' }`, so loading it once in this component is fine; if it's already loaded from another page navigation the call is idempotent.
+
+### Critical Patterns to Follow
+
+1. **Signal store pattern** — match `WorkOrderStore`. Use `rxMethod<T>(pipe(...))` with `tap → switchMap → tap + catchError` blocks. Never re-throw from `catchError`; return `of(null)` to keep the stream alive.
+2. **Standalone components** — `inject()`, `input()` / `output()` signal API, `@if`/`@for` control flow.
+3. **Service pattern** — `HttpClient`, returns `Observable<T>`. Build params via `HttpParams` to omit empty keys.
+4. **MatSnackBar for feedback** — not needed for this read-only inbox, but available if you extend.
+5. **Prettier** — `singleQuote: true`, `printWidth: 100`. Run `npx prettier --write` if in doubt.
+6. **No try/catch in controllers** — N/A here (frontend story), but reinforce: don't add backend defensive code "just in case."
+7. **`data-testid` attributes** for E2E selector stability (don't rely on translatable text).
+
+### Previous Story Intelligence
+
+From Story 20.3:
+- `MaintenanceRequestsController` lives at `api/v1/maintenance-requests`. The Owner GET path returns every request in the account.
+- `MaintenanceRequestDto` includes `Photos` as an optional list (always present on detail, omitted on the list response).
+- Submitter display name: `IIdentityService.GetUserDisplayNamesAsync` returns the user's display name OR email; the DTO's `SubmittedByUserName` may be null if neither is set.
+
+From Story 20.4:
+- Photo `thumbnailUrl` and `viewUrl` are presigned URLs (with expiry). Display them directly in `<img>` and `<a>` tags. They are regenerated per request — DO NOT cache them in the store across reloads.
+
+From Story 20.5:
+- `ownerGuard` redirects Tenant users to `/tenant` (not `/dashboard`). This satisfies AC #11 without new guard code.
+- Sidebar/bottom nav use `currentUser()?.role` to differentiate. The `Tenant` branch returns a hard-coded list — adding to `allItems` (Owner branch) does not affect Tenant.
+- Shared empty-state, loading-spinner, error-card components are usable here.
+
+From Story 20.6:
+- The tenant submit flow lands on `/tenant` after success and `loadRequests()` is called to refresh — that's their list. The landlord sees the same backend records via the inbox; no SignalR live-update is required for 20.7 (out of scope; the dashboard refresh on navigation is sufficient).
+
+From Story 21.1:
+- Backend integration tests for the Owner GET path are exhaustive (account scoping, ordering, status filter case-insensitive, property filter, pagination edge cases). No new backend tests needed.
+
+From Story 21.4:
+- Tenant E2E pattern: throwaway landlord + tenant via `setupTenantContext`. Reuse the helpers; **do not** modify `claude@claude.com`'s data. Add a `setupLandlordWithTenants` style helper if needed for the inbox spec — or compose existing helpers inline.
+
+### Testing Strategy (Testing Pyramid)
+
+Per the user's "Testing Pyramid" memory: full-stack stories require unit + integration (WebApplicationFactory) + E2E (Playwright). Justification per layer:
+
+- **Unit (Vitest, frontend):** YES. New service, store, component, detail component — each gets a co-located spec. Coverage targets: ~25 new tests across the 4 spec files.
+- **Integration (WebApplicationFactory, backend):** SKIPPED — justified. The Owner GET endpoint and detail endpoint are exhaustively tested by Story 21.1's `MaintenanceRequestsControllerTests.cs` (account isolation, ordering, status filter case-insensitive, property filter, pagination edge cases, AccessToken auth). This story makes ZERO backend changes; adding redundant integration tests would be busywork.
+- **E2E (Playwright):** YES. New routes, new component, new role-aware navigation — needs end-to-end verification of the landlord flow. 6 specs covering happy path, navigation, filtering (UI invocation), empty states, and tenant-redirect security boundary.
+
+If Task 9's status-filter spec has trouble seeding non-Submitted statuses (since 20.8/20.9 don't yet exist), fall back to `page.route()` interception to assert the API is called with the correct query string — this is acceptable per the project's testing rules ("Use `page.route()` to control what the component sees" from `CLAUDE.md`).
+
+### Out of Scope (Subsequent Stories)
+
+- **Convert request to work order** — Story 20.8. The detail view shows the request read-only with no Convert button.
+- **Dismiss request with reason** — Story 20.9. Same: no Dismiss button.
+- **Resolve when work order completes** — Story 20.10. Backend logic, no UI in this story.
+- **Tenant authorization lockdown integration tests** — Story 20.11. Already-implemented enforcement is exercised by 20.7 only at the route-guard layer (AC #11 + Spec 6).
+- **Multi-status backend filtering** — Future. See "Status Filter Encoding" above for the current single-status workaround.
+- **Real-time inbox updates (SignalR)** — Future. The dashboard refresh on navigation is sufficient for 20.7.
+
+### References
+
+- Epic file: `docs/project/stories/epic-20/epic-20-tenant-portal.md` (Story 20.7)
+- Previous stories:
+  - `docs/project/stories/epic-20/20-3-maintenance-request-entity-api.md`
+  - `docs/project/stories/epic-20/20-4-maintenance-request-photos.md`
+  - `docs/project/stories/epic-20/20-5-tenant-dashboard-role-routing.md`
+  - `docs/project/stories/epic-20/20-6-submit-maintenance-request-tenant-ui.md`
+- PRD: `docs/project/prd-tenant-portal.md` (FR-TP12)
+- Architecture: `docs/project/architecture.md`
+- Project Context: `docs/project/project-context.md`
+- Reference implementations:
+  - Backend controller: `backend/src/PropertyManager.Api/Controllers/MaintenanceRequestsController.cs`
+  - Backend list handler: `backend/src/PropertyManager.Application/MaintenanceRequests/GetMaintenanceRequests.cs`
+  - Backend detail handler: `backend/src/PropertyManager.Application/MaintenanceRequests/GetMaintenanceRequestById.cs`
+  - Backend DTO: `backend/src/PropertyManager.Application/MaintenanceRequests/MaintenanceRequestDto.cs`
+  - Backend integration tests (already passing): `backend/tests/PropertyManager.Api.Tests/MaintenanceRequestsControllerTests.cs`
+  - Frontend list-page pattern: `frontend/src/app/features/work-orders/work-orders.component.ts`
+  - Frontend signal store pattern: `frontend/src/app/features/work-orders/stores/work-order.store.ts`
+  - Frontend service pattern: `frontend/src/app/features/work-orders/services/work-order.service.ts`
+  - Tenant-side request UI (status colors, photo grid): `frontend/src/app/features/tenant-dashboard/tenant-dashboard.component.html`
+  - Tenant-side store pattern: `frontend/src/app/features/tenant-dashboard/stores/tenant-dashboard.store.ts`
+  - Tenant request detail (photo grid pattern): `frontend/src/app/features/tenant-dashboard/components/request-detail/request-detail.component.html`
+  - Sidebar nav (where to add the inbox item): `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts`
+  - Bottom nav: `frontend/src/app/core/components/bottom-nav/bottom-nav.component.ts`
+  - Owner guard (already redirects Tenant → /tenant): `frontend/src/app/core/auth/owner.guard.ts`
+  - Routes file: `frontend/src/app/app.routes.ts`
+  - E2E page object pattern: `frontend/e2e/pages/work-order-list.page.ts`
+  - E2E tenant helpers: `frontend/e2e/helpers/tenant.helper.ts`
+  - Tenant E2E precedent: `frontend/e2e/tests/tenant-dashboard/tenant-dashboard.spec.ts`
+  - Shared empty-state / loading-spinner / error-card: `frontend/src/app/shared/components/`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7[1m] (Claude Opus 4.7, 1M context).
+
+### Debug Log References
+
+- Initial E2E run for `landlord-inbox.spec.ts`: 5/6 passed; spec 1 failed because `text-transform: uppercase` makes the chip's rendered text mixed-case ("Submitted") rather than uppercase. Switched the assertion to `toHaveClass(/status-submitted/) + toContainText('Submitted')`. Also updated the page-object helper.
+- Frontend test runner: `ng test --include='**/<glob>' --watch=false` (NOT `npx vitest`). Confirmed the Vitest runner config in `angular.json`.
+- Bundle budget warning: 579.70 kB initial, 4.70 kB over 575 kB. Matches the documented 4.4 kB pre-existing overage (story Task 8.2). No new regression.
+
+### Completion Notes List
+
+1. Stayed within the planned scope. No backend changes; story is frontend-only and reuses APIs from 20.3/20.4.
+2. **DTOs duplicated** from `tenant.service.ts` per the story's decoupling decision; consolidation is a future tech-debt opportunity.
+3. **Bottom-nav left unchanged** per Task 6.2 decision rule (Owner currently has 5 items; the story said "add only if ≤ 4").
+4. **Status filter encoding**: `n=1 → status param`; otherwise omitted. Empty selection refused (matches `WorkOrderStore`).
+5. **`RouterLink` removed** from the inbox component imports — navigation is programmatic via `Router.navigate`. Detail component still imports `RouterLink` for the back button and linked-work-order badge.
+6. **Visual verification**: Used Playwright MCP to confirm the inbox renders with sidebar nav highlighted, status badges color-coded, and detail navigation working. Screenshots saved under `screenshots/` then deleted at story end (Step 5 cleanup).
+7. **E2E test isolation**: every spec creates a throwaway landlord via `createLandlordViaInvitation` (per the tenant-dashboard precedent). Empty-state spec uses `page.route()` to stub the inbox endpoint since the throwaway landlord shares the seeded account.
+8. The detail-page chip's color override (`--mdc-chip-elevated-container-color`) renders correctly; visual was confirmed with the inbox view's chip class binding.
+
+### File List
+
+**Created**:
+- `frontend/src/app/features/maintenance-requests/services/maintenance-request.service.ts`
+- `frontend/src/app/features/maintenance-requests/services/maintenance-request.service.spec.ts`
+- `frontend/src/app/features/maintenance-requests/stores/maintenance-request.store.ts`
+- `frontend/src/app/features/maintenance-requests/stores/maintenance-request.store.spec.ts`
+- `frontend/src/app/features/maintenance-requests/maintenance-requests.component.ts`
+- `frontend/src/app/features/maintenance-requests/maintenance-requests.component.spec.ts`
+- `frontend/src/app/features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component.ts`
+- `frontend/src/app/features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component.spec.ts`
+- `frontend/e2e/pages/maintenance-requests-list.page.ts`
+- `frontend/e2e/pages/maintenance-request-detail.page.ts`
+- `frontend/e2e/tests/maintenance-requests/landlord-inbox.spec.ts`
+
+**Modified**:
+- `frontend/src/app/app.routes.ts` — added `/maintenance-requests` and `/maintenance-requests/:id` routes (ownerGuard).
+- `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts` — added Maintenance Requests nav item between Work Orders and Reports.
+- `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.spec.ts` — updated counts (9 → 10), added position + Tenant/Contributor exclusion tests.
+- `frontend/src/app/core/auth/owner.guard.spec.ts` — added Tenant → `/tenant` redirect test for `/maintenance-requests`.
+- `frontend/e2e/helpers/tenant.helper.ts` — added `loginAsLandlord` helper.
+- `frontend/e2e/fixtures/test-fixtures.ts` — registered the two new page-object fixtures.
+- `docs/project/sprint-status.yaml` — `20-7-landlord-maintenance-request-inbox: in-progress` → `review`.

--- a/frontend/e2e/fixtures/test-fixtures.ts
+++ b/frontend/e2e/fixtures/test-fixtures.ts
@@ -35,6 +35,8 @@ import { WorkOrderFormPage } from '../pages/work-order-form.page';
 import { WorkOrderDetailPage } from '../pages/work-order-detail.page';
 import { TenantDashboardPage } from '../pages/tenant-dashboard.page';
 import { SubmitRequestPage } from '../pages/submit-request.page';
+import { MaintenanceRequestsListPage } from '../pages/maintenance-requests-list.page';
+import { MaintenanceRequestDetailPage } from '../pages/maintenance-request-detail.page';
 import { AuthHelper, DEFAULT_TEST_USER } from '../helpers/auth.helper';
 import { MailHogHelper } from '../helpers/mailhog.helper';
 
@@ -78,6 +80,10 @@ type Fixtures = {
   tenantDashboardPage: TenantDashboardPage;
   /** Submit maintenance request page object (Story 21.4) */
   submitRequestPage: SubmitRequestPage;
+  /** Landlord maintenance request inbox list page object (Story 20.7) */
+  maintenanceRequestsListPage: MaintenanceRequestsListPage;
+  /** Landlord maintenance request detail page object (Story 20.7) */
+  maintenanceRequestDetailPage: MaintenanceRequestDetailPage;
   /** Authentication helper for login flows */
   authHelper: AuthHelper;
   /** MailHog helper for email verification (invitation flow) */
@@ -151,6 +157,14 @@ export const test = base.extend<Fixtures>({
 
   submitRequestPage: async ({ page }, use) => {
     await use(new SubmitRequestPage(page));
+  },
+
+  maintenanceRequestsListPage: async ({ page }, use) => {
+    await use(new MaintenanceRequestsListPage(page));
+  },
+
+  maintenanceRequestDetailPage: async ({ page }, use) => {
+    await use(new MaintenanceRequestDetailPage(page));
   },
 
   authHelper: async ({ page }, use) => {

--- a/frontend/e2e/helpers/tenant.helper.ts
+++ b/frontend/e2e/helpers/tenant.helper.ts
@@ -214,6 +214,26 @@ export async function loginAsTenant(page: Page, email: string, password: string)
 }
 
 /**
+ * Log in as a landlord (Owner role). Mirrors `AuthHelper.login` but accepts
+ * arbitrary credentials so a throwaway landlord created via the invitation
+ * flow can drive the UI. Waits for `/dashboard` since Owner is redirected
+ * there by `LoginComponent.getSafeReturnUrl()`.
+ *
+ * Used by the landlord-inbox E2E specs (Story 20.7).
+ */
+export async function loginAsLandlord(
+  page: Page,
+  email: string,
+  password: string,
+): Promise<void> {
+  await page.goto('/login');
+  await page.locator('input[formControlName="email"]').fill(email);
+  await page.locator('input[formControlName="password"]').fill(password);
+  await page.locator('button[type="submit"]').click();
+  await page.waitForURL('/dashboard', { timeout: 10000 });
+}
+
+/**
  * Submit a maintenance request via API as the supplied tenant. Used to seed
  * requests for AC-2 (cross-property isolation) without exercising the UI.
  *

--- a/frontend/e2e/pages/maintenance-request-detail.page.ts
+++ b/frontend/e2e/pages/maintenance-request-detail.page.ts
@@ -1,0 +1,50 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { BasePage } from './base.page';
+
+/**
+ * MaintenanceRequestDetailPage - Page object for the landlord detail view
+ * (Story 20.7).
+ *
+ * Covers `/maintenance-requests/:id`:
+ * - Status chip
+ * - Description
+ * - Dismissal reason (only present when status = Dismissed)
+ * - Linked work order badge (only present when workOrderId is set)
+ * - Photo grid (only present when photos array is non-empty)
+ */
+export class MaintenanceRequestDetailPage extends BasePage {
+  readonly root: Locator;
+  readonly statusChip: Locator;
+  readonly description: Locator;
+  readonly dismissalReason: Locator;
+  readonly linkedWorkOrder: Locator;
+  readonly photoGrid: Locator;
+  readonly backButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.root = page.locator('[data-testid="request-detail-page"]');
+    this.statusChip = page.locator('[data-testid="status-chip"]');
+    this.description = page.locator('[data-testid="request-description"]');
+    this.dismissalReason = page.locator('[data-testid="dismissal-reason"]');
+    this.linkedWorkOrder = page.locator('[data-testid="linked-work-order"]');
+    this.photoGrid = page.locator('[data-testid="photo-grid"]');
+    this.backButton = page.locator('[data-testid="back-button"]');
+  }
+
+  async goto(id?: string): Promise<void> {
+    if (!id) {
+      throw new Error('MaintenanceRequestDetailPage.goto requires a request id');
+    }
+    await this.page.goto(`/maintenance-requests/${id}`);
+    await this.waitForLoading();
+  }
+
+  async expectStatusBadge(label: string): Promise<void> {
+    await expect(this.statusChip).toHaveText(label);
+  }
+
+  async expectDescription(text: string): Promise<void> {
+    await expect(this.description).toContainText(text);
+  }
+}

--- a/frontend/e2e/pages/maintenance-requests-list.page.ts
+++ b/frontend/e2e/pages/maintenance-requests-list.page.ts
@@ -1,0 +1,104 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { BasePage } from './base.page';
+
+/**
+ * MaintenanceRequestsListPage - Page object for the landlord inbox (Story 20.7).
+ *
+ * Covers `/maintenance-requests`:
+ * - Status chip filter listbox
+ * - Property select filter
+ * - Aggregated request rows (status chip + description + property + submitter)
+ * - Empty / filtered-empty states
+ * - Paginator
+ */
+export class MaintenanceRequestsListPage extends BasePage {
+  readonly root: Locator;
+  readonly requestRows: Locator;
+  readonly statusFilter: Locator;
+  readonly propertyFilter: Locator;
+  readonly paginator: Locator;
+  readonly emptyState: Locator;
+  readonly filteredEmptyState: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.root = page.locator('[data-testid="maintenance-requests-page"]');
+    this.requestRows = page.locator('[data-testid="request-row"]');
+    this.statusFilter = page.locator('[data-testid="status-filter"]');
+    this.propertyFilter = page.locator('[data-testid="property-filter"]');
+    this.paginator = page.locator('[data-testid="paginator"]');
+    this.emptyState = page.locator('[data-testid="empty-state"]');
+    this.filteredEmptyState = page.locator('[data-testid="filtered-empty-state"]');
+  }
+
+  /**
+   * Override BasePage default — the inbox empty-state uses a `data-testid`
+   * wrapper instead of `.empty-state` (which is also used for the filtered
+   * empty state in the same template).
+   */
+  override get emptyStateLocator(): Locator {
+    return this.emptyState;
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/maintenance-requests');
+    await this.waitForLoading();
+  }
+
+  /**
+   * Locate a row by its description text (truncated descriptions are still matched).
+   */
+  getRowByDescription(description: string): Locator {
+    return this.requestRows.filter({ hasText: description });
+  }
+
+  async clickRow(description: string): Promise<void> {
+    await this.getRowByDescription(description).click();
+  }
+
+  async expectRowVisible(description: string): Promise<void> {
+    await expect(this.getRowByDescription(description)).toBeVisible();
+  }
+
+  async expectRowHidden(description: string): Promise<void> {
+    await expect(this.getRowByDescription(description)).toHaveCount(0);
+  }
+
+  async expectRowCount(n: number): Promise<void> {
+    await expect(this.requestRows).toHaveCount(n);
+  }
+
+  /**
+   * Click a status chip in the filter listbox.
+   * @param label The user-visible label: 'Submitted' | 'In Progress' | 'Resolved' | 'Dismissed'
+   */
+  async clickStatusChip(label: string): Promise<void> {
+    await this.statusFilter.locator('mat-chip-option', { hasText: label }).click();
+  }
+
+  /**
+   * Open the property filter and select an option by name.
+   */
+  async selectProperty(name: string): Promise<void> {
+    await this.propertyFilter.click();
+    await this.page.locator('mat-option', { hasText: name }).click();
+  }
+
+  async clickClearFilters(): Promise<void> {
+    await this.page.locator('[data-testid="clear-filters-btn"]').click();
+  }
+
+  async expectFilteredEmptyState(): Promise<void> {
+    await expect(this.filteredEmptyState).toBeVisible();
+  }
+
+  /**
+   * Assert a row's status chip text matches the supplied label.
+   * The chip is styled with `text-transform: uppercase`, so the underlying
+   * DOM text is mixed-case — use `toContainText` (case-sensitive substring).
+   */
+  async expectStatusBadge(description: string, label: string): Promise<void> {
+    const row = this.getRowByDescription(description);
+    await expect(row.locator('.status-chip')).toContainText(label);
+  }
+}

--- a/frontend/e2e/tests/maintenance-requests/landlord-inbox.spec.ts
+++ b/frontend/e2e/tests/maintenance-requests/landlord-inbox.spec.ts
@@ -1,0 +1,271 @@
+/**
+ * E2E Tests: Landlord Maintenance Request Inbox (Story 20.7)
+ *
+ * Verifies the landlord inbox flow end-to-end: aggregated request list,
+ * row → detail navigation, status/property filters, empty states, and
+ * the role-guard tenant redirect.
+ *
+ * Test isolation strategy: every spec that needs landlord login creates a
+ * throwaway landlord via `createLandlordViaInvitation` so the seeded
+ * `claude@claude.com` account is not polluted (matches the Tenant Dashboard
+ * E2E precedent in `tenant-dashboard.spec.ts`). The throwaway landlord is
+ * actually a co-Owner of the seeded account (see `tenant.helper.ts`), but
+ * data is uniquely-named per run so prior rows never satisfy current
+ * assertions.
+ *
+ * Status filter limitation: backend currently parses one status only. When
+ * fewer than all 4 statuses are selected, only `n === 1` results in a
+ * `status=` query param. Spec 3 verifies the API call carries the param.
+ */
+import { test, expect } from '../../fixtures/test-fixtures';
+import {
+  createLandlordViaInvitation,
+  createPropertyViaApi,
+  inviteTenantViaApi,
+  acceptTenantInvitation,
+  getAccessToken,
+  loginAsLandlord,
+  loginAsTenant,
+  submitMaintenanceRequestViaApi,
+} from '../../helpers/tenant.helper';
+
+test.describe('Landlord Maintenance Request Inbox E2E (Story 20.7)', () => {
+  // ─────────────────────────────────────────────────────────────────────────
+  // Spec 1 — Inbox shows aggregated requests across properties (AC #1, #2)
+  // ─────────────────────────────────────────────────────────────────────────
+  test('inbox shows aggregated requests across all properties', async ({
+    page,
+    mailhog,
+    maintenanceRequestsListPage,
+  }) => {
+    const landlord = await createLandlordViaInvitation(mailhog);
+    const propertyA = await createPropertyViaApi(landlord.token, {
+      name: `Inbox-PropA ${Date.now()}`,
+    });
+    const propertyB = await createPropertyViaApi(landlord.token, {
+      name: `Inbox-PropB ${Date.now()}`,
+    });
+
+    const tenantPassword = 'Throwaway@123456';
+    const tenantA = `e2e-mr-tenant-a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+    const tenantB = `e2e-mr-tenant-b-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+    await inviteTenantViaApi(landlord.token, propertyA, tenantA);
+    await inviteTenantViaApi(landlord.token, propertyB, tenantB);
+    await acceptTenantInvitation(page, mailhog, tenantA, tenantPassword);
+    await acceptTenantInvitation(page, mailhog, tenantB, tenantPassword);
+
+    const tokenA = await getAccessToken(tenantA, tenantPassword);
+    const tokenB = await getAccessToken(tenantB, tenantPassword);
+    const suffix = Date.now();
+    const descA = `Inbox-A request ${suffix}`;
+    const descB = `Inbox-B request ${suffix}`;
+    await submitMaintenanceRequestViaApi(tokenA, descA);
+    await submitMaintenanceRequestViaApi(tokenB, descB);
+
+    await loginAsLandlord(page, landlord.email, landlord.password);
+    await maintenanceRequestsListPage.goto();
+
+    // Both rows are visible — the inbox is account-aggregated, not per-property.
+    await maintenanceRequestsListPage.expectRowVisible(descA);
+    await maintenanceRequestsListPage.expectRowVisible(descB);
+
+    // Row meta: status chip + property + submitter (AC #2)
+    const rowA = maintenanceRequestsListPage.getRowByDescription(descA);
+    // Chip uses CSS `text-transform: uppercase`, so the rendered DOM text
+    // is mixed-case; assert via class + trimmed text.
+    const chip = rowA.locator('.status-chip');
+    await expect(chip).toHaveClass(/status-submitted/);
+    await expect(chip).toContainText('Submitted');
+    await expect(rowA.locator('.request-property')).toContainText(`Inbox-PropA`);
+    await expect(rowA.locator('.request-submitter')).toContainText(tenantA);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Spec 2 — Row click opens detail (AC #3)
+  // ─────────────────────────────────────────────────────────────────────────
+  test('clicking a row navigates to detail view with full description', async ({
+    page,
+    mailhog,
+    maintenanceRequestsListPage,
+    maintenanceRequestDetailPage,
+  }) => {
+    const landlord = await createLandlordViaInvitation(mailhog);
+    const propertyId = await createPropertyViaApi(landlord.token, {
+      name: `Inbox-Detail-Prop ${Date.now()}`,
+    });
+    const tenantPassword = 'Throwaway@123456';
+    const tenantEmail = `e2e-mr-detail-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+    await inviteTenantViaApi(landlord.token, propertyId, tenantEmail);
+    await acceptTenantInvitation(page, mailhog, tenantEmail, tenantPassword);
+    const tenantToken = await getAccessToken(tenantEmail, tenantPassword);
+    const description = `Inbox detail request ${Date.now()} — full text including punctuation, etc.`;
+    await submitMaintenanceRequestViaApi(tenantToken, description);
+
+    await loginAsLandlord(page, landlord.email, landlord.password);
+    await maintenanceRequestsListPage.goto();
+
+    await maintenanceRequestsListPage.clickRow(description);
+    await page.waitForURL(/\/maintenance-requests\/[a-f0-9-]+$/);
+
+    // Full detail rendered (AC #3): description + status chip + property + submitter.
+    await expect(maintenanceRequestDetailPage.root).toBeVisible();
+    await expect(maintenanceRequestDetailPage.statusChip).toHaveText('Submitted');
+    await maintenanceRequestDetailPage.expectDescription(description);
+    // No photos => grid hidden (AC #3 photos block — empty state means no grid)
+    await expect(maintenanceRequestDetailPage.photoGrid).toHaveCount(0);
+    // No work order linked => badge hidden (AC #3)
+    await expect(maintenanceRequestDetailPage.linkedWorkOrder).toHaveCount(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Spec 3 — Status filter calls the API with the right param (AC #6)
+  //
+  // Since 20.8/20.9 don't yet exist, we can't seed a request in the
+  // `InProgress` state via API. Per Task 9.3 fallback, intercept the GET
+  // and assert the query string contains `status=InProgress`.
+  // ─────────────────────────────────────────────────────────────────────────
+  test('selecting "In Progress" sends status=InProgress on the next API call', async ({
+    page,
+    mailhog,
+    maintenanceRequestsListPage,
+  }) => {
+    const landlord = await createLandlordViaInvitation(mailhog);
+    const propertyId = await createPropertyViaApi(landlord.token, {
+      name: `Inbox-Filter-Prop ${Date.now()}`,
+    });
+    const tenantPassword = 'Throwaway@123456';
+    const tenantEmail = `e2e-mr-filter-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+    await inviteTenantViaApi(landlord.token, propertyId, tenantEmail);
+    await acceptTenantInvitation(page, mailhog, tenantEmail, tenantPassword);
+    const tenantToken = await getAccessToken(tenantEmail, tenantPassword);
+    await submitMaintenanceRequestViaApi(tenantToken, `Filter test ${Date.now()}`);
+
+    await loginAsLandlord(page, landlord.email, landlord.password);
+    await maintenanceRequestsListPage.goto();
+
+    // Wait for the next inbox GET that carries `status=InProgress` after the
+    // chip click. The current chip-listbox starts with all four selected, so
+    // clicking In Progress will deselect it (n=3 → no status param). To get
+    // `n=1`, click each of the other three to deselect them, leaving only
+    // InProgress selected. We assert on the LAST request that has the
+    // status=InProgress param.
+    const statusInProgressRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes('/api/v1/maintenance-requests') &&
+        req.method() === 'GET' &&
+        req.url().includes('status=InProgress'),
+      { timeout: 10000 },
+    );
+
+    // Deselect Submitted, Resolved, Dismissed (leaves InProgress selected).
+    await maintenanceRequestsListPage.clickStatusChip('Submitted');
+    await maintenanceRequestsListPage.clickStatusChip('Resolved');
+    await maintenanceRequestsListPage.clickStatusChip('Dismissed');
+
+    const req = await statusInProgressRequest;
+    expect(req.url()).toContain('status=InProgress');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Spec 4 — Property filter narrows results (AC #7)
+  // ─────────────────────────────────────────────────────────────────────────
+  test('property filter narrows results to the selected property', async ({
+    page,
+    mailhog,
+    maintenanceRequestsListPage,
+  }) => {
+    const landlord = await createLandlordViaInvitation(mailhog);
+    const suffix = Date.now();
+    const propAName = `Inbox-PropA-${suffix}`;
+    const propBName = `Inbox-PropB-${suffix}`;
+    const propA = await createPropertyViaApi(landlord.token, { name: propAName });
+    const propB = await createPropertyViaApi(landlord.token, { name: propBName });
+
+    const tenantPassword = 'Throwaway@123456';
+    const tenantA = `e2e-mr-pf-a-${suffix}-${Math.random().toString(36).slice(2, 6)}@example.com`;
+    const tenantB = `e2e-mr-pf-b-${suffix}-${Math.random().toString(36).slice(2, 6)}@example.com`;
+    await inviteTenantViaApi(landlord.token, propA, tenantA);
+    await inviteTenantViaApi(landlord.token, propB, tenantB);
+    await acceptTenantInvitation(page, mailhog, tenantA, tenantPassword);
+    await acceptTenantInvitation(page, mailhog, tenantB, tenantPassword);
+    const tokenA = await getAccessToken(tenantA, tenantPassword);
+    const tokenB = await getAccessToken(tenantB, tenantPassword);
+    const descA = `PF-A request ${suffix}`;
+    const descB = `PF-B request ${suffix}`;
+    await submitMaintenanceRequestViaApi(tokenA, descA);
+    await submitMaintenanceRequestViaApi(tokenB, descB);
+
+    await loginAsLandlord(page, landlord.email, landlord.password);
+    await maintenanceRequestsListPage.goto();
+    await maintenanceRequestsListPage.expectRowVisible(descA);
+    await maintenanceRequestsListPage.expectRowVisible(descB);
+
+    await maintenanceRequestsListPage.selectProperty(propAName);
+    await maintenanceRequestsListPage.expectRowVisible(descA);
+    await maintenanceRequestsListPage.expectRowHidden(descB);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Spec 5 — Empty state when no requests exist (AC #9)
+  // ─────────────────────────────────────────────────────────────────────────
+  test('shows empty state when no requests exist on the account', async ({
+    page,
+    mailhog,
+    maintenanceRequestsListPage,
+  }) => {
+    const landlord = await createLandlordViaInvitation(mailhog);
+    // The seeded account already has data on it (since the throwaway landlord
+    // is a co-Owner — see `tenant.helper.ts`). To prove the empty-state
+    // renders end-to-end, intercept the inbox GET with an empty payload.
+    await page.route('**/api/v1/maintenance-requests*', async (route) => {
+      const req = route.request();
+      // Only stub the list endpoint, NOT detail (which has /:id suffix).
+      const url = req.url();
+      const path = new URL(url).pathname;
+      if (path === '/api/v1/maintenance-requests' && req.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            items: [],
+            totalCount: 0,
+            page: 1,
+            pageSize: 20,
+            totalPages: 0,
+          }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await loginAsLandlord(page, landlord.email, landlord.password);
+    await maintenanceRequestsListPage.goto();
+
+    await maintenanceRequestsListPage.expectEmptyState();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Spec 6 — Tenant cannot access the landlord inbox (AC #11)
+  // ─────────────────────────────────────────────────────────────────────────
+  test('tenant navigating to /maintenance-requests is redirected to /tenant', async ({
+    page,
+    mailhog,
+  }) => {
+    const landlord = await createLandlordViaInvitation(mailhog);
+    const propertyId = await createPropertyViaApi(landlord.token, {
+      name: `Inbox-Guard-Prop ${Date.now()}`,
+    });
+    const tenantPassword = 'Throwaway@123456';
+    const tenantEmail = `e2e-mr-guard-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+    await inviteTenantViaApi(landlord.token, propertyId, tenantEmail);
+    await acceptTenantInvitation(page, mailhog, tenantEmail, tenantPassword);
+
+    await loginAsTenant(page, tenantEmail, tenantPassword);
+
+    // Direct navigation — `ownerGuard` should redirect back to /tenant.
+    await page.goto('/maintenance-requests');
+    await page.waitForURL('/tenant', { timeout: 10000 });
+    expect(page.url()).toContain('/tenant');
+  });
+});

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -250,6 +250,24 @@ export const routes: Routes = [
         canActivate: [ownerGuard],
         canDeactivate: [unsavedChangesGuard],
       },
+      // Maintenance Requests Inbox (Story 20.7, AC #1, #11)
+      {
+        path: 'maintenance-requests',
+        loadComponent: () =>
+          import('./features/maintenance-requests/maintenance-requests.component').then(
+            (m) => m.MaintenanceRequestsComponent,
+          ),
+        canActivate: [ownerGuard],
+      },
+      // Maintenance Request Detail (Story 20.7, AC #3)
+      {
+        path: 'maintenance-requests/:id',
+        loadComponent: () =>
+          import(
+            './features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component'
+          ).then((m) => m.MaintenanceRequestDetailComponent),
+        canActivate: [ownerGuard],
+      },
       // Tenant Dashboard (Story 20.5, AC #1, #2, #3)
       {
         path: 'tenant',

--- a/frontend/src/app/core/auth/owner.guard.spec.ts
+++ b/frontend/src/app/core/auth/owner.guard.spec.ts
@@ -69,6 +69,19 @@ describe('ownerGuard', () => {
     });
   });
 
+  // Story 20.7, AC #11: Tenant accessing /maintenance-requests redirects to /tenant
+  it('should redirect Tenant accessing /maintenance-requests to /tenant', () => {
+    currentUserSignal.set(createUser('Tenant'));
+    const mockUrlTree = {} as UrlTree;
+    vi.mocked(mockRouter.createUrlTree!).mockReturnValue(mockUrlTree);
+
+    TestBed.runInInjectionContext(() => {
+      const result = ownerGuard(null as any, { url: '/maintenance-requests' } as any);
+      expect(result).toBe(mockUrlTree);
+      expect(mockRouter.createUrlTree).toHaveBeenCalledWith(['/tenant']);
+    });
+  });
+
   it('should redirect null user to /dashboard', () => {
     currentUserSignal.set(null);
     const mockUrlTree = {} as UrlTree;

--- a/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.spec.ts
+++ b/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.spec.ts
@@ -81,8 +81,8 @@ describe('SidebarNavComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    it('should have 9 navigation items for Owner', () => {
-      expect(component.navItems().length).toBe(9);
+    it('should have 10 navigation items for Owner', () => {
+      expect(component.navItems().length).toBe(10);
     });
 
     it('should have correct navigation items in order for Owner', () => {
@@ -94,11 +94,24 @@ describe('SidebarNavComponent', () => {
         'Receipts',
         'Vendors',
         'Work Orders',
+        'Maintenance Requests',
         'Reports',
         'Settings',
       ];
       const actualLabels = component.navItems().map((item) => item.label);
       expect(actualLabels).toEqual(expectedLabels);
+    });
+
+    // Story 20.7, AC #10: "Maintenance Requests" appears between Work Orders and Reports
+    it('should include Maintenance Requests with inbox icon between Work Orders and Reports', () => {
+      const items = component.navItems();
+      const woIdx = items.findIndex((i) => i.label === 'Work Orders');
+      const mrIdx = items.findIndex((i) => i.label === 'Maintenance Requests');
+      const rIdx = items.findIndex((i) => i.label === 'Reports');
+      expect(mrIdx).toBe(woIdx + 1);
+      expect(rIdx).toBe(mrIdx + 1);
+      expect(items[mrIdx].route).toBe('/maintenance-requests');
+      expect(items[mrIdx].icon).toBe('inbox');
     });
 
     it('should have Dashboard as first item', () => {
@@ -135,9 +148,9 @@ describe('SidebarNavComponent', () => {
       expect(mockLogoutAndRedirect).toHaveBeenCalledWith(component.isLoggingOut);
     });
 
-    it('should render all 9 nav items in the DOM', () => {
+    it('should render all 10 nav items in the DOM', () => {
       const navItems = fixture.debugElement.queryAll(By.css('.nav-item'));
-      expect(navItems.length).toBe(9);
+      expect(navItems.length).toBe(10);
     });
   });
 
@@ -168,6 +181,12 @@ describe('SidebarNavComponent', () => {
     it('should NOT show Settings for Contributor', () => {
       const labels = component.navItems().map((item) => item.label);
       expect(labels).not.toContain('Settings');
+    });
+
+    // Story 20.7, AC #10: Contributor must NOT see Maintenance Requests
+    it('should NOT show Maintenance Requests for Contributor', () => {
+      const labels = component.navItems().map((item) => item.label);
+      expect(labels).not.toContain('Maintenance Requests');
     });
 
     it('should render 3 nav items in the DOM', () => {
@@ -205,6 +224,12 @@ describe('SidebarNavComponent', () => {
     it('should render 2 nav items in the DOM', () => {
       const navItems = fixture.debugElement.queryAll(By.css('.nav-item'));
       expect(navItems.length).toBe(2);
+    });
+
+    // Story 20.7, AC #10/#11: Tenant must NOT see Maintenance Requests landlord inbox
+    it('should NOT show Maintenance Requests for Tenant', () => {
+      const labels = component.navItems().map((item) => item.label);
+      expect(labels).not.toContain('Maintenance Requests');
     });
   });
 

--- a/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts
+++ b/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts
@@ -67,6 +67,7 @@ export class SidebarNavComponent implements OnInit {
       { label: 'Receipts', route: '/receipts', icon: 'document_scanner' },
       { label: 'Vendors', route: '/vendors', icon: 'business' },
       { label: 'Work Orders', route: '/work-orders', icon: 'assignment' },
+      { label: 'Maintenance Requests', route: '/maintenance-requests', icon: 'inbox' },
       { label: 'Reports', route: '/reports', icon: 'assessment' },
       { label: 'Settings', route: '/settings', icon: 'settings' },
     ];

--- a/frontend/src/app/features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component.spec.ts
+++ b/frontend/src/app/features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component.spec.ts
@@ -1,0 +1,189 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { MaintenanceRequestDetailComponent } from './maintenance-request-detail.component';
+import { MaintenanceRequestStore } from '../../stores/maintenance-request.store';
+import {
+  MaintenanceRequestDto,
+  MaintenanceRequestPhotoDto,
+} from '../../services/maintenance-request.service';
+
+describe('MaintenanceRequestDetailComponent', () => {
+  let fixture: ComponentFixture<MaintenanceRequestDetailComponent>;
+  let component: MaintenanceRequestDetailComponent;
+  let storeMock: any;
+
+  const mockPhoto: MaintenanceRequestPhotoDto = {
+    id: 'photo-1',
+    thumbnailUrl: 'https://example.com/thumb.jpg',
+    viewUrl: 'https://example.com/view.jpg',
+    isPrimary: true,
+    displayOrder: 1,
+    originalFileName: 'kitchen.jpg',
+    fileSizeBytes: 12345,
+    createdAt: '2026-05-01T10:00:00Z',
+  };
+
+  const mockRequest: MaintenanceRequestDto = {
+    id: 'req-1',
+    propertyId: 'prop-1',
+    propertyName: 'Test Property',
+    propertyAddress: '123 Test St, Austin, TX',
+    description: 'Leaky faucet in the kitchen',
+    status: 'Submitted',
+    dismissalReason: null,
+    submittedByUserId: 'user-1',
+    submittedByUserName: 'Jane Tenant',
+    workOrderId: null,
+    createdAt: '2026-05-01T10:00:00Z',
+    updatedAt: '2026-05-01T10:00:00Z',
+    photos: null,
+  };
+
+  function setupTest(initial?: { request?: MaintenanceRequestDto | null; detailError?: string | null; isLoading?: boolean }) {
+    storeMock = {
+      selectedRequest: signal<MaintenanceRequestDto | null>(initial?.request ?? mockRequest),
+      isLoadingDetail: signal(initial?.isLoading ?? false),
+      detailError: signal<string | null>(initial?.detailError ?? null),
+      loadRequestById: vi.fn(),
+      clearSelectedRequest: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [MaintenanceRequestDetailComponent, NoopAnimationsModule],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: MaintenanceRequestStore, useValue: storeMock },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: { get: (key: string) => (key === 'id' ? 'req-1' : null) },
+            },
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(MaintenanceRequestDetailComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('calls store.loadRequestById from the route param', () => {
+    setupTest();
+    fixture.detectChanges();
+    expect(storeMock.loadRequestById).toHaveBeenCalledWith('req-1');
+  });
+
+  it('shows loading spinner while loading', () => {
+    setupTest({ isLoading: true, request: null });
+    fixture.detectChanges();
+    const spinner = fixture.debugElement.query(By.css('app-loading-spinner'));
+    expect(spinner).toBeTruthy();
+  });
+
+  it('shows error card when detailError set', () => {
+    setupTest({ detailError: 'Maintenance request not found', request: null });
+    fixture.detectChanges();
+    const error = fixture.debugElement.query(By.css('app-error-card'));
+    expect(error).toBeTruthy();
+  });
+
+  it('renders status chip with correct class for Submitted', () => {
+    setupTest();
+    fixture.detectChanges();
+    const chip = fixture.debugElement.query(By.css('[data-testid="status-chip"]'));
+    expect(chip).toBeTruthy();
+    expect(chip.nativeElement.classList).toContain('status-submitted');
+  });
+
+  it('renders status chip with status-in-progress class for InProgress', () => {
+    setupTest({ request: { ...mockRequest, status: 'InProgress' } });
+    fixture.detectChanges();
+    const chip = fixture.debugElement.query(By.css('[data-testid="status-chip"]'));
+    expect(chip.nativeElement.classList).toContain('status-in-progress');
+    expect(chip.nativeElement.textContent).toContain('In Progress');
+  });
+
+  it('shows dismissal reason ONLY when status is Dismissed', () => {
+    setupTest({
+      request: {
+        ...mockRequest,
+        status: 'Dismissed',
+        dismissalReason: 'Tenant withdrew the request',
+      },
+    });
+    fixture.detectChanges();
+    const dismissal = fixture.debugElement.query(By.css('[data-testid="dismissal-reason"]'));
+    expect(dismissal).toBeTruthy();
+    expect(dismissal.nativeElement.textContent).toContain('Tenant withdrew the request');
+  });
+
+  it('hides dismissal reason when status is not Dismissed', () => {
+    setupTest({ request: { ...mockRequest, status: 'Submitted', dismissalReason: 'ignored' } });
+    fixture.detectChanges();
+    const dismissal = fixture.debugElement.query(By.css('[data-testid="dismissal-reason"]'));
+    expect(dismissal).toBeFalsy();
+  });
+
+  it('shows linked work order badge ONLY when workOrderId is non-null', () => {
+    setupTest({ request: { ...mockRequest, workOrderId: 'wo-1' } });
+    fixture.detectChanges();
+    const linked = fixture.debugElement.query(By.css('[data-testid="linked-work-order"]'));
+    expect(linked).toBeTruthy();
+    expect(linked.nativeElement.textContent).toContain('View linked work order');
+  });
+
+  it('hides linked work order badge when workOrderId is null', () => {
+    setupTest();
+    fixture.detectChanges();
+    const linked = fixture.debugElement.query(By.css('[data-testid="linked-work-order"]'));
+    expect(linked).toBeFalsy();
+  });
+
+  it('renders photos grid when photos array is non-empty', () => {
+    setupTest({ request: { ...mockRequest, photos: [mockPhoto] } });
+    fixture.detectChanges();
+    const grid = fixture.debugElement.query(By.css('[data-testid="photo-grid"]'));
+    expect(grid).toBeTruthy();
+    const imgs = fixture.debugElement.queryAll(By.css('[data-testid="photo-grid"] img'));
+    expect(imgs.length).toBe(1);
+    expect(imgs[0].nativeElement.getAttribute('src')).toBe('https://example.com/thumb.jpg');
+  });
+
+  it('hides photos grid when photos is null', () => {
+    setupTest();
+    fixture.detectChanges();
+    const grid = fixture.debugElement.query(By.css('[data-testid="photo-grid"]'));
+    expect(grid).toBeFalsy();
+  });
+
+  it('renders the back button linking to /maintenance-requests', () => {
+    setupTest();
+    fixture.detectChanges();
+    const back = fixture.debugElement.query(By.css('[data-testid="back-button"]'));
+    expect(back).toBeTruthy();
+  });
+
+  it('renders submitter name with fallback to "Unknown"', () => {
+    setupTest({ request: { ...mockRequest, submittedByUserName: null } });
+    fixture.detectChanges();
+    const submitter = fixture.debugElement.query(By.css('.submitter-name'));
+    expect(submitter.nativeElement.textContent).toContain('Unknown');
+  });
+
+  it('clearSelectedRequest is called on destroy', () => {
+    setupTest();
+    fixture.detectChanges();
+    fixture.destroy();
+    expect(storeMock.clearSelectedRequest).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component.ts
+++ b/frontend/src/app/features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component.ts
@@ -1,0 +1,337 @@
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { LoadingSpinnerComponent } from '../../../../shared/components/loading-spinner/loading-spinner.component';
+import { ErrorCardComponent } from '../../../../shared/components/error-card/error-card.component';
+import { MaintenanceRequestStore } from '../../stores/maintenance-request.store';
+
+/**
+ * MaintenanceRequestDetailComponent (Story 20.7, AC #3, #5, #12).
+ *
+ * Read-only detail view for a single maintenance request from the landlord
+ * inbox. Convert/dismiss actions live in 20.8/20.9 and are intentionally
+ * out of scope here.
+ */
+@Component({
+  selector: 'app-maintenance-request-detail',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    DatePipe,
+    MatCardModule,
+    MatIconModule,
+    MatButtonModule,
+    LoadingSpinnerComponent,
+    ErrorCardComponent,
+  ],
+  template: `
+    <div class="request-detail-page" data-testid="request-detail-page">
+      <button mat-button routerLink="/maintenance-requests" class="back-button" data-testid="back-button">
+        <mat-icon>arrow_back</mat-icon>
+        Back to Inbox
+      </button>
+
+      @if (store.isLoadingDetail()) {
+        <app-loading-spinner />
+      } @else if (store.detailError()) {
+        <app-error-card
+          [message]="store.detailError()!"
+          [showRetry]="true"
+          (retry)="retry()"
+        />
+      } @else if (store.selectedRequest(); as req) {
+        <mat-card class="detail-card">
+          <mat-card-content>
+            <!-- Header: status chip + submission date -->
+            <div class="detail-header">
+              <span
+                class="status-chip"
+                data-testid="status-chip"
+                [class.status-submitted]="req.status === 'Submitted'"
+                [class.status-in-progress]="req.status === 'InProgress'"
+                [class.status-resolved]="req.status === 'Resolved'"
+                [class.status-dismissed]="req.status === 'Dismissed'"
+              >
+                {{ getStatusLabel(req.status) }}
+              </span>
+              <span class="submission-date">
+                Submitted {{ req.createdAt | date: 'medium' }}
+              </span>
+            </div>
+
+            <!-- Property block -->
+            <section class="detail-section property-block">
+              <h3>
+                <mat-icon class="section-icon">home</mat-icon>
+                Property
+              </h3>
+              <p class="property-name">{{ req.propertyName }}</p>
+              <p class="property-address">{{ req.propertyAddress }}</p>
+            </section>
+
+            <!-- Submitter block -->
+            <section class="detail-section submitter-block">
+              <h3>
+                <mat-icon class="section-icon">person</mat-icon>
+                Submitted by
+              </h3>
+              <p class="submitter-name">{{ req.submittedByUserName || 'Unknown' }}</p>
+              <small class="submitter-id">{{ req.submittedByUserId }}</small>
+            </section>
+
+            <!-- Description -->
+            <section class="detail-section description-block" data-testid="request-description">
+              <h3>Description</h3>
+              <p class="description-text">{{ req.description }}</p>
+            </section>
+
+            <!-- Dismissal reason (only when Dismissed) -->
+            @if (req.status === 'Dismissed' && req.dismissalReason) {
+              <section
+                class="detail-section dismissal-block"
+                data-testid="dismissal-reason"
+              >
+                <h3>
+                  <mat-icon class="section-icon">info</mat-icon>
+                  Dismissal Reason
+                </h3>
+                <p class="dismissal-text">{{ req.dismissalReason }}</p>
+              </section>
+            }
+
+            <!-- Linked work order badge -->
+            @if (req.workOrderId) {
+              <section class="detail-section linked-wo-block">
+                <a
+                  mat-stroked-button
+                  color="primary"
+                  [routerLink]="['/work-orders', req.workOrderId]"
+                  class="linked-wo-link"
+                  data-testid="linked-work-order"
+                >
+                  <mat-icon>link</mat-icon>
+                  View linked work order
+                </a>
+              </section>
+            }
+
+            <!-- Photos grid -->
+            @if (req.photos && req.photos.length > 0) {
+              <section class="detail-section photos-block">
+                <h3>Photos</h3>
+                <div class="photo-grid" data-testid="photo-grid">
+                  @for (photo of req.photos; track photo.id) {
+                    <a
+                      class="photo-thumbnail"
+                      [href]="photo.viewUrl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <img
+                        [src]="photo.thumbnailUrl || photo.viewUrl"
+                        [alt]="photo.originalFileName"
+                        loading="lazy"
+                      />
+                    </a>
+                  }
+                </div>
+              </section>
+            }
+
+            <!-- Updated timestamp -->
+            <footer class="detail-footer">
+              <small>Last updated {{ req.updatedAt | date: 'medium' }}</small>
+            </footer>
+          </mat-card-content>
+        </mat-card>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .request-detail-page {
+        padding: 24px 16px;
+        max-width: 800px;
+        margin: 0 auto;
+      }
+
+      .back-button {
+        margin-bottom: 16px;
+      }
+
+      .back-button mat-icon {
+        margin-right: 4px;
+      }
+
+      .detail-card {
+        margin-bottom: 24px;
+      }
+
+      .detail-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 24px;
+      }
+
+      .submission-date {
+        color: var(--mat-sys-on-surface-variant);
+        font-size: 0.875rem;
+      }
+
+      .detail-section {
+        margin-bottom: 20px;
+      }
+
+      .detail-section h3 {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin: 0 0 8px 0;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--mat-sys-on-surface-variant);
+      }
+
+      .section-icon {
+        font-size: 18px;
+        height: 18px;
+        width: 18px;
+      }
+
+      .property-name,
+      .submitter-name {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 500;
+      }
+
+      .property-address,
+      .submitter-id {
+        margin: 4px 0 0 0;
+        color: var(--mat-sys-on-surface-variant);
+        font-size: 0.875rem;
+      }
+
+      .description-text {
+        margin: 0;
+        white-space: pre-wrap;
+        line-height: 1.5;
+      }
+
+      .dismissal-text {
+        margin: 0;
+        white-space: pre-wrap;
+        padding: 12px;
+        background-color: var(--mat-sys-error-container, #fff3e0);
+        color: var(--mat-sys-on-error-container, #e65100);
+        border-radius: 4px;
+        line-height: 1.4;
+      }
+
+      .photo-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+        gap: 12px;
+      }
+
+      .photo-thumbnail {
+        display: block;
+        aspect-ratio: 1 / 1;
+        border-radius: 8px;
+        overflow: hidden;
+        background-color: var(--mat-sys-surface-container);
+      }
+
+      .photo-thumbnail img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .detail-footer {
+        margin-top: 16px;
+        text-align: right;
+        color: var(--mat-sys-on-surface-variant);
+      }
+
+      /* Status chip — match landlord inbox + tenant dashboard. */
+      .status-chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 12px;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+
+      .status-submitted {
+        background-color: var(--mat-sys-warning-container, #fef3c7);
+        color: var(--mat-sys-on-warning-container, #92400e);
+      }
+
+      .status-in-progress {
+        background-color: var(--mat-sys-primary-container, #dbeafe);
+        color: var(--mat-sys-on-primary-container, #1e40af);
+      }
+
+      .status-resolved {
+        background-color: var(--mat-sys-tertiary-container, #d1fae5);
+        color: var(--mat-sys-on-tertiary-container, #065f46);
+      }
+
+      .status-dismissed {
+        background-color: var(--mat-sys-error-container, #ffe0b2);
+        color: var(--mat-sys-on-error-container, #e65100);
+      }
+
+      @media (max-width: 768px) {
+        .request-detail-page {
+          padding: 16px 12px;
+        }
+
+        .detail-header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+      }
+    `,
+  ],
+})
+export class MaintenanceRequestDetailComponent implements OnInit, OnDestroy {
+  protected readonly store = inject(MaintenanceRequestStore);
+  private readonly route = inject(ActivatedRoute);
+
+  private requestId = '';
+
+  ngOnInit(): void {
+    this.requestId = this.route.snapshot.paramMap.get('id') ?? '';
+    if (this.requestId) {
+      this.store.loadRequestById(this.requestId);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.store.clearSelectedRequest();
+  }
+
+  retry(): void {
+    if (this.requestId) {
+      this.store.loadRequestById(this.requestId);
+    }
+  }
+
+  getStatusLabel(status: string): string {
+    return status === 'InProgress' ? 'In Progress' : status;
+  }
+}

--- a/frontend/src/app/features/maintenance-requests/maintenance-requests.component.spec.ts
+++ b/frontend/src/app/features/maintenance-requests/maintenance-requests.component.spec.ts
@@ -1,0 +1,213 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { signal } from '@angular/core';
+import { provideRouter, Router } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+import { MaintenanceRequestsComponent } from './maintenance-requests.component';
+import { MaintenanceRequestStore } from './stores/maintenance-request.store';
+import { PropertyStore } from '../properties/stores/property.store';
+import { MaintenanceRequestDto } from './services/maintenance-request.service';
+import { PropertySummaryDto } from '../properties/services/property.service';
+
+describe('MaintenanceRequestsComponent', () => {
+  let fixture: ComponentFixture<MaintenanceRequestsComponent>;
+  let component: MaintenanceRequestsComponent;
+  let storeMock: any;
+  let propertyStoreMock: any;
+  let routerMock: { navigate: ReturnType<typeof vi.fn> };
+
+  const mockRequest: MaintenanceRequestDto = {
+    id: 'req-1',
+    propertyId: 'prop-1',
+    propertyName: 'Test Property',
+    propertyAddress: '123 Test St, Austin, TX',
+    description: 'Leaky faucet in the kitchen',
+    status: 'Submitted',
+    dismissalReason: null,
+    submittedByUserId: 'user-1',
+    submittedByUserName: 'Jane Tenant',
+    workOrderId: null,
+    createdAt: '2026-05-01T10:00:00Z',
+    updatedAt: '2026-05-01T10:00:00Z',
+    photos: null,
+  };
+
+  const mockProperty: PropertySummaryDto = {
+    id: 'prop-1',
+    name: 'Test Property',
+    street: '123 Test St',
+    city: 'Austin',
+    state: 'TX',
+    zipCode: '78701',
+    expenseTotal: 0,
+    incomeTotal: 0,
+    primaryPhotoThumbnailUrl: null,
+  };
+
+  beforeEach(() => {
+    storeMock = {
+      requests: signal([mockRequest]),
+      selectedRequest: signal(null),
+      isLoading: signal(false),
+      isLoadingDetail: signal(false),
+      error: signal<string | null>(null),
+      detailError: signal<string | null>(null),
+      selectedStatuses: signal<string[]>(['Submitted', 'InProgress', 'Resolved', 'Dismissed']),
+      selectedPropertyId: signal<string | null>(null),
+      page: signal(1),
+      pageSize: signal(20),
+      totalCount: signal(1),
+      totalPages: signal(1),
+      isEmpty: signal(false),
+      isFilteredEmpty: signal(false),
+      hasActiveFilters: signal(false),
+      loadRequests: vi.fn(),
+      loadRequestById: vi.fn(),
+      setStatusFilter: vi.fn(),
+      setPropertyFilter: vi.fn(),
+      clearFilters: vi.fn(),
+      setPage: vi.fn(),
+      clearSelectedRequest: vi.fn(),
+    };
+
+    propertyStoreMock = {
+      properties: signal([mockProperty]),
+      loadProperties: vi.fn(),
+    };
+
+    routerMock = {
+      navigate: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [MaintenanceRequestsComponent, NoopAnimationsModule],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: MaintenanceRequestStore, useValue: storeMock },
+        { provide: PropertyStore, useValue: propertyStoreMock },
+        { provide: Router, useValue: routerMock },
+      ],
+    });
+
+    fixture = TestBed.createComponent(MaintenanceRequestsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the page header', () => {
+    fixture.detectChanges();
+    const header = fixture.debugElement.query(By.css('h1'));
+    expect(header.nativeElement.textContent).toContain('Maintenance Requests');
+  });
+
+  it('calls store.loadRequests and propertyStore.loadProperties on init', () => {
+    fixture.detectChanges();
+    expect(storeMock.loadRequests).toHaveBeenCalled();
+    expect(propertyStoreMock.loadProperties).toHaveBeenCalledWith(undefined);
+  });
+
+  it('renders rows when requests is non-empty', () => {
+    fixture.detectChanges();
+    const rows = fixture.debugElement.queryAll(By.css('[data-testid="request-row"]'));
+    expect(rows.length).toBe(1);
+    expect(rows[0].nativeElement.textContent).toContain('Leaky faucet');
+    expect(rows[0].nativeElement.textContent).toContain('Test Property');
+    expect(rows[0].nativeElement.textContent).toContain('Jane Tenant');
+  });
+
+  it('shows loading spinner when isLoading is true', () => {
+    storeMock.isLoading.set(true);
+    fixture.detectChanges();
+    const spinner = fixture.debugElement.query(By.css('app-loading-spinner'));
+    expect(spinner).toBeTruthy();
+  });
+
+  it('shows error card when error is set', () => {
+    storeMock.error.set('Failed to load');
+    fixture.detectChanges();
+    const errorCard = fixture.debugElement.query(By.css('app-error-card'));
+    expect(errorCard).toBeTruthy();
+  });
+
+  it('shows empty state when isEmpty is true', () => {
+    storeMock.requests.set([]);
+    storeMock.isEmpty.set(true);
+    storeMock.totalCount.set(0);
+    fixture.detectChanges();
+    const empty = fixture.debugElement.query(By.css('[data-testid="empty-state"]'));
+    expect(empty).toBeTruthy();
+  });
+
+  it('shows filtered empty state when isFilteredEmpty is true', () => {
+    storeMock.requests.set([]);
+    storeMock.isFilteredEmpty.set(true);
+    storeMock.hasActiveFilters.set(true);
+    fixture.detectChanges();
+    const empty = fixture.debugElement.query(By.css('[data-testid="filtered-empty-state"]'));
+    expect(empty).toBeTruthy();
+  });
+
+  it('clicking a row navigates to /maintenance-requests/:id', () => {
+    fixture.detectChanges();
+    const row = fixture.debugElement.query(By.css('[data-testid="request-row"]'));
+    row.nativeElement.click();
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/maintenance-requests', 'req-1']);
+  });
+
+  it('onStatusFilterChange forwards selected values to the store', () => {
+    fixture.detectChanges();
+    component.onStatusFilterChange({ value: ['Submitted'] } as any);
+    expect(storeMock.setStatusFilter).toHaveBeenCalledWith(['Submitted']);
+  });
+
+  it('onPropertyFilterChange forwards property id to the store', () => {
+    fixture.detectChanges();
+    component.onPropertyFilterChange('prop-1');
+    expect(storeMock.setPropertyFilter).toHaveBeenCalledWith('prop-1');
+  });
+
+  it('onPageChange converts pageIndex to 1-based page and forwards', () => {
+    fixture.detectChanges();
+    component.onPageChange({ pageIndex: 2, pageSize: 50 } as any);
+    expect(storeMock.setPage).toHaveBeenCalledWith(3, 50);
+  });
+
+  it('clearFilters delegates to store.clearFilters', () => {
+    fixture.detectChanges();
+    component.clearFilters();
+    expect(storeMock.clearFilters).toHaveBeenCalled();
+  });
+
+  it('getStatusLabel returns "In Progress" for "InProgress"', () => {
+    expect(component.getStatusLabel('InProgress')).toBe('In Progress');
+    expect(component.getStatusLabel('Submitted')).toBe('Submitted');
+  });
+
+  it('truncateDescription truncates strings longer than maxLength', () => {
+    expect(component.truncateDescription('a'.repeat(150))).toBe('a'.repeat(100) + '...');
+    expect(component.truncateDescription('short')).toBe('short');
+  });
+
+  it('shows linked badge when workOrderId is present', () => {
+    storeMock.requests.set([{ ...mockRequest, workOrderId: 'wo-1' }]);
+    fixture.detectChanges();
+    const linked = fixture.debugElement.query(By.css('.request-linked'));
+    expect(linked).toBeTruthy();
+    expect(linked.nativeElement.textContent).toContain('Linked');
+  });
+
+  it('hides linked badge when workOrderId is null', () => {
+    fixture.detectChanges();
+    const linked = fixture.debugElement.query(By.css('.request-linked'));
+    expect(linked).toBeFalsy();
+  });
+});

--- a/frontend/src/app/features/maintenance-requests/maintenance-requests.component.ts
+++ b/frontend/src/app/features/maintenance-requests/maintenance-requests.component.ts
@@ -1,0 +1,471 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatChipsModule, MatChipListboxChange } from '@angular/material/chips';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatCardModule } from '@angular/material/card';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
+import { ErrorCardComponent } from '../../shared/components/error-card/error-card.component';
+import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
+import { MaintenanceRequestStore } from './stores/maintenance-request.store';
+import { PropertyStore } from '../properties/stores/property.store';
+
+/**
+ * MaintenanceRequestsComponent (Story 20.7).
+ *
+ * Landlord maintenance request inbox. Shows all requests across the account's
+ * properties with status + property filtering and pagination. Frontend-only
+ * story — all backend APIs already exist (Stories 20.3 + 20.4).
+ *
+ * Filter limitation: backend only accepts a single status. When the user
+ * selects 2 or 3 statuses, no `status` param is sent (returns the unfiltered
+ * set). See store's `encodeStatusParam` for details.
+ */
+@Component({
+  selector: 'app-maintenance-requests',
+  standalone: true,
+  imports: [
+    CommonModule,
+    DatePipe,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatChipsModule,
+    MatSelectModule,
+    MatFormFieldModule,
+    MatCardModule,
+    MatPaginatorModule,
+    LoadingSpinnerComponent,
+    ErrorCardComponent,
+    EmptyStateComponent,
+  ],
+  template: `
+    <div class="maintenance-requests-page" data-testid="maintenance-requests-page">
+      <div class="page-header">
+        <h1>Maintenance Requests</h1>
+      </div>
+
+      <!-- Filter Section (AC #6, #7) -->
+      <div class="filter-section">
+        <div class="filter-group">
+          <label class="filter-label">Status</label>
+          <mat-chip-listbox
+            multiple
+            [value]="store.selectedStatuses()"
+            (change)="onStatusFilterChange($event)"
+            class="status-chips"
+            data-testid="status-filter"
+          >
+            <mat-chip-option value="Submitted">Submitted</mat-chip-option>
+            <mat-chip-option value="InProgress">In Progress</mat-chip-option>
+            <mat-chip-option value="Resolved">Resolved</mat-chip-option>
+            <mat-chip-option value="Dismissed">Dismissed</mat-chip-option>
+          </mat-chip-listbox>
+        </div>
+
+        <div class="filter-group">
+          <mat-form-field appearance="outline" class="property-filter">
+            <mat-label>Property</mat-label>
+            <mat-select
+              [value]="store.selectedPropertyId()"
+              (selectionChange)="onPropertyFilterChange($event.value)"
+              data-testid="property-filter"
+            >
+              <mat-option [value]="null">All Properties</mat-option>
+              @for (property of propertyStore.properties(); track property.id) {
+                <mat-option [value]="property.id">{{ property.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        </div>
+
+        @if (store.hasActiveFilters()) {
+          <button
+            mat-button
+            color="primary"
+            (click)="clearFilters()"
+            class="clear-filters-btn"
+            data-testid="clear-filters-btn"
+          >
+            <mat-icon>clear</mat-icon>
+            Clear filters
+          </button>
+        }
+      </div>
+
+      @if (store.isLoading()) {
+        <app-loading-spinner />
+      } @else if (store.error()) {
+        <app-error-card
+          [message]="store.error()!"
+          [showRetry]="true"
+          (retry)="retry()"
+        />
+      } @else if (store.isFilteredEmpty()) {
+        <mat-card class="empty-state filtered-empty" data-testid="filtered-empty-state">
+          <mat-card-content>
+            <mat-icon class="empty-icon">filter_list_off</mat-icon>
+            <h2>No requests match your filters</h2>
+            <p>Try adjusting your filters or clear them to see all maintenance requests.</p>
+            <button mat-raised-button color="primary" (click)="clearFilters()">
+              <mat-icon>clear</mat-icon>
+              Clear filters
+            </button>
+          </mat-card-content>
+        </mat-card>
+      } @else if (store.isEmpty()) {
+        <div data-testid="empty-state">
+          <app-empty-state
+            icon="inbox"
+            title="No maintenance requests yet"
+            message="When tenants submit maintenance requests for your properties, they will appear here."
+          />
+        </div>
+      } @else {
+        <div class="request-list">
+          @for (request of store.requests(); track request.id) {
+            <div
+              class="request-row"
+              data-testid="request-row"
+              [attr.data-testid-id]="'request-row-' + request.id"
+              (click)="openRequest(request.id)"
+              (keydown.enter)="openRequest(request.id)"
+              tabindex="0"
+              role="button"
+            >
+              <div class="row-content">
+                <!-- Line 1: status chip + description (truncated, flex 1) + date -->
+                <div class="line-1">
+                  <span
+                    class="status-chip"
+                    [class.status-submitted]="request.status === 'Submitted'"
+                    [class.status-in-progress]="request.status === 'InProgress'"
+                    [class.status-resolved]="request.status === 'Resolved'"
+                    [class.status-dismissed]="request.status === 'Dismissed'"
+                  >
+                    {{ getStatusLabel(request.status) }}
+                  </span>
+                  <span class="request-description">{{
+                    truncateDescription(request.description)
+                  }}</span>
+                  <span class="request-date">{{ request.createdAt | date: 'MMM d' }}</span>
+                </div>
+
+                <!-- Line 2: property + submitter + work order link badge -->
+                <div class="line-2">
+                  <span class="request-property">
+                    <mat-icon class="inline-icon">home</mat-icon>
+                    {{ request.propertyName }}
+                  </span>
+                  <span class="request-submitter">
+                    <mat-icon class="inline-icon">person</mat-icon>
+                    {{ request.submittedByUserName || 'Unknown' }}
+                  </span>
+                  @if (request.workOrderId) {
+                    <span class="request-linked">
+                      <mat-icon class="inline-icon">link</mat-icon>
+                      Linked
+                    </span>
+                  }
+                </div>
+              </div>
+            </div>
+          }
+
+          @if (store.totalCount() > store.pageSize()) {
+            <mat-paginator
+              [length]="store.totalCount()"
+              [pageSize]="store.pageSize()"
+              [pageIndex]="store.page() - 1"
+              [pageSizeOptions]="[10, 20, 50]"
+              (page)="onPageChange($event)"
+              data-testid="paginator"
+            />
+          }
+        </div>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .maintenance-requests-page {
+        padding: 24px 16px;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+
+      .page-header {
+        margin-bottom: 24px;
+      }
+
+      .page-header h1 {
+        margin: 0;
+      }
+
+      .filter-section {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 16px;
+        margin-bottom: 24px;
+        padding: 16px;
+        background-color: var(--mat-sys-surface-container-low);
+        border-radius: 8px;
+      }
+
+      .filter-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .filter-label {
+        font-weight: 500;
+        color: var(--mat-sys-on-surface-variant);
+        font-size: 0.9em;
+      }
+
+      .status-chips {
+        display: flex;
+        gap: 8px;
+      }
+
+      .property-filter {
+        min-width: 200px;
+      }
+
+      .property-filter ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+        display: none;
+      }
+
+      .clear-filters-btn {
+        margin-left: auto;
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 48px;
+      }
+
+      .empty-state mat-card-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
+
+      .empty-icon {
+        font-size: 64px;
+        height: 64px;
+        width: 64px;
+        color: var(--mat-sys-outline);
+      }
+
+      .filtered-empty .empty-icon {
+        color: var(--mat-sys-primary);
+      }
+
+      .request-list {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .request-row {
+        display: flex;
+        align-items: center;
+        border-bottom: 1px solid var(--mat-sys-outline-variant);
+        padding: 12px 16px;
+        cursor: pointer;
+        transition: background-color 0.15s;
+      }
+
+      .request-row:hover,
+      .request-row:focus-visible {
+        background-color: var(--mat-sys-surface-container);
+        outline: none;
+      }
+
+      .row-content {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .line-1 {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-weight: 500;
+      }
+
+      .line-2 {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        font-size: 0.875rem;
+        color: var(--mat-sys-on-surface-variant);
+        flex-wrap: wrap;
+      }
+
+      .request-description {
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+      }
+
+      .request-date {
+        flex-shrink: 0;
+        color: var(--mat-sys-on-surface-variant);
+        font-size: 0.875rem;
+        font-weight: 400;
+      }
+
+      .request-property,
+      .request-submitter,
+      .request-linked {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .inline-icon {
+        font-size: 16px;
+        height: 16px;
+        width: 16px;
+        vertical-align: middle;
+      }
+
+      /* Status chip (AC #5) — match tenant-dashboard color scheme. */
+      .status-chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 10px;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+
+      .status-submitted {
+        background-color: var(--mat-sys-warning-container, #fef3c7);
+        color: var(--mat-sys-on-warning-container, #92400e);
+      }
+
+      .status-in-progress {
+        background-color: var(--mat-sys-primary-container, #dbeafe);
+        color: var(--mat-sys-on-primary-container, #1e40af);
+      }
+
+      .status-resolved {
+        background-color: var(--mat-sys-tertiary-container, #d1fae5);
+        color: var(--mat-sys-on-tertiary-container, #065f46);
+      }
+
+      .status-dismissed {
+        background-color: var(--mat-sys-error-container, #ffe0b2);
+        color: var(--mat-sys-on-error-container, #e65100);
+      }
+
+      /* Mobile breakpoint @ 768px (AC #13): stack lines. */
+      @media (max-width: 768px) {
+        .filter-section {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .clear-filters-btn {
+          margin-left: 0;
+          margin-top: 8px;
+        }
+
+        .request-row {
+          padding: 16px;
+        }
+
+        .line-1 {
+          flex-wrap: wrap;
+          gap: 8px;
+        }
+
+        .line-1 .request-description {
+          width: 100%;
+          white-space: normal;
+          flex-basis: 100%;
+          order: 2;
+        }
+
+        .line-1 .status-chip {
+          order: 0;
+        }
+
+        .line-1 .request-date {
+          order: 1;
+          margin-left: auto;
+        }
+
+        .line-2 {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 4px;
+        }
+      }
+    `,
+  ],
+})
+export class MaintenanceRequestsComponent implements OnInit {
+  protected readonly store = inject(MaintenanceRequestStore);
+  protected readonly propertyStore = inject(PropertyStore);
+  private readonly router = inject(Router);
+
+  ngOnInit(): void {
+    this.store.loadRequests();
+    this.propertyStore.loadProperties(undefined);
+  }
+
+  onStatusFilterChange(event: MatChipListboxChange): void {
+    const selected = (event.value as string[]) ?? [];
+    this.store.setStatusFilter(selected);
+  }
+
+  onPropertyFilterChange(propertyId: string | null): void {
+    this.store.setPropertyFilter(propertyId);
+  }
+
+  clearFilters(): void {
+    this.store.clearFilters();
+  }
+
+  onPageChange(event: PageEvent): void {
+    this.store.setPage(event.pageIndex + 1, event.pageSize);
+  }
+
+  retry(): void {
+    this.store.loadRequests();
+  }
+
+  openRequest(id: string): void {
+    this.router.navigate(['/maintenance-requests', id]);
+  }
+
+  getStatusLabel(status: string): string {
+    return status === 'InProgress' ? 'In Progress' : status;
+  }
+
+  truncateDescription(description: string, maxLength = 100): string {
+    if (description.length <= maxLength) {
+      return description;
+    }
+    return description.substring(0, maxLength) + '...';
+  }
+}

--- a/frontend/src/app/features/maintenance-requests/services/maintenance-request.service.spec.ts
+++ b/frontend/src/app/features/maintenance-requests/services/maintenance-request.service.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import {
+  MaintenanceRequestService,
+  PaginatedMaintenanceRequests,
+  MaintenanceRequestDto,
+} from './maintenance-request.service';
+
+describe('MaintenanceRequestService', () => {
+  let service: MaintenanceRequestService;
+  let httpMock: HttpTestingController;
+
+  const mockRequest: MaintenanceRequestDto = {
+    id: 'req-1',
+    propertyId: 'prop-1',
+    propertyName: 'Test Property',
+    propertyAddress: '123 Test St, Austin, TX 78701',
+    description: 'Leaky faucet',
+    status: 'Submitted',
+    dismissalReason: null,
+    submittedByUserId: 'user-1',
+    submittedByUserName: 'Jane Tenant',
+    workOrderId: null,
+    createdAt: '2026-05-01T10:00:00Z',
+    updatedAt: '2026-05-01T10:00:00Z',
+    photos: null,
+  };
+
+  const mockPaginated: PaginatedMaintenanceRequests = {
+    items: [mockRequest],
+    totalCount: 1,
+    page: 1,
+    pageSize: 20,
+    totalPages: 1,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MaintenanceRequestService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    service = TestBed.inject(MaintenanceRequestService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getMaintenanceRequests', () => {
+    it('should hit /api/v1/maintenance-requests with no params', () => {
+      service.getMaintenanceRequests().subscribe((response) => {
+        expect(response).toEqual(mockPaginated);
+      });
+
+      const req = httpMock.expectOne((r) => r.url === '/api/v1/maintenance-requests');
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.keys()).toHaveLength(0);
+      req.flush(mockPaginated);
+    });
+
+    it('should send status param when provided', () => {
+      service.getMaintenanceRequests({ status: 'InProgress' }).subscribe();
+
+      const req = httpMock.expectOne((r) => r.url === '/api/v1/maintenance-requests');
+      expect(req.request.params.get('status')).toBe('InProgress');
+      expect(req.request.params.has('propertyId')).toBe(false);
+      expect(req.request.params.has('page')).toBe(false);
+      req.flush(mockPaginated);
+    });
+
+    it('should send propertyId param when provided', () => {
+      service.getMaintenanceRequests({ propertyId: 'prop-42' }).subscribe();
+
+      const req = httpMock.expectOne((r) => r.url === '/api/v1/maintenance-requests');
+      expect(req.request.params.get('propertyId')).toBe('prop-42');
+      expect(req.request.params.has('status')).toBe(false);
+      req.flush(mockPaginated);
+    });
+
+    it('should send page, pageSize, status, and propertyId together', () => {
+      service
+        .getMaintenanceRequests({
+          status: 'Submitted',
+          propertyId: 'prop-1',
+          page: 2,
+          pageSize: 50,
+        })
+        .subscribe();
+
+      const req = httpMock.expectOne((r) => r.url === '/api/v1/maintenance-requests');
+      expect(req.request.params.get('status')).toBe('Submitted');
+      expect(req.request.params.get('propertyId')).toBe('prop-1');
+      expect(req.request.params.get('page')).toBe('2');
+      expect(req.request.params.get('pageSize')).toBe('50');
+      req.flush(mockPaginated);
+    });
+
+    it('should omit empty string status', () => {
+      service.getMaintenanceRequests({ status: '' }).subscribe();
+
+      const req = httpMock.expectOne((r) => r.url === '/api/v1/maintenance-requests');
+      expect(req.request.params.has('status')).toBe(false);
+      req.flush(mockPaginated);
+    });
+  });
+
+  describe('getMaintenanceRequestById', () => {
+    it('should hit /api/v1/maintenance-requests/:id', () => {
+      service.getMaintenanceRequestById('req-1').subscribe((response) => {
+        expect(response.id).toBe('req-1');
+      });
+
+      const req = httpMock.expectOne('/api/v1/maintenance-requests/req-1');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockRequest);
+    });
+  });
+});

--- a/frontend/src/app/features/maintenance-requests/services/maintenance-request.service.ts
+++ b/frontend/src/app/features/maintenance-requests/services/maintenance-request.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+/**
+ * Maintenance Request Photo DTO (Story 20.4 / 20.7).
+ *
+ * Defined locally — these types are intentionally duplicated from
+ * `tenant.service.ts` to keep the landlord inbox feature decoupled
+ * from the tenant-dashboard module. Consolidation is a future tech-debt
+ * opportunity once the landlord views (20.7–20.10) are stable.
+ */
+export interface MaintenanceRequestPhotoDto {
+  id: string;
+  thumbnailUrl: string | null;
+  viewUrl: string | null;
+  isPrimary: boolean;
+  displayOrder: number;
+  originalFileName: string;
+  fileSizeBytes: number;
+  createdAt: string;
+}
+
+/**
+ * Maintenance Request DTO (matches backend MaintenanceRequestDto).
+ */
+export interface MaintenanceRequestDto {
+  id: string;
+  propertyId: string;
+  propertyName: string;
+  propertyAddress: string;
+  description: string;
+  status: string;
+  dismissalReason: string | null;
+  submittedByUserId: string;
+  submittedByUserName: string | null;
+  workOrderId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  photos: MaintenanceRequestPhotoDto[] | null;
+}
+
+/**
+ * Paginated maintenance requests response.
+ */
+export interface PaginatedMaintenanceRequests {
+  items: MaintenanceRequestDto[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+/**
+ * Query parameters for the landlord maintenance requests inbox.
+ *
+ * Backend's `GetMaintenanceRequestsQuery.Status` is parsed via a single
+ * `Enum.TryParse<MaintenanceRequestStatus>`. See "Status Filter Encoding"
+ * in `docs/project/stories/epic-20/20-7-landlord-maintenance-request-inbox.md`.
+ */
+export interface MaintenanceRequestQueryParams {
+  status?: string;
+  propertyId?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+/**
+ * Maintenance Request Service (Story 20.7, AC #1, #2, #3, #4, #6, #7).
+ *
+ * HTTP service for the landlord maintenance request inbox.
+ * Calls the same backend endpoints as `TenantService`; the backend
+ * differentiates Owner vs Tenant via the JWT role claim.
+ */
+@Injectable({ providedIn: 'root' })
+export class MaintenanceRequestService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/v1/maintenance-requests';
+
+  /**
+   * Get the landlord's aggregated maintenance request inbox.
+   *
+   * @param params Optional filters: status, propertyId, page, pageSize.
+   *               Empty values are omitted from the query string.
+   */
+  getMaintenanceRequests(
+    params: MaintenanceRequestQueryParams = {},
+  ): Observable<PaginatedMaintenanceRequests> {
+    let httpParams = new HttpParams();
+    if (params.status) {
+      httpParams = httpParams.set('status', params.status);
+    }
+    if (params.propertyId) {
+      httpParams = httpParams.set('propertyId', params.propertyId);
+    }
+    if (params.page !== undefined && params.page !== null) {
+      httpParams = httpParams.set('page', params.page.toString());
+    }
+    if (params.pageSize !== undefined && params.pageSize !== null) {
+      httpParams = httpParams.set('pageSize', params.pageSize.toString());
+    }
+    return this.http.get<PaginatedMaintenanceRequests>(this.baseUrl, { params: httpParams });
+  }
+
+  /**
+   * Get a single maintenance request by ID with full detail (photos included).
+   */
+  getMaintenanceRequestById(id: string): Observable<MaintenanceRequestDto> {
+    return this.http.get<MaintenanceRequestDto>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/frontend/src/app/features/maintenance-requests/stores/maintenance-request.store.spec.ts
+++ b/frontend/src/app/features/maintenance-requests/stores/maintenance-request.store.spec.ts
@@ -1,0 +1,265 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of, throwError } from 'rxjs';
+import { MaintenanceRequestStore } from './maintenance-request.store';
+import {
+  MaintenanceRequestService,
+  MaintenanceRequestDto,
+  PaginatedMaintenanceRequests,
+} from '../services/maintenance-request.service';
+
+describe('MaintenanceRequestStore', () => {
+  let store: InstanceType<typeof MaintenanceRequestStore>;
+  let serviceMock: {
+    getMaintenanceRequests: ReturnType<typeof vi.fn>;
+    getMaintenanceRequestById: ReturnType<typeof vi.fn>;
+  };
+
+  const mockRequest: MaintenanceRequestDto = {
+    id: 'req-1',
+    propertyId: 'prop-1',
+    propertyName: 'Test Property',
+    propertyAddress: '123 Test St, Austin, TX',
+    description: 'Leaky faucet',
+    status: 'Submitted',
+    dismissalReason: null,
+    submittedByUserId: 'user-1',
+    submittedByUserName: 'Jane Tenant',
+    workOrderId: null,
+    createdAt: '2026-05-01T10:00:00Z',
+    updatedAt: '2026-05-01T10:00:00Z',
+    photos: null,
+  };
+
+  const mockResponse: PaginatedMaintenanceRequests = {
+    items: [mockRequest],
+    totalCount: 1,
+    page: 1,
+    pageSize: 20,
+    totalPages: 1,
+  };
+
+  beforeEach(() => {
+    serviceMock = {
+      getMaintenanceRequests: vi.fn().mockReturnValue(of(mockResponse)),
+      getMaintenanceRequestById: vi.fn().mockReturnValue(of(mockRequest)),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        MaintenanceRequestStore,
+        { provide: MaintenanceRequestService, useValue: serviceMock },
+      ],
+    });
+
+    store = TestBed.inject(MaintenanceRequestStore);
+  });
+
+  describe('initial state', () => {
+    it('starts with empty requests', () => {
+      expect(store.requests()).toEqual([]);
+    });
+
+    it('starts with all statuses selected', () => {
+      expect(store.selectedStatuses()).toEqual(['Submitted', 'InProgress', 'Resolved', 'Dismissed']);
+    });
+
+    it('starts with no property filter', () => {
+      expect(store.selectedPropertyId()).toBeNull();
+    });
+
+    it('starts with page=1, pageSize=20', () => {
+      expect(store.page()).toBe(1);
+      expect(store.pageSize()).toBe(20);
+    });
+
+    it('starts with no selected request', () => {
+      expect(store.selectedRequest()).toBeNull();
+    });
+  });
+
+  describe('computed signals', () => {
+    it('hasActiveFilters is false on defaults', () => {
+      expect(store.hasActiveFilters()).toBe(false);
+    });
+
+    it('hasActiveFilters is true when status subset selected', () => {
+      store.setStatusFilter(['Submitted']);
+      expect(store.hasActiveFilters()).toBe(true);
+    });
+
+    it('hasActiveFilters is true when property filter applied', () => {
+      store.setPropertyFilter('prop-1');
+      expect(store.hasActiveFilters()).toBe(true);
+    });
+
+    it('isEmpty is true when no requests AND no filters', () => {
+      serviceMock.getMaintenanceRequests.mockReturnValue(
+        of({ items: [], totalCount: 0, page: 1, pageSize: 20, totalPages: 0 }),
+      );
+      store.loadRequests();
+      expect(store.isEmpty()).toBe(true);
+      expect(store.isFilteredEmpty()).toBe(false);
+    });
+
+    it('isFilteredEmpty is true when no requests AND filters active', () => {
+      serviceMock.getMaintenanceRequests.mockReturnValue(
+        of({ items: [], totalCount: 0, page: 1, pageSize: 20, totalPages: 0 }),
+      );
+      store.setStatusFilter(['Submitted']);
+      expect(store.isFilteredEmpty()).toBe(true);
+      expect(store.isEmpty()).toBe(false);
+    });
+  });
+
+  describe('loadRequests', () => {
+    it('happy path patches requests and pagination', () => {
+      store.loadRequests();
+      expect(store.requests()).toEqual([mockRequest]);
+      expect(store.totalCount()).toBe(1);
+      expect(store.page()).toBe(1);
+      expect(store.pageSize()).toBe(20);
+      expect(store.totalPages()).toBe(1);
+      expect(store.isLoading()).toBe(false);
+      expect(store.error()).toBeNull();
+    });
+
+    it('sends no status param when all statuses selected', () => {
+      store.loadRequests();
+      expect(serviceMock.getMaintenanceRequests).toHaveBeenCalledWith({
+        status: undefined,
+        propertyId: undefined,
+        page: 1,
+        pageSize: 20,
+      });
+    });
+
+    it('sends single status when exactly one selected', () => {
+      store.setStatusFilter(['InProgress']);
+      const lastCall =
+        serviceMock.getMaintenanceRequests.mock.calls[
+          serviceMock.getMaintenanceRequests.mock.calls.length - 1
+        ];
+      expect(lastCall[0].status).toBe('InProgress');
+    });
+
+    it('sends no status when 2 of 4 statuses selected', () => {
+      store.setStatusFilter(['Submitted', 'InProgress']);
+      const lastCall =
+        serviceMock.getMaintenanceRequests.mock.calls[
+          serviceMock.getMaintenanceRequests.mock.calls.length - 1
+        ];
+      expect(lastCall[0].status).toBeUndefined();
+    });
+
+    it('sets error on failure', () => {
+      serviceMock.getMaintenanceRequests.mockReturnValue(throwError(() => new Error('boom')));
+      store.loadRequests();
+      expect(store.error()).toBe('Failed to load maintenance requests. Please try again.');
+      expect(store.isLoading()).toBe(false);
+    });
+  });
+
+  describe('setStatusFilter', () => {
+    it('patches state and reloads', () => {
+      const callsBefore = serviceMock.getMaintenanceRequests.mock.calls.length;
+      store.setStatusFilter(['Submitted']);
+      expect(store.selectedStatuses()).toEqual(['Submitted']);
+      expect(store.page()).toBe(1);
+      expect(serviceMock.getMaintenanceRequests.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it('refuses an empty selection (no patch, no reload)', () => {
+      store.setStatusFilter(['Submitted']); // patch first
+      const before = serviceMock.getMaintenanceRequests.mock.calls.length;
+      store.setStatusFilter([]);
+      expect(store.selectedStatuses()).toEqual(['Submitted']);
+      expect(serviceMock.getMaintenanceRequests.mock.calls.length).toBe(before);
+    });
+  });
+
+  describe('setPropertyFilter', () => {
+    it('patches and reloads', () => {
+      const callsBefore = serviceMock.getMaintenanceRequests.mock.calls.length;
+      store.setPropertyFilter('prop-9');
+      expect(store.selectedPropertyId()).toBe('prop-9');
+      expect(store.page()).toBe(1);
+      expect(serviceMock.getMaintenanceRequests.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it('clearing property filter sends propertyId=undefined', () => {
+      store.setPropertyFilter('prop-9');
+      store.setPropertyFilter(null);
+      const lastCall =
+        serviceMock.getMaintenanceRequests.mock.calls[
+          serviceMock.getMaintenanceRequests.mock.calls.length - 1
+        ];
+      expect(lastCall[0].propertyId).toBeUndefined();
+    });
+  });
+
+  describe('clearFilters', () => {
+    it('resets to defaults and reloads', () => {
+      store.setStatusFilter(['Submitted']);
+      store.setPropertyFilter('prop-7');
+      store.clearFilters();
+      expect(store.selectedStatuses()).toEqual([
+        'Submitted',
+        'InProgress',
+        'Resolved',
+        'Dismissed',
+      ]);
+      expect(store.selectedPropertyId()).toBeNull();
+      expect(store.page()).toBe(1);
+      expect(store.hasActiveFilters()).toBe(false);
+    });
+  });
+
+  describe('setPage', () => {
+    it('passes page and pageSize to the service', () => {
+      store.setPage(2, 50);
+      const lastCall =
+        serviceMock.getMaintenanceRequests.mock.calls[
+          serviceMock.getMaintenanceRequests.mock.calls.length - 1
+        ];
+      expect(lastCall[0].page).toBe(2);
+      expect(lastCall[0].pageSize).toBe(50);
+    });
+  });
+
+  describe('loadRequestById', () => {
+    it('happy path patches selectedRequest', () => {
+      store.loadRequestById('req-1');
+      expect(store.selectedRequest()).toEqual(mockRequest);
+      expect(store.isLoadingDetail()).toBe(false);
+      expect(store.detailError()).toBeNull();
+    });
+
+    it('404 sets detailError to "Maintenance request not found"', () => {
+      serviceMock.getMaintenanceRequestById.mockReturnValue(throwError(() => ({ status: 404 })));
+      store.loadRequestById('missing');
+      expect(store.detailError()).toBe('Maintenance request not found');
+      expect(store.selectedRequest()).toBeNull();
+    });
+
+    it('non-404 errors set generic detailError', () => {
+      serviceMock.getMaintenanceRequestById.mockReturnValue(throwError(() => ({ status: 500 })));
+      store.loadRequestById('boom');
+      expect(store.detailError()).toBe('Failed to load maintenance request. Please try again.');
+    });
+  });
+
+  describe('clearSelectedRequest', () => {
+    it('clears selectedRequest and detailError', () => {
+      store.loadRequestById('req-1');
+      // Manually patch detailError to verify the method clears it too:
+      serviceMock.getMaintenanceRequestById.mockReturnValue(throwError(() => ({ status: 500 })));
+      store.loadRequestById('boom');
+      expect(store.detailError()).not.toBeNull();
+
+      store.clearSelectedRequest();
+      expect(store.selectedRequest()).toBeNull();
+      expect(store.detailError()).toBeNull();
+    });
+  });
+});

--- a/frontend/src/app/features/maintenance-requests/stores/maintenance-request.store.ts
+++ b/frontend/src/app/features/maintenance-requests/stores/maintenance-request.store.ts
@@ -1,0 +1,253 @@
+import { computed, inject } from '@angular/core';
+import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { pipe, switchMap, tap, catchError, of } from 'rxjs';
+import {
+  MaintenanceRequestService,
+  MaintenanceRequestDto,
+  MaintenanceRequestQueryParams,
+} from '../services/maintenance-request.service';
+
+/**
+ * All available maintenance request statuses (Story 20.7, AC #5, #6).
+ */
+export const ALL_REQUEST_STATUSES = ['Submitted', 'InProgress', 'Resolved', 'Dismissed'] as const;
+
+const ALL_STATUSES_ARRAY: string[] = [...ALL_REQUEST_STATUSES];
+
+/**
+ * Helper: are filters currently active?
+ *
+ * Active when not all statuses are selected, or a property filter is applied.
+ */
+function areFiltersActive(selectedStatuses: string[], selectedPropertyId: string | null): boolean {
+  const hasStatusFilter = selectedStatuses.length < ALL_STATUSES_ARRAY.length;
+  const hasPropertyFilter = selectedPropertyId !== null;
+  return hasStatusFilter || hasPropertyFilter;
+}
+
+/**
+ * Encode the user's status selection into the single backend `status` query param.
+ *
+ * The backend `GetMaintenanceRequestsQuery.Status` only parses one status. When
+ * the user selects exactly one status chip, send it. Otherwise send `undefined`
+ * — see `docs/project/stories/epic-20/20-7-landlord-maintenance-request-inbox.md`
+ * §"Status Filter Encoding (One-Status Constraint)".
+ */
+function encodeStatusParam(selectedStatuses: string[]): string | undefined {
+  if (selectedStatuses.length === 1) {
+    return selectedStatuses[0];
+  }
+  return undefined;
+}
+
+/**
+ * Maintenance Request Store State (Story 20.7, AC #1, #4, #6, #7, #12).
+ */
+interface MaintenanceRequestState {
+  requests: MaintenanceRequestDto[];
+  selectedRequest: MaintenanceRequestDto | null;
+  isLoading: boolean;
+  isLoadingDetail: boolean;
+  error: string | null;
+  detailError: string | null;
+  // Filter state (AC #6, #7)
+  selectedStatuses: string[];
+  selectedPropertyId: string | null;
+  // Pagination (AC #4)
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  totalPages: number;
+}
+
+const initialState: MaintenanceRequestState = {
+  requests: [],
+  selectedRequest: null,
+  isLoading: false,
+  isLoadingDetail: false,
+  error: null,
+  detailError: null,
+  selectedStatuses: [...ALL_STATUSES_ARRAY],
+  selectedPropertyId: null,
+  page: 1,
+  pageSize: 20,
+  totalCount: 0,
+  totalPages: 0,
+};
+
+/**
+ * Maintenance Request Store (Story 20.7).
+ *
+ * State management for the landlord maintenance request inbox using @ngrx/signals.
+ * Mirrors `WorkOrderStore` patterns: rxMethod with switchMap + catchError → of(null).
+ */
+export const MaintenanceRequestStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+  withComputed((store) => ({
+    /** True when not loading, list is empty, AND no filters are active (AC #9). */
+    isEmpty: computed(
+      () =>
+        !store.isLoading() &&
+        store.requests().length === 0 &&
+        !areFiltersActive(store.selectedStatuses(), store.selectedPropertyId()),
+    ),
+    /** True when not loading, list is empty, AND filters are active (AC #8). */
+    isFilteredEmpty: computed(
+      () =>
+        !store.isLoading() &&
+        store.requests().length === 0 &&
+        areFiltersActive(store.selectedStatuses(), store.selectedPropertyId()),
+    ),
+    /** True when any filter (status subset or property) is active. */
+    hasActiveFilters: computed(() =>
+      areFiltersActive(store.selectedStatuses(), store.selectedPropertyId()),
+    ),
+  })),
+  withMethods((store, requestService = inject(MaintenanceRequestService)) => {
+    function buildParams(overrides?: { page?: number; pageSize?: number }): MaintenanceRequestQueryParams {
+      const status = encodeStatusParam(store.selectedStatuses());
+      const propertyId = store.selectedPropertyId() ?? undefined;
+      return {
+        status,
+        propertyId,
+        page: overrides?.page ?? store.page(),
+        pageSize: overrides?.pageSize ?? store.pageSize(),
+      };
+    }
+
+    return {
+      /**
+       * Load the inbox with the current filter/pagination state.
+       *
+       * @param overrides Optional `{ page, pageSize }` to apply for this request.
+       *                  When omitted, uses the store's current page/pageSize.
+       */
+      loadRequests: rxMethod<{ page?: number; pageSize?: number } | void>(
+        pipe(
+          tap((overrides) => {
+            patchState(store, {
+              isLoading: true,
+              error: null,
+              page: overrides?.page ?? store.page(),
+              pageSize: overrides?.pageSize ?? store.pageSize(),
+            });
+          }),
+          switchMap((overrides) =>
+            requestService.getMaintenanceRequests(buildParams(overrides ?? undefined)).pipe(
+              tap((response) =>
+                patchState(store, {
+                  requests: response.items,
+                  totalCount: response.totalCount,
+                  page: response.page,
+                  pageSize: response.pageSize,
+                  totalPages: response.totalPages,
+                  isLoading: false,
+                }),
+              ),
+              catchError(() => {
+                patchState(store, {
+                  isLoading: false,
+                  error: 'Failed to load maintenance requests. Please try again.',
+                });
+                return of(null);
+              }),
+            ),
+          ),
+        ),
+      ),
+
+      /**
+       * Load a single maintenance request by ID for the detail view.
+       * 404 → `detailError = 'Maintenance request not found'`; other errors get a generic message.
+       */
+      loadRequestById: rxMethod<string>(
+        pipe(
+          tap(() =>
+            patchState(store, {
+              isLoadingDetail: true,
+              detailError: null,
+              selectedRequest: null,
+            }),
+          ),
+          switchMap((id) =>
+            requestService.getMaintenanceRequestById(id).pipe(
+              tap((request) =>
+                patchState(store, {
+                  selectedRequest: request,
+                  isLoadingDetail: false,
+                }),
+              ),
+              catchError((error: { status?: number }) => {
+                const detailError =
+                  error?.status === 404
+                    ? 'Maintenance request not found'
+                    : 'Failed to load maintenance request. Please try again.';
+                patchState(store, {
+                  isLoadingDetail: false,
+                  detailError,
+                });
+                return of(null);
+              }),
+            ),
+          ),
+        ),
+      ),
+
+      /**
+       * Update the status filter and reload from page 1.
+       *
+       * Refuses an empty selection — matches `WorkOrderStore` UX so users can't
+       * land on a "no statuses → unfiltered" state.
+       */
+      setStatusFilter(statuses: string[]): void {
+        if (statuses.length === 0) {
+          return;
+        }
+        patchState(store, { selectedStatuses: statuses, page: 1 });
+        this.loadRequests();
+      },
+
+      /**
+       * Update the property filter and reload from page 1.
+       */
+      setPropertyFilter(propertyId: string | null): void {
+        patchState(store, { selectedPropertyId: propertyId, page: 1 });
+        this.loadRequests();
+      },
+
+      /**
+       * Reset all filters to defaults and reload from page 1.
+       */
+      clearFilters(): void {
+        patchState(store, {
+          selectedStatuses: [...ALL_STATUSES_ARRAY],
+          selectedPropertyId: null,
+          page: 1,
+        });
+        this.loadRequests();
+      },
+
+      /**
+       * Update pagination (used by `mat-paginator`).
+       *
+       * @param page 1-based page number (the paginator's pageIndex + 1)
+       * @param pageSize Items per page
+       */
+      setPage(page: number, pageSize: number): void {
+        this.loadRequests({ page, pageSize });
+      },
+
+      /**
+       * Clear the selected request and detail error — call on detail-page leave.
+       */
+      clearSelectedRequest(): void {
+        patchState(store, {
+          selectedRequest: null,
+          detailError: null,
+        });
+      },
+    };
+  }),
+);


### PR DESCRIPTION
## Summary
- Adds landlord-facing inbox at `/maintenance-requests` aggregating all requests across the owner's properties (FR-TP12, Epic 20).
- Status + property filters, `mat-paginator` (10/20/50, default 20), status-color chips, detail view with photo grid, `ownerGuard`-based tenant redirect.
- Frontend-only — reuses existing APIs from 20.3/20.4. Sidebar nav adds Maintenance Requests entry between Work Orders and Reports.

## Test plan
- [x] Unit tests — 2835 / 2835 pass (~63 new across service, store, list, detail specs)
- [x] Backend tests — 2127 / 2127 pass (no backend changes, regression check)
- [x] E2E — 6 / 6 new specs pass with `--workers=1`: aggregation, row→detail, status filter, property filter, empty state, tenant guard redirect
- [x] `dotnet build` clean; `ng build` clean (initial bundle 4.7 kB over budget — pre-existing)
- [x] Live-app smoke test against all 13 ACs (per /evaluate)

## Notes
- Integration tests skipped per Story 21.1 — exhaustive Owner GET coverage already exists.
- Status filter encoding: backend accepts a single status; UI sends `status=<value>` only when exactly one is selected (consistent with work-orders precedent). Multi-status backend support deferred.
- Pre-existing flake on `report-flow.spec.ts:293` traced to `TestController.Reset` not deleting MaintenanceRequests/Photos — unrelated to this PR; will be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)