### PR TITLE
feat(20-10): auto-resolve maintenance request on work order completion

### DIFF
--- a/backend/src/PropertyManager.Application/WorkOrders/UpdateWorkOrder.cs
+++ b/backend/src/PropertyManager.Application/WorkOrders/UpdateWorkOrder.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using PropertyManager.Application.Common.Interfaces;
 using PropertyManager.Domain.Entities;
 using PropertyManager.Domain.Enums;
@@ -28,13 +29,16 @@ public class UpdateWorkOrderCommandHandler : IRequestHandler<UpdateWorkOrderComm
 {
     private readonly IAppDbContext _dbContext;
     private readonly ICurrentUser _currentUser;
+    private readonly ILogger<UpdateWorkOrderCommandHandler> _logger;
 
     public UpdateWorkOrderCommandHandler(
         IAppDbContext dbContext,
-        ICurrentUser currentUser)
+        ICurrentUser currentUser,
+        ILogger<UpdateWorkOrderCommandHandler> logger)
     {
         _dbContext = dbContext;
         _currentUser = currentUser;
+        _logger = logger;
     }
 
     public async Task Handle(UpdateWorkOrderCommand request, CancellationToken cancellationToken)
@@ -48,6 +52,10 @@ public class UpdateWorkOrderCommandHandler : IRequestHandler<UpdateWorkOrderComm
         {
             throw new NotFoundException(nameof(WorkOrder), request.Id);
         }
+
+        // Capture prior status BEFORE any mutation so we can detect a true status transition
+        // for the Story 20.10 sync block below.
+        var priorStatus = workOrder.Status;
 
         // Validate category if provided
         if (request.CategoryId.HasValue)
@@ -117,6 +125,34 @@ public class UpdateWorkOrderCommandHandler : IRequestHandler<UpdateWorkOrderComm
                     WorkOrderId = workOrder.Id,
                     TagId = tagId
                 });
+            }
+        }
+
+        // Story 20.10: Sync linked MaintenanceRequest to Resolved when this WO transitions
+        // from a non-Completed status to Completed. Guarded transition-only (AC #3): a no-op
+        // PUT that keeps Completed → Completed does NOT trigger the sync. Unlinked work orders
+        // and non-Completed transitions skip the lookup entirely (AC #4, #11).
+        if (workOrder.Status == WorkOrderStatus.Completed
+            && priorStatus != WorkOrderStatus.Completed)
+        {
+            var linkedRequest = await _dbContext.MaintenanceRequests
+                .FirstOrDefaultAsync(
+                    mr => mr.WorkOrderId == workOrder.Id
+                        && mr.AccountId == _currentUser.AccountId
+                        && mr.DeletedAt == null,
+                    cancellationToken);
+
+            if (linkedRequest != null && linkedRequest.Status != MaintenanceRequestStatus.Resolved)
+            {
+                // Domain enforces InProgress → Resolved. Any other source status throws
+                // BusinessRuleException → 400 (AC #7) and rolls back the WO update via EF's
+                // implicit SaveChanges transaction.
+                linkedRequest.TransitionTo(MaintenanceRequestStatus.Resolved);
+
+                _logger.LogInformation(
+                    "Linked maintenance request {RequestId} marked Resolved due to work order {WorkOrderId} completion",
+                    linkedRequest.Id,
+                    workOrder.Id);
             }
         }
 

--- a/backend/tests/PropertyManager.Api.Tests/WorkOrdersControllerTests.cs
+++ b/backend/tests/PropertyManager.Api.Tests/WorkOrdersControllerTests.cs
@@ -3,6 +3,8 @@ using System.Net.Http.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Enums;
 using PropertyManager.Infrastructure.Persistence;
 
 namespace PropertyManager.Api.Tests;
@@ -686,6 +688,198 @@ public class WorkOrdersControllerTests : IClassFixture<PropertyManagerWebApplica
     }
 
     // =====================================================
+    // PUT /api/v1/work-orders/{id} — Story 20.10 resolution sync (AC #1, #2, #4, #7, #10)
+    // =====================================================
+
+    [Fact]
+    public async Task UpdateWorkOrder_StatusToCompleted_WithLinkedRequest_MarksRequestResolved()
+    {
+        // AC #1, #5 — landlord completes a WO linked to an InProgress MR → MR is Resolved.
+        var (accessToken, propertyId, accountId, userId) = await CreateUserPropertyAndCaptureContextAsync();
+        var workOrderId = await CreateWorkOrderAsync(accessToken, propertyId, status: "Reported");
+        var requestId = await SeedMaintenanceRequestLinkedToAsync(
+            accountId, propertyId, userId, workOrderId, MaintenanceRequestStatus.InProgress);
+
+        var updateRequest = new { Description = "Job done", Status = "Completed" };
+
+        var response = await PutAsJsonWithAuthAsync(
+            $"/api/v1/work-orders/{workOrderId}", updateRequest, accessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var wo = await db.WorkOrders.IgnoreQueryFilters().FirstAsync(w => w.Id == workOrderId);
+        wo.Status.Should().Be(WorkOrderStatus.Completed);
+        var mr = await db.MaintenanceRequests.IgnoreQueryFilters().FirstAsync(m => m.Id == requestId);
+        mr.Status.Should().Be(MaintenanceRequestStatus.Resolved);
+    }
+
+    [Fact]
+    public async Task UpdateWorkOrder_StatusToCompleted_NoLinkedRequest_StillSucceeds()
+    {
+        // AC #4 — unlinked WO completion is unaffected.
+        var (accessToken, propertyId, _, _) = await CreateUserPropertyAndCaptureContextAsync();
+        var workOrderId = await CreateWorkOrderAsync(accessToken, propertyId, status: "Assigned");
+
+        var updateRequest = new { Description = "Job done", Status = "Completed" };
+
+        var response = await PutAsJsonWithAuthAsync(
+            $"/api/v1/work-orders/{workOrderId}", updateRequest, accessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var wo = await db.WorkOrders.IgnoreQueryFilters().FirstAsync(w => w.Id == workOrderId);
+        wo.Status.Should().Be(WorkOrderStatus.Completed);
+    }
+
+    [Fact]
+    public async Task UpdateWorkOrder_StatusToAssigned_DoesNotModifyLinkedRequest()
+    {
+        // AC #2 — non-Completed transitions leave the linked MR untouched.
+        var (accessToken, propertyId, accountId, userId) = await CreateUserPropertyAndCaptureContextAsync();
+        var workOrderId = await CreateWorkOrderAsync(accessToken, propertyId, status: "Reported");
+        var requestId = await SeedMaintenanceRequestLinkedToAsync(
+            accountId, propertyId, userId, workOrderId, MaintenanceRequestStatus.InProgress);
+
+        var updateRequest = new { Description = "Reassigning", Status = "Assigned" };
+
+        var response = await PutAsJsonWithAuthAsync(
+            $"/api/v1/work-orders/{workOrderId}", updateRequest, accessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var wo = await db.WorkOrders.IgnoreQueryFilters().FirstAsync(w => w.Id == workOrderId);
+        wo.Status.Should().Be(WorkOrderStatus.Assigned);
+        var mr = await db.MaintenanceRequests.IgnoreQueryFilters().FirstAsync(m => m.Id == requestId);
+        mr.Status.Should().Be(MaintenanceRequestStatus.InProgress);
+    }
+
+    [Fact]
+    public async Task UpdateWorkOrder_NoOpStatusCompleted_DoesNotRetransitionRequest()
+    {
+        // AC #3 — Completed → Completed is gated out; linked Resolved MR is not touched.
+        var (accessToken, propertyId, accountId, userId) = await CreateUserPropertyAndCaptureContextAsync();
+        // Create a WO and seed it as Completed directly via DbContext so we don't have to
+        // first complete it through the handler (which would itself trigger the sync).
+        var workOrderId = await CreateWorkOrderAsync(accessToken, propertyId, status: "Reported");
+        var requestId = await SeedMaintenanceRequestLinkedToAsync(
+            accountId, propertyId, userId, workOrderId, MaintenanceRequestStatus.Resolved);
+
+        using (var seedScope = _factory.Services.CreateScope())
+        {
+            var seedDb = seedScope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var seedWo = await seedDb.WorkOrders.IgnoreQueryFilters().FirstAsync(w => w.Id == workOrderId);
+            seedWo.Status = WorkOrderStatus.Completed;
+            await seedDb.SaveChangesAsync();
+        }
+
+        var updateRequest = new { Description = "Tag tweak", Status = "Completed" };
+
+        var response = await PutAsJsonWithAuthAsync(
+            $"/api/v1/work-orders/{workOrderId}", updateRequest, accessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var wo = await db.WorkOrders.IgnoreQueryFilters().FirstAsync(w => w.Id == workOrderId);
+        wo.Status.Should().Be(WorkOrderStatus.Completed);
+        wo.Description.Should().Be("Tag tweak");
+        var mr = await db.MaintenanceRequests.IgnoreQueryFilters().FirstAsync(m => m.Id == requestId);
+        mr.Status.Should().Be(MaintenanceRequestStatus.Resolved);
+    }
+
+    [Fact]
+    public async Task UpdateWorkOrder_StatusToCompleted_LinkedRequestDismissed_Returns400_RollsBackWO()
+    {
+        // AC #7 — Dismissed MR cannot transition to Resolved; entire SaveChanges rolls back.
+        var (accessToken, propertyId, accountId, userId) = await CreateUserPropertyAndCaptureContextAsync();
+        var workOrderId = await CreateWorkOrderAsync(accessToken, propertyId, status: "Assigned");
+        var requestId = await SeedMaintenanceRequestLinkedToAsync(
+            accountId, propertyId, userId, workOrderId, MaintenanceRequestStatus.Dismissed);
+
+        var updateRequest = new { Description = "Should not stick", Status = "Completed" };
+
+        var response = await PutAsJsonWithAuthAsync(
+            $"/api/v1/work-orders/{workOrderId}", updateRequest, accessToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Dismissed").And.Contain("Resolved");
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var wo = await db.WorkOrders.IgnoreQueryFilters().FirstAsync(w => w.Id == workOrderId);
+        wo.Status.Should().Be(WorkOrderStatus.Assigned);
+        wo.Description.Should().NotBe("Should not stick");
+        var mr = await db.MaintenanceRequests.IgnoreQueryFilters().FirstAsync(m => m.Id == requestId);
+        mr.Status.Should().Be(MaintenanceRequestStatus.Dismissed);
+    }
+
+    [Fact]
+    public async Task UpdateWorkOrder_StatusToCompleted_AsTenant_Returns403()
+    {
+        // AC #10 — Tenant role cannot reach the sync code path (CanManageWorkOrders denies).
+        var ownerEmail = $"owner-{Guid.NewGuid():N}@example.com";
+        var (_, ownerAccountId) = await _factory.CreateTestUserAsync(ownerEmail);
+        var (ownerToken, _) = await LoginUserAsync(ownerEmail);
+
+        var propertyId = await _factory.CreatePropertyInAccountAsync(ownerAccountId);
+        var workOrderId = await CreateWorkOrderAsync(ownerToken, propertyId, status: "Assigned");
+
+        var tenantEmail = $"tenant-{Guid.NewGuid():N}@example.com";
+        await _factory.CreateTenantUserInAccountAsync(ownerAccountId, propertyId, tenantEmail);
+        var (tenantToken, _) = await LoginUserAsync(tenantEmail);
+
+        var updateRequest = new { Description = "Forbidden", Status = "Completed" };
+
+        var response = await PutAsJsonWithAuthAsync(
+            $"/api/v1/work-orders/{workOrderId}", updateRequest, tenantToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateWorkOrder_StatusToCompleted_LinkedRequestFromDifferentAccount_DoesNotMutateCrossAccount()
+    {
+        // Multi-tenancy — Owner A's WO completion must not touch Owner B's MR (even though
+        // the MR's WorkOrderId is forged to match A's WO id).
+        var (ownerAToken, propertyAId, accountAId, userAId) = await CreateUserPropertyAndCaptureContextAsync();
+        var workOrderId = await CreateWorkOrderAsync(ownerAToken, propertyAId, status: "Reported");
+        var ownAccountRequestId = await SeedMaintenanceRequestLinkedToAsync(
+            accountAId, propertyAId, userAId, workOrderId, MaintenanceRequestStatus.InProgress);
+
+        // Owner B (different account) — forge an MR with B's accountId but A's WorkOrderId.
+        var ownerBEmail = $"owner-b-{Guid.NewGuid():N}@example.com";
+        var (_, accountBId) = await _factory.CreateTestUserAsync(ownerBEmail);
+        var propertyBId = await _factory.CreatePropertyInAccountAsync(accountBId);
+        var userBId = Guid.NewGuid();
+        var crossAccountRequestId = await SeedMaintenanceRequestLinkedToAsync(
+            accountBId, propertyBId, userBId, workOrderId, MaintenanceRequestStatus.InProgress);
+
+        var updateRequest = new { Description = "Done", Status = "Completed" };
+
+        var response = await PutAsJsonWithAuthAsync(
+            $"/api/v1/work-orders/{workOrderId}", updateRequest, ownerAToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var ownMr = await db.MaintenanceRequests.IgnoreQueryFilters()
+            .FirstAsync(m => m.Id == ownAccountRequestId);
+        ownMr.Status.Should().Be(MaintenanceRequestStatus.Resolved);
+        var crossMr = await db.MaintenanceRequests.IgnoreQueryFilters()
+            .FirstAsync(m => m.Id == crossAccountRequestId);
+        crossMr.Status.Should().Be(MaintenanceRequestStatus.InProgress);
+    }
+
+    // =====================================================
     // DELETE /api/v1/work-orders/{id} Tests
     // =====================================================
 
@@ -1066,6 +1260,81 @@ public class WorkOrdersControllerTests : IClassFixture<PropertyManagerWebApplica
         var request = new HttpRequestMessage(HttpMethod.Delete, url);
         request.Headers.Add("Authorization", $"Bearer {accessToken}");
         return await _client.SendAsync(request);
+    }
+
+    /// <summary>
+    /// Owner registration helper that ALSO exposes the freshly-created AccountId and UserId
+    /// (RegisterAndLoginAsync only returns the access token / user id). Used by the Story 20.10
+    /// integration tests which need to seed a linked MaintenanceRequest directly.
+    /// </summary>
+    private async Task<(string AccessToken, Guid PropertyId, Guid AccountId, Guid UserId)>
+        CreateUserPropertyAndCaptureContextAsync()
+    {
+        var email = $"workorder-sync-{Guid.NewGuid():N}@example.com";
+        var password = "Test@123456";
+        var (userId, accountId) = await _factory.CreateTestUserAsync(email, password);
+
+        var loginRequest = new { Email = email, Password = password };
+        var loginResponse = await _client.PostAsJsonAsync("/api/v1/auth/login", loginRequest);
+        loginResponse.EnsureSuccessStatusCode();
+        var loginContent = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        var accessToken = loginContent!.AccessToken;
+
+        var propertyId = await _factory.CreatePropertyInAccountAsync(accountId);
+
+        return (accessToken, propertyId, accountId, userId);
+    }
+
+    private async Task<(string AccessToken, Guid? UserId)> LoginUserAsync(
+        string email, string password = "Test@123456")
+    {
+        var loginRequest = new { Email = email, Password = password };
+        var loginResponse = await _client.PostAsJsonAsync("/api/v1/auth/login", loginRequest);
+        loginResponse.EnsureSuccessStatusCode();
+        var loginContent = await loginResponse.Content.ReadFromJsonAsync<LoginResponse>();
+        return (loginContent!.AccessToken, null);
+    }
+
+    private async Task<Guid> CreateWorkOrderAsync(string accessToken, Guid propertyId, string status)
+    {
+        var createResponse = await PostAsJsonWithAuthAsync(
+            "/api/v1/work-orders",
+            new { PropertyId = propertyId, Description = "Test WO", Status = status },
+            accessToken);
+        createResponse.EnsureSuccessStatusCode();
+        var content = await createResponse.Content.ReadFromJsonAsync<CreateWorkOrderResponse>();
+        return content!.Id;
+    }
+
+    /// <summary>
+    /// Direct-DB seed of a MaintenanceRequest linked to an existing WorkOrder.
+    /// Mirrors <c>MaintenanceRequestsControllerTests.SeedMaintenanceRequestAsync</c>, but
+    /// adds the <c>WorkOrderId</c> link so the Story 20.10 sync block sees it.
+    /// </summary>
+    private async Task<Guid> SeedMaintenanceRequestLinkedToAsync(
+        Guid accountId,
+        Guid propertyId,
+        Guid submittedByUserId,
+        Guid workOrderId,
+        MaintenanceRequestStatus status)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var entity = new MaintenanceRequest
+        {
+            Id = Guid.NewGuid(),
+            AccountId = accountId,
+            PropertyId = propertyId,
+            SubmittedByUserId = submittedByUserId,
+            WorkOrderId = workOrderId,
+            Description = "seeded for sync test",
+            Status = status
+        };
+
+        db.MaintenanceRequests.Add(entity);
+        await db.SaveChangesAsync();
+        return entity.Id;
     }
 }
 

--- a/backend/tests/PropertyManager.Application.Tests/WorkOrders/UpdateWorkOrderHandlerTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/WorkOrders/UpdateWorkOrderHandlerTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using MockQueryable.Moq;
 using Moq;
 using PropertyManager.Application.Common.Interfaces;
@@ -16,6 +17,7 @@ public class UpdateWorkOrderHandlerTests
 {
     private readonly Mock<IAppDbContext> _dbContextMock;
     private readonly Mock<ICurrentUser> _currentUserMock;
+    private readonly Mock<ILogger<UpdateWorkOrderCommandHandler>> _loggerMock;
     private readonly UpdateWorkOrderCommandHandler _handler;
     private readonly Guid _testAccountId = Guid.NewGuid();
     private readonly Guid _testUserId = Guid.NewGuid();
@@ -25,13 +27,17 @@ public class UpdateWorkOrderHandlerTests
     {
         _dbContextMock = new Mock<IAppDbContext>();
         _currentUserMock = new Mock<ICurrentUser>();
+        _loggerMock = new Mock<ILogger<UpdateWorkOrderCommandHandler>>();
         _currentUserMock.Setup(x => x.AccountId).Returns(_testAccountId);
         _currentUserMock.Setup(x => x.UserId).Returns(_testUserId);
         _currentUserMock.Setup(x => x.IsAuthenticated).Returns(true);
 
         _dbContextMock.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
-        _handler = new UpdateWorkOrderCommandHandler(_dbContextMock.Object, _currentUserMock.Object);
+        _handler = new UpdateWorkOrderCommandHandler(
+            _dbContextMock.Object,
+            _currentUserMock.Object,
+            _loggerMock.Object);
     }
 
     [Fact]
@@ -272,6 +278,9 @@ public class UpdateWorkOrderHandlerTests
         SetupWorkOrderExists(workOrder);
         SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
         SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        // Transitioning to Completed triggers the Story 20.10 sync lookup; seed an empty
+        // MaintenanceRequests set so the FirstOrDefaultAsync returns null and the sync no-ops.
+        SetupMaintenanceRequestsDbSet();
 
         var command = new UpdateWorkOrderCommand(
             workOrderId,
@@ -448,6 +457,365 @@ public class UpdateWorkOrderHandlerTests
 
     #endregion
 
+    #region Sync Resolution Tests (Story 20-10)
+
+    [Fact]
+    public async Task Handle_StatusChangedToCompleted_WithLinkedRequest_TransitionsRequestToResolved()
+    {
+        // AC #1 — Completed transition with linked InProgress request resolves it.
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        // Prior status is Reported (from CreateWorkOrder) — transitioning to Completed.
+        var linkedRequest = CreateMaintenanceRequest(
+            accountId: _testAccountId,
+            workOrderId: workOrderId,
+            status: MaintenanceRequestStatus.InProgress);
+
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        SetupMaintenanceRequestsDbSet(linkedRequest);
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Job done",
+            null,
+            "Completed",
+            null,
+            null);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        workOrder.Status.Should().Be(WorkOrderStatus.Completed);
+        linkedRequest.Status.Should().Be(MaintenanceRequestStatus.Resolved);
+        _dbContextMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_StatusChangedToCompleted_NoLinkedRequest_DoesNotThrow_AndDoesNotMutateAnyRequest()
+    {
+        // AC #4, #13 — Unlinked WO completion succeeds and performs the lookup
+        // (returns null) without throwing.
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        SetupMaintenanceRequestsDbSet(); // empty — no linked request
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Job done",
+            null,
+            "Completed",
+            null,
+            null);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+        workOrder.Status.Should().Be(WorkOrderStatus.Completed);
+        // The lookup IS made (returns null) — this proves AC #13 path.
+        _dbContextMock.Verify(x => x.MaintenanceRequests, Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task Handle_StatusChangedToAssigned_DoesNotQueryMaintenanceRequests()
+    {
+        // AC #2, #11 — Non-Completed transitions skip the lookup entirely.
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        // workOrder.Status is Reported (from CreateWorkOrder)
+        var linkedRequest = CreateMaintenanceRequest(
+            accountId: _testAccountId,
+            workOrderId: workOrderId,
+            status: MaintenanceRequestStatus.InProgress);
+
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        // Intentionally do NOT setup MaintenanceRequests DbSet — accessing it would NRE
+        // if the handler reached the lookup. That's the assertion we want.
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Assign it",
+            null,
+            "Assigned",
+            null,
+            null);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        workOrder.Status.Should().Be(WorkOrderStatus.Assigned);
+        linkedRequest.Status.Should().Be(MaintenanceRequestStatus.InProgress);
+        _dbContextMock.Verify(x => x.MaintenanceRequests, Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_StatusUnchanged_Completed_DoesNotQueryMaintenanceRequests()
+    {
+        // AC #3 — Re-saving an already-Completed WO is a no-op for the sync.
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        workOrder.Status = WorkOrderStatus.Completed; // priorStatus == Completed already
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Tag tweak",
+            null,
+            "Completed",
+            null,
+            null);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        workOrder.Status.Should().Be(WorkOrderStatus.Completed);
+        _dbContextMock.Verify(x => x.MaintenanceRequests, Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_StatusChangedToCompleted_LinkedRequestAlreadyResolved_DoesNotTransition()
+    {
+        // AC #8 — Defensive: linked request already Resolved is skipped (no re-transition).
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        var linkedRequest = CreateMaintenanceRequest(
+            accountId: _testAccountId,
+            workOrderId: workOrderId,
+            status: MaintenanceRequestStatus.Resolved);
+
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        SetupMaintenanceRequestsDbSet(linkedRequest);
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Job done",
+            null,
+            "Completed",
+            null,
+            null);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+        workOrder.Status.Should().Be(WorkOrderStatus.Completed);
+        linkedRequest.Status.Should().Be(MaintenanceRequestStatus.Resolved);
+    }
+
+    [Fact]
+    public async Task Handle_StatusChangedToCompleted_LinkedRequestDismissed_ThrowsBusinessRuleException()
+    {
+        // AC #7 — Dismissed source status cannot transition to Resolved.
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        var linkedRequest = CreateMaintenanceRequest(
+            accountId: _testAccountId,
+            workOrderId: workOrderId,
+            status: MaintenanceRequestStatus.Dismissed);
+
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        SetupMaintenanceRequestsDbSet(linkedRequest);
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Job done",
+            null,
+            "Completed",
+            null,
+            null);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<BusinessRuleException>()
+            .WithMessage("*'Dismissed' to 'Resolved'*");
+    }
+
+    [Fact]
+    public async Task Handle_StatusChangedToCompleted_LinkedRequestSubmitted_ThrowsBusinessRuleException()
+    {
+        // AC #7 — Submitted source status cannot transition to Resolved.
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        var linkedRequest = CreateMaintenanceRequest(
+            accountId: _testAccountId,
+            workOrderId: workOrderId,
+            status: MaintenanceRequestStatus.Submitted);
+
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        SetupMaintenanceRequestsDbSet(linkedRequest);
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Job done",
+            null,
+            "Completed",
+            null,
+            null);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<BusinessRuleException>()
+            .WithMessage("*'Submitted' to 'Resolved'*");
+    }
+
+    [Fact]
+    public async Task Handle_StatusChangedToCompleted_LinkedRequestFromDifferentAccount_DoesNotMutate()
+    {
+        // AC #1 + multi-tenancy — cross-account request must be excluded by the AccountId filter.
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        var crossAccountRequest = CreateMaintenanceRequest(
+            accountId: _otherAccountId,
+            workOrderId: workOrderId,
+            status: MaintenanceRequestStatus.InProgress);
+
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        SetupMaintenanceRequestsDbSet(crossAccountRequest);
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Job done",
+            null,
+            "Completed",
+            null,
+            null);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        workOrder.Status.Should().Be(WorkOrderStatus.Completed);
+        // Cross-account row was filtered out — its status remains untouched.
+        crossAccountRequest.Status.Should().Be(MaintenanceRequestStatus.InProgress);
+    }
+
+    [Fact]
+    public async Task Handle_StatusChangedToCompleted_LinkedRequestSoftDeleted_DoesNotMutate()
+    {
+        // Soft-deleted requests must be excluded by the DeletedAt == null filter.
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        var softDeletedRequest = CreateMaintenanceRequest(
+            accountId: _testAccountId,
+            workOrderId: workOrderId,
+            status: MaintenanceRequestStatus.InProgress);
+        softDeletedRequest.DeletedAt = DateTime.UtcNow;
+
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        SetupMaintenanceRequestsDbSet(softDeletedRequest);
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Job done",
+            null,
+            "Completed",
+            null,
+            null);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        workOrder.Status.Should().Be(WorkOrderStatus.Completed);
+        softDeletedRequest.Status.Should().Be(MaintenanceRequestStatus.InProgress);
+    }
+
+    [Fact]
+    public async Task Handle_StatusChangedToCompleted_LinkedRequestTransitions_LoggerCalledOnce()
+    {
+        // AC #9 — A single Information-level log entry mentioning "Linked maintenance request"
+        // is emitted when the sync mutates a linked request.
+        // Arrange
+        var workOrderId = Guid.NewGuid();
+        var workOrder = CreateWorkOrder(workOrderId, _testAccountId);
+        var linkedRequest = CreateMaintenanceRequest(
+            accountId: _testAccountId,
+            workOrderId: workOrderId,
+            status: MaintenanceRequestStatus.InProgress);
+
+        SetupWorkOrderExists(workOrder);
+        SetupTagsExist(Array.Empty<Guid>(), _testAccountId);
+        SetupTagAssignmentsDbSet(new List<WorkOrderTagAssignment>());
+        SetupMaintenanceRequestsDbSet(linkedRequest);
+
+        var command = new UpdateWorkOrderCommand(
+            workOrderId,
+            "Job done",
+            null,
+            "Completed",
+            null,
+            null);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Linked maintenance request")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    private MaintenanceRequest CreateMaintenanceRequest(
+        Guid accountId,
+        Guid workOrderId,
+        MaintenanceRequestStatus status)
+    {
+        return new MaintenanceRequest
+        {
+            Id = Guid.NewGuid(),
+            AccountId = accountId,
+            PropertyId = Guid.NewGuid(),
+            SubmittedByUserId = Guid.NewGuid(),
+            WorkOrderId = workOrderId,
+            Description = "test request",
+            Status = status
+        };
+    }
+
     private WorkOrder CreateWorkOrder(Guid id, Guid accountId)
     {
         return new WorkOrder
@@ -535,5 +903,12 @@ public class UpdateWorkOrderHandlerTests
         var vendors = new List<Vendor>();
         var mockDbSet = vendors.BuildMockDbSet();
         _dbContextMock.Setup(x => x.Vendors).Returns(mockDbSet.Object);
+    }
+
+    private void SetupMaintenanceRequestsDbSet(params MaintenanceRequest[] requests)
+    {
+        var list = requests.ToList();
+        var mockDbSet = list.BuildMockDbSet();
+        _dbContextMock.Setup(x => x.MaintenanceRequests).Returns(mockDbSet.Object);
     }
 }

--- a/docs/project/sprint-status.yaml
+++ b/docs/project/sprint-status.yaml
@@ -334,7 +334,7 @@ development_status:
   20-7-landlord-maintenance-request-inbox: done    # FR-TP12 - Size 5
   20-8-convert-request-to-work-order: done    # FR-TP13, FR-TP14, FR-TP16 - Size 5
   20-9-dismiss-maintenance-request: done    # FR-TP15, FR-TP16 - Size 5
-  20-10-request-resolution-sync: backlog    # FR-TP17 - Size 3
+  20-10-request-resolution-sync: done    # FR-TP17 - Size 3
   20-11-tenant-authorization-lockdown: backlog    # NFR-TP1, NFR-TP2, NFR-TP3 - Size 5
 
   # ============================================================

--- a/docs/project/stories/epic-20/20-10-request-resolution-sync.md
+++ b/docs/project/stories/epic-20/20-10-request-resolution-sync.md
@@ -1,0 +1,508 @@
+# Story 20.10: Request Resolution Sync
+
+Status: done
+
+## Story
+
+As a tenant,
+I want my maintenance request to show "Resolved" when the landlord completes the associated work order,
+so that I know the issue has been fixed without checking with the landlord.
+
+## Acceptance Criteria
+
+1. **Given** a `WorkOrder` linked to a `MaintenanceRequest` (i.e., the maintenance request's `WorkOrderId == workOrder.Id` and `request.Status == InProgress`),
+   **When** the landlord updates the work order's status to `Completed` via `PUT /api/v1/work-orders/{id}` (the only status-change endpoint — used by both the inline status dropdown from Story 17-10 and the edit form),
+   **And** the request status changes from a non-Completed value to `Completed` in the same handler call,
+   **Then** the linked maintenance request's `Status` is automatically set to `Resolved` via `MaintenanceRequest.TransitionTo(MaintenanceRequestStatus.Resolved)` (enforcing the `InProgress → Resolved` rule) within the same `SaveChangesAsync` transaction. (AC-20.10.1)
+
+2. **Given** a `WorkOrder` linked to a `MaintenanceRequest`,
+   **When** the work order's status changes to any value other than `Completed` (e.g., `Reported`, `Assigned`),
+   **Then** the linked maintenance request's `Status` is NOT modified by the work-order update handler — its status remains whatever it was (typically `InProgress` after Story 20.8 conversion). (AC-20.10.2)
+
+3. **Given** a `WorkOrder` whose status is already `Completed`,
+   **When** the landlord submits another `PUT /api/v1/work-orders/{id}` payload with `status = "Completed"` (a no-op status update — e.g., a tag/description edit that keeps the status the same),
+   **Then** the linked maintenance request is NOT touched (no second `TransitionTo` call). The sync is gated on the work order's status *transitioning to* `Completed`, not on the status value itself. This avoids `BusinessRuleException` when the request is already `Resolved` (the state machine has no `Resolved → Resolved` transition). (AC-20.10.1 corollary)
+
+4. **Given** a `WorkOrder` that is NOT linked to a maintenance request (`WorkOrderId` is `null` on every row in `MaintenanceRequests` for that work-order id, OR equivalently, no maintenance request exists with `WorkOrderId == workOrder.Id && DeletedAt == null`),
+   **When** the work order's status is changed to `Completed` (or any other status),
+   **Then** no maintenance request lookup-and-mutate occurs (no exception thrown, no extra DB roundtrip if the linked request is not in scope). All work-order updates that have always succeeded continue to succeed identically — full backward compatibility. (AC-20.10.4)
+
+5. **Given** a tenant viewing their maintenance request in the tenant dashboard,
+   **When** the dashboard reloads after the landlord completes the linked work order,
+   **Then** the tenant sees the status displayed as `Resolved` (English-cased; the tenant dashboard `getStatusLabel` already handles `Resolved` → "Resolved"). (AC-20.10.3)
+
+6. **Given** a landlord viewing the maintenance request detail page in the landlord inbox after completing the linked work order,
+   **When** the detail page reloads (via store `loadRequestById`),
+   **Then** the status chip shows `Resolved` (status-resolved CSS class), the `Convert to Work Order` and `Dismiss` buttons remain hidden (they are gated on `status === 'Submitted'`), and the existing linked-work-order chip continues to link to the now-completed work order.
+
+7. **Given** the work-order status transitions to `Completed` for a linked maintenance request whose current status is NOT `InProgress` (e.g., a manually-corrupted request with `Status = Dismissed` and a non-null `WorkOrderId` — an edge case),
+   **When** the handler attempts `request.TransitionTo(Resolved)`,
+   **Then** the entity throws `BusinessRuleException("Cannot transition maintenance request from 'Dismissed' to 'Resolved'.")` which propagates up through the handler and is mapped to `400 Bad Request` by `GlobalExceptionHandlerMiddleware`. The work-order update is rolled back via the implicit `SaveChanges` transaction (EF Core wraps multiple operations in one transaction by default — verified via Ref MCP, see References). The landlord sees a 400 error and the work order's status is unchanged. This proves the state machine and the data layer remain consistent on the edge case path.
+
+8. **Given** the work-order status transitions to `Completed` for a linked maintenance request that is already `Resolved` (defensive — should not happen under normal flow because the `Resolved` transition can only originate from this sync),
+   **When** the sync logic runs,
+   **Then** the sync is a no-op (the request is NOT re-transitioned to `Resolved` — the entity's state machine has no `Resolved → Resolved` transition and would throw). Guard the sync with `if (request.Status != MaintenanceRequestStatus.Resolved)`. (AC-20.10.1 corollary)
+
+9. **Given** the structured logging in the handler,
+   **When** the sync mutates a linked maintenance request,
+   **Then** a single `_logger.LogInformation("Linked maintenance request {RequestId} marked Resolved due to work order {WorkOrderId} completion", ...)` line is emitted after the entity transition and before `SaveChangesAsync`. No tenant-personal data is logged (no description, no submitter info).
+
+10. **Given** a tenant attempting `PUT /api/v1/work-orders/{id}` (which would be the only way to trigger the sync from the tenant side),
+    **When** the tenant is authenticated as `Tenant` role,
+    **Then** the endpoint returns `403 Forbidden` per the existing `CanManageWorkOrders` policy (Tenant lacks `WorkOrders.Update`). The sync code path is therefore unreachable by tenants — no new authorization work is required.
+
+11. **Given** a `WorkOrder` with no linked maintenance request — i.e., one created via the standard work-order form, not via the convert flow,
+    **When** the landlord changes its status from `Assigned` to `Completed`,
+    **Then** the handler does NOT make a maintenance-request lookup query AT ALL (the lookup must be conditional on the transition being to `Completed`, not on every PUT). Specifically: the handler issues the maintenance-request `FirstOrDefaultAsync` only when (a) the inbound status is `Completed` AND (b) the current `workOrder.Status` was different (i.e., a true transition). This keeps the no-op cost at zero extra queries for the overwhelmingly common case (description / tag / vendor edits, status to non-Completed values).
+
+12. **Given** the existing `UpdateWorkOrderCommandHandler` unit tests in `backend/tests/PropertyManager.Application.Tests/WorkOrders/UpdateWorkOrderHandlerTests.cs`,
+    **When** the new sync logic is added,
+    **Then** every existing test continues to pass with zero modifications (backward compatibility — see AC #4). The new tests are added to the existing test class via new `[Fact]`/`[Theory]` methods using the existing test setup helpers.
+
+13. **Given** an unlinked work order whose status transitions to `Completed`,
+    **When** the handler attempts the conditional `MaintenanceRequests.FirstOrDefaultAsync(...)` lookup,
+    **Then** the lookup returns `null`, the handler skips the sync block, and the work-order update proceeds normally (this is the path covered by AC #4; it adds ONE extra DB query when transitioning to `Completed` — acceptable cost because completing a work order is a rare event compared to the other field edits).
+
+## Tasks / Subtasks
+
+- [x] Task 1: Backend — Extend `UpdateWorkOrderCommandHandler` with the sync block (AC #1, #2, #3, #4, #7, #8, #11, #13)
+  - [x] 1.1 Open `backend/src/PropertyManager.Application/WorkOrders/UpdateWorkOrder.cs`.
+  - [x] 1.2 Capture the **prior** work-order status BEFORE the status-parsing block. After `workOrder` is loaded:
+    ```csharp
+    var priorStatus = workOrder.Status;
+    ```
+  - [x] 1.3 Keep the existing status-parsing block exactly as-is (lines 98–104). It sets `workOrder.Status = status` when the inbound status is parseable. The sync logic runs AFTER this assignment but BEFORE the `SaveChangesAsync` call so both writes flush atomically per EF's default transaction wrap (see Dev Notes "Transactionality").
+  - [x] 1.4 Immediately after the existing status-parsing block (and AFTER the tag-assignment block that ends ~line 121), add the sync block — placed RIGHT BEFORE the final `await _dbContext.SaveChangesAsync(cancellationToken);` so the linked-request update is part of the same `SaveChanges` flush:
+    ```csharp
+    // Story 20.10: Sync linked MaintenanceRequest to Resolved when this WO transitions
+    // from a non-Completed status to Completed. Guarded transition-only (AC #3): a no-op
+    // PUT that keeps Completed → Completed does NOT trigger the sync. Unlinked work orders
+    // and non-Completed transitions skip the lookup entirely (AC #4, #11).
+    if (workOrder.Status == WorkOrderStatus.Completed
+        && priorStatus != WorkOrderStatus.Completed)
+    {
+        var linkedRequest = await _dbContext.MaintenanceRequests
+            .FirstOrDefaultAsync(
+                mr => mr.WorkOrderId == workOrder.Id
+                    && mr.AccountId == _currentUser.AccountId
+                    && mr.DeletedAt == null,
+                cancellationToken);
+
+        if (linkedRequest != null && linkedRequest.Status != MaintenanceRequestStatus.Resolved)
+        {
+            // Domain enforces InProgress → Resolved. Any other source status throws
+            // BusinessRuleException → 400 (AC #7) and rolls back the WO update via EF's
+            // implicit SaveChanges transaction.
+            linkedRequest.TransitionTo(MaintenanceRequestStatus.Resolved);
+
+            _logger.LogInformation(
+                "Linked maintenance request {RequestId} marked Resolved due to work order {WorkOrderId} completion",
+                linkedRequest.Id,
+                workOrder.Id);
+        }
+    }
+    ```
+  - [x] 1.5 Inject `ILogger<UpdateWorkOrderCommandHandler>` via constructor (the existing handler has no logger). Add the field `private readonly ILogger<UpdateWorkOrderCommandHandler> _logger;` and pass through the constructor. Update DI is automatic via `Microsoft.Extensions.Logging`.
+  - [x] 1.6 Do NOT add an explicit `using var transaction = await _dbContext.Database.BeginTransactionAsync(...)`. EF Core wraps all operations in a single `SaveChanges` call in one transaction by default (verified via Ref MCP — see References). This is structurally identical to the existing handler's single-save pattern. If `TransitionTo` throws, the entire `SaveChanges` (including the work-order field updates) rolls back atomically — verified by integration test in Task 8.
+  - [x] 1.7 Verify no `using` is missing for the new types: `PropertyManager.Domain.Enums` (`MaintenanceRequestStatus`) is already imported; confirm `using Microsoft.Extensions.Logging;` is added if not present.
+  - [x] 1.8 Do NOT add try/catch — domain exceptions flow to `GlobalExceptionHandlerMiddleware` per project-context anti-patterns.
+
+- [x] Task 2: Backend — Unit tests in `UpdateWorkOrderHandlerTests.cs` (AC #1, #2, #3, #4, #7, #8, #11, #12, #13)
+  - [x] 2.1 Open `backend/tests/PropertyManager.Application.Tests/WorkOrders/UpdateWorkOrderHandlerTests.cs`. Add `using PropertyManager.Domain.Entities;` (already present) and `using Microsoft.Extensions.Logging;` to support the new `ILogger` injection.
+  - [x] 2.2 Update the test class field declarations to add a logger mock:
+    ```csharp
+    private readonly Mock<ILogger<UpdateWorkOrderCommandHandler>> _loggerMock;
+    ```
+    And in the constructor: `_loggerMock = new Mock<ILogger<UpdateWorkOrderCommandHandler>>();` + pass `_loggerMock.Object` to the handler constructor.
+  - [x] 2.3 Add helper `SetupMaintenanceRequestsDbSet(params MaintenanceRequest[] requests)` mirroring `SetupTagAssignmentsDbSet`:
+    ```csharp
+    private void SetupMaintenanceRequestsDbSet(params MaintenanceRequest[] requests)
+    {
+        var list = requests.ToList();
+        var mockDbSet = list.BuildMockDbSet();
+        _dbContextMock.Setup(x => x.MaintenanceRequests).Returns(mockDbSet.Object);
+    }
+    ```
+    Add inside the `private` helper region near the bottom of the file. For tests that don't touch the sync block, default to seeding an empty list via this helper (or skip — see 2.4 step note).
+  - [x] 2.4 Update the `SetupWorkOrderExists` flow used by existing tests: where a test will execute the sync block (status becomes Completed AND priorStatus was different), explicitly call `SetupMaintenanceRequestsDbSet(...)` BEFORE the handler `Handle` call. For tests that update fields without a status transition or transition to non-Completed values, no `SetupMaintenanceRequestsDbSet` is needed because the sync block early-exits before touching `_dbContext.MaintenanceRequests`. Verify this by reading the handler — the `MaintenanceRequests` access lives inside the `if (workOrder.Status == Completed && priorStatus != Completed)` guard.
+  - [x] 2.5 Add a new `#region Sync Resolution Tests (Story 20-10)` block at the bottom of the test class (before the helper region) containing:
+    - `Handle_StatusChangedToCompleted_WithLinkedRequest_TransitionsRequestToResolved` — Arrange: WO with `Status = Assigned` + linked MR `Status = InProgress`, `WorkOrderId = WO.Id`. Act: PUT with `status = "Completed"`. Assert: `linkedRequest.Status == Resolved`, `_dbContextMock.Verify(x => x.SaveChangesAsync(...), Times.Once)`, `_loggerMock.Verify(x => x.Log(LogLevel.Information, ...), Times.AtLeastOnce)` (or count the `Linked maintenance request` log message specifically using a callback). (AC #1)
+    - `Handle_StatusChangedToCompleted_NoLinkedRequest_DoesNotThrow_AndDoesNotQueryMaintenanceRequests` — Arrange: WO with `Status = Assigned`, NO linked MR (`SetupMaintenanceRequestsDbSet()` with empty list). Act: PUT with `status = "Completed"`. Assert: handler completes successfully, `workOrder.Status == Completed`, `_dbContextMock.Verify(x => x.MaintenanceRequests, Times.Once)` (the lookup IS made, returns null). (AC #4, #13)
+    - `Handle_StatusChangedToAssigned_DoesNotQueryMaintenanceRequests` — Arrange: WO with `Status = Reported` + linked MR `Status = InProgress`. Act: PUT with `status = "Assigned"`. Assert: `linkedRequest.Status == InProgress` (unchanged), `_dbContextMock.Verify(x => x.MaintenanceRequests, Times.Never)` — proves the lookup is skipped for non-Completed transitions. (AC #2, #11)
+    - `Handle_StatusUnchanged_Completed_DoesNotQueryMaintenanceRequests` — Arrange: WO already `Status = Completed`. Act: PUT with `status = "Completed"` (no-op edit). Assert: linked MR unchanged, `_dbContextMock.Verify(x => x.MaintenanceRequests, Times.Never)`. (AC #3)
+    - `Handle_StatusChangedToCompleted_LinkedRequestAlreadyResolved_DoesNotTransition` — Arrange: WO `Status = Assigned` + linked MR `Status = Resolved`. Act: PUT with `status = "Completed"`. Assert: `linkedRequest.Status == Resolved` (unchanged), no exception, `workOrder.Status == Completed`. (AC #8)
+    - `Handle_StatusChangedToCompleted_LinkedRequestDismissed_ThrowsBusinessRuleException` — Arrange: WO `Status = Assigned` + linked MR `Status = Dismissed`. Act: PUT with `status = "Completed"`. Assert: `BusinessRuleException` with message containing `"'Dismissed' to 'Resolved'"`. (AC #7)
+    - `Handle_StatusChangedToCompleted_LinkedRequestSubmitted_ThrowsBusinessRuleException` — Arrange: WO `Status = Assigned` + linked MR `Status = Submitted`, `WorkOrderId = WO.Id` (defensive — should not happen under normal flow). Act: PUT with `status = "Completed"`. Assert: `BusinessRuleException` with message containing `"'Submitted' to 'Resolved'"`. (AC #7)
+    - `Handle_StatusChangedToCompleted_LinkedRequestFromDifferentAccount_DoesNotMutate` — Arrange: WO with `AccountId = _testAccountId`, linked MR with `AccountId = _otherAccountId`. Act: PUT with `status = "Completed"`. Assert: `linkedRequest.Status` unchanged (the AccountId filter in the handler's lookup excludes the cross-account row, returning null). This proves the multi-tenant boundary holds for the sync path. (AC #1 + multi-tenancy)
+    - `Handle_StatusChangedToCompleted_LinkedRequestSoftDeleted_DoesNotMutate` — Arrange: linked MR with `DeletedAt = DateTime.UtcNow`. Act: PUT with `status = "Completed"`. Assert: MR unchanged (the `mr.DeletedAt == null` filter excludes it).
+    - `Handle_StatusChangedToCompleted_LinkedRequestTransitions_LoggerCalledOnce` — Arrange: WO + linked MR as in the happy path. Act: PUT. Assert: the logger received an information-level call whose message template contains `"Linked maintenance request"` exactly once (use `_loggerMock.Verify` with the callback pattern from existing tests). (AC #9)
+  - [x] 2.6 Each test sets `workOrder.Id = Guid.NewGuid()` BEFORE creating the linked MR with `WorkOrderId = workOrder.Id` so the join condition matches. The existing `CreateWorkOrder` helper assigns an Id — confirm by reading.
+
+- [x] Task 3: Backend — Domain entity confirmation (AC #1, #7, #8)
+  - [x] 3.1 No domain code change. `MaintenanceRequest.TransitionTo(Resolved)` (lines 39–56 of `MaintenanceRequest.cs`) already enforces `InProgress → Resolved` and throws `BusinessRuleException` for any other source status. The story 20.3 entity tests already cover `InProgress → Resolved` success and the failure paths from `Submitted`/`Dismissed`/`Resolved` sources — no new entity unit tests are required.
+  - [x] 3.2 Confirm in the Dev Notes that the sync block calls `TransitionTo` AFTER the guard `linkedRequest.Status != Resolved` so the `Resolved → Resolved` self-transition is never attempted (the state machine would throw).
+
+- [x] Task 4: Backend — `dotnet build` + `dotnet test` (gate)
+  - [x] 4.1 `cd backend && dotnet build` — zero errors. Cite warning count if any.
+  - [x] 4.2 `cd backend && dotnet test` — all unit tests pass including the new ones. Cite the total count and the per-project breakdown in the Dev Agent Record (latest baseline from Story 20.9: ~2196 tests).
+
+- [x] Task 5: Backend — Integration tests (AC #1, #2, #4, #5, #7, #10)
+  - [x] 5.1 Append a new region to `backend/tests/PropertyManager.Api.Tests/WorkOrdersControllerTests.cs` titled `// PUT /api/v1/work-orders/{id} — Story 20.10 resolution sync (AC #1, #2, #4, #7, #10)`. Reuse existing helpers: `CreateTestUserAsync`, `CreatePropertyInAccountAsync`, `CreateTenantUserInAccountAsync`, `LoginAsync`, `PutAsJsonWithAuthAsync`, `GetWithAuthAsync`, and the existing WO create flow (`PostAsJsonWithAuthAsync` against `/api/v1/work-orders`).
+  - [x] 5.2 Add a local helper `SeedMaintenanceRequestLinkedToAsync(Guid accountId, Guid propertyId, Guid submittedByUserId, Guid workOrderId, MaintenanceRequestStatus status = MaintenanceRequestStatus.InProgress)` modeled on the helper in `MaintenanceRequestsControllerTests.SeedMaintenanceRequestAsync` (lines 1467–1490). The Id of the WO comes from the create-WO response. **Direct DB seed is preferred** over invoking the convert endpoint because convert is its own story-under-test; we want this story's tests isolated.
+  - [x] 5.3 Tests (each test creates its own throwaway owner via `CreateTestUserAsync(Guid.NewGuid() + "@test")`):
+    - `UpdateWorkOrder_StatusToCompleted_WithLinkedRequest_MarksRequestResolved` — seed WO (Reported) + linked MR (InProgress). PUT with `status = "Completed"`. Assert: 204; query DB → WO `Status = Completed`, MR `Status = Resolved`. (AC #1, #5)
+    - `UpdateWorkOrder_StatusToCompleted_NoLinkedRequest_StillSucceeds` — seed WO (Assigned), no MR. PUT with `status = "Completed"`. Assert: 204; query DB → WO `Status = Completed`. (AC #4)
+    - `UpdateWorkOrder_StatusToAssigned_DoesNotModifyLinkedRequest` — seed WO (Reported) + linked MR (InProgress). PUT with `status = "Assigned"`. Assert: 204; query DB → WO `Status = Assigned`, MR `Status = InProgress`. (AC #2)
+    - `UpdateWorkOrder_NoOpStatusCompleted_DoesNotRetransitionRequest` — seed WO (Completed) + linked MR (Resolved). PUT with `status = "Completed"` (no transition). Assert: 204; query DB → WO + MR unchanged. (AC #3)
+    - `UpdateWorkOrder_StatusToCompleted_LinkedRequestDismissed_Returns400_RollsBackWO` — seed WO (Assigned) + linked MR (`Dismissed`, with `WorkOrderId` set — defensive edge). PUT with `status = "Completed"`. Assert: 400, problem-details body contains `"Dismissed"` and `"Resolved"`; query DB → WO `Status` is STILL `Assigned` (rollback verified — proves AC #7 transactional rollback). MR `Status` still `Dismissed`.
+    - `UpdateWorkOrder_StatusToCompleted_AsTenant_Returns403` — seed tenant. PUT `/api/v1/work-orders/{id}` with tenant token. Assert: 403 (existing `CanManageWorkOrders` policy denies — confirms AC #10).
+    - `UpdateWorkOrder_StatusToCompleted_LinkedRequestFromDifferentAccount_DoesNotMutateCross_Account` — seed Owner A's WO + linked MR; create Owner B; ensure that a forged MR with B's accountId but A's WorkOrderId is not touched (or simply assert that a properly-linked MR in account A IS resolved while an unrelated MR in account B is not). Confirms multi-tenant isolation in the sync path.
+  - [x] 5.4 For DB introspection use the existing pattern from `MaintenanceRequestsControllerTests`:
+    ```csharp
+    using var scope = _factory.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    var mr = await db.MaintenanceRequests.IgnoreQueryFilters()
+        .FirstAsync(x => x.Id == requestId);
+    mr.Status.Should().Be(MaintenanceRequestStatus.Resolved);
+    ```
+    `IgnoreQueryFilters()` is essential when querying across accounts for the multi-tenant assertion test.
+
+- [x] Task 6: Frontend — Tenant dashboard read-side regression check (AC #5)
+  - [x] 6.1 Read `frontend/src/app/features/tenant-dashboard/tenant-dashboard.component.ts` lines 66–86 to confirm `getStatusColor` and `getStatusLabel` already handle the `Resolved` value (they do per the grep at story-authoring time — case `'Resolved'` returns `'accent'` / no special label transform, so display reads `"Resolved"`).
+  - [x] 6.2 Read `frontend/src/app/features/tenant-dashboard/components/request-detail/request-detail.component.html` to confirm the status binding works for `Resolved`. **Expectation: no frontend code change required.** Story 20.5 wired the four-status display, and 20.7 added the badge styles for all four statuses on the landlord side. Confirm in Dev Agent Record.
+  - [x] 6.3 If somehow a status case is missing, add it via a small follow-up commit — but **expectation is no change** because the enum has always had `Resolved` (per Story 20.3).
+
+- [x] Task 7: Frontend — Landlord detail page read-side regression check (AC #6)
+  - [x] 7.1 Read `frontend/src/app/features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component.ts` lines 95 (`[class.status-resolved]`) and the styles block (lines 319–353) to confirm `status-resolved` CSS exists and the chip renders correctly. **Expectation: no change.**
+  - [x] 7.2 Confirm the `Convert to Work Order` and `Dismiss` buttons are gated on `req.status === 'Submitted'` (line 52 region) — they will be hidden for `Resolved`. No change needed.
+
+- [x] Task 8: Frontend — Unit test for tenant dashboard / detail components is NOT required
+  - [x] 8.1 No new frontend logic ships in this story (the resolution sync is server-side). The existing unit tests for `tenant-dashboard.component.spec.ts` and `request-detail.component.spec.ts` already exercise the `Resolved` status path (per Story 20.5). Re-running them as part of the existing test suite is sufficient — no new spec methods needed.
+  - [x] 8.2 If a test happens to fail when `Resolved` is rendered (unlikely), fix at that time as a regression. Document in Dev Agent Record.
+
+- [x] Task 9: Frontend — Vitest + ng build gate (AC: read-side regression only)
+  - [x] 9.1 `cd frontend && npm test` — all suites pass (no new specs; verify the existing `Resolved` paths still render).
+  - [x] 9.2 `cd frontend && ng build` — clean production build. Expected initial bundle ~580 kB (same as 20-9 baseline; this story adds zero frontend code).
+
+- [x] Task 10: E2E — Playwright resolution-sync flow (AC #1, #5, #6)
+  - [x] 10.1 Create `frontend/e2e/tests/maintenance-requests/resolution-sync.spec.ts` with TWO specs (this is a SIZE 3 story — keep E2E minimal but cover the end-to-end contract):
+    - **Spec 1 — Happy path: landlord completes WO → tenant sees Resolved (AC #1, #5):**
+      1. Use `createLandlordViaInvitation` + `setupTenantContext` from `frontend/e2e/helpers/tenant.helper.ts`.
+      2. Tenant submits maintenance request via `submitMaintenanceRequestViaApi`.
+      3. Landlord logs in, navigates to inbox, opens detail, clicks Convert (use the existing `ConvertRequestDialogPage`), submits Convert dialog — now MR is `InProgress` and a WO exists.
+      4. Landlord navigates to `/work-orders/{workOrderId}` (URL captured from the navigation after convert), changes status dropdown to `Completed` (inline status dropdown from Story 17-10).
+      5. Landlord navigates BACK to `/maintenance-requests/{requestId}` — assert status chip reads `Resolved` (use `[data-testid="status-chip"]` selector with text "Resolved").
+      6. Clear cookies + local storage on the same `page` context (pattern from Story 20.8 spec 3). `loginAsTenant`. Navigate to `/tenant`. Assert the request row shows `Resolved`.
+    - **Spec 2 — Status change to a non-Completed value does NOT change MR (AC #2):**
+      1. Same setup through the Convert step — MR is `InProgress`, WO is `Reported` (the default after convert).
+      2. Landlord navigates to the WO detail, changes status to `Assigned` (NOT `Completed`).
+      3. Landlord navigates to the MR detail. Assert status chip is still `In Progress` (i.e., NOT `Resolved`).
+  - [x] 10.2 Reuse the existing `ConvertRequestDialogPage` (Story 20.8) and the existing work-order detail status dropdown (Story 17-10). No new page object needed.
+  - [x] 10.3 Each spec uses unique data names (`Date.now()` + `Math.random().toString(36).slice(2,8)`) per the test-isolation pattern carried from Stories 20.7/20.8/20.9.
+  - [x] 10.4 Note: the WO detail page status dropdown is `<mat-select>` — use the `mat-select` selector and the option list pattern from Story 17-10's E2E (if exists). If a page object isn't available, do the click flow inline:
+    ```ts
+    await page.locator('mat-select').first().click();
+    await page.locator(`mat-option:has-text("Completed")`).click();
+    await page.waitForResponse(r => r.url().includes('/api/v1/work-orders/') && r.request().method() === 'PUT');
+    ```
+    Wait for the snackbar `"Status updated"` to confirm the PUT succeeded before navigating back.
+
+- [x] Task 11: Sprint status (Process)
+  - [x] 11.1 Update `docs/project/sprint-status.yaml`: `20-10-request-resolution-sync: ready-for-dev` → flip to `in-progress` at dev start, then `review` when work + smoke is green (the `/dev-story` workflow handles this; story-creation only sets `ready-for-dev`).
+
+## Dev Notes
+
+### Backend: Why the Sync Lives in `UpdateWorkOrderCommandHandler`
+
+The epic-20 Technical Note for Story 20.10 says: *"Modify existing UpdateWorkOrderStatus handler to check for linked maintenance request."* There is no separate `UpdateWorkOrderStatus` handler — the codebase has a single `UpdateWorkOrderCommandHandler` (in `WorkOrders/UpdateWorkOrder.cs`) that handles ALL work-order field updates including status, called from the controller's `PUT /api/v1/work-orders/{id}` endpoint. The inline status dropdown from Story 17-10 uses the same endpoint (it just sends a payload where only `status` differs). So this story's sync logic belongs in `UpdateWorkOrderCommandHandler` — there is no other status-change pathway to wire.
+
+### Backend: Why Not an Event / Domain Event / Notification
+
+Per epic-20 Technical Notes: *"Keep it simple: synchronous update in the same transaction, not event-driven."* The codebase has no existing domain-event infrastructure (no `INotification`, no `IMediator.Publish` calls for entity lifecycle). Introducing one for a single cross-aggregate sync would be over-engineering. The synchronous block is ~15 lines and is trivially testable.
+
+### Backend: Transactionality (Verified via Ref MCP)
+
+`SaveChanges` in EF Core is transactional by default — *"all the operations either succeed or fail and the operations are never left partially applied."* (Microsoft Learn — `https://learn.microsoft.com/en-us/ef/core/saving/basic#multiple-operations-in-a-single-savechanges`). We do NOT need `await using var transaction = await _dbContext.Database.BeginTransactionAsync(...)` for this handler — both the work-order field mutations AND the maintenance-request `TransitionTo` flush in one `SaveChanges` call, wrapped in one implicit transaction. If `TransitionTo` throws (AC #7), the in-memory change to `workOrder.Status` is discarded because `SaveChanges` is never called (exception fires before the call). Integration test `UpdateWorkOrder_StatusToCompleted_LinkedRequestDismissed_Returns400_RollsBackWO` proves this end-to-end.
+
+This is structurally identical to the existing handler's "single SaveChanges" shape (Story 20.9 dismiss is the closest precedent), and intentionally simpler than Story 20.8 convert which DID use an explicit transaction because it needed two SaveChanges calls for FK sequencing.
+
+### Backend: Conditional Lookup — Why the Guard
+
+The naïve implementation would be `var linkedRequest = await _dbContext.MaintenanceRequests.FirstOrDefaultAsync(mr => mr.WorkOrderId == workOrder.Id ...)` on EVERY update. That's a wasted DB roundtrip for description / tag / vendor edits and non-Completed status transitions — by far the most common update shape.
+
+The guarded form `if (workOrder.Status == Completed && priorStatus != Completed)` ensures the lookup only happens when the WO actually transitions INTO Completed. This is:
+
+1. **Free for unlinked WOs** — most WOs are not linked to MRs (a landlord creates WOs directly far more often than tenants submit MR-driven ones).
+2. **Free for non-status edits** — the common case of "update description / add tags" never touches the lookup.
+3. **Free for no-op status saves** — re-saving an already-Completed WO does nothing.
+
+For the rare case where a status transitions to Completed, ONE extra `FirstOrDefaultAsync` is acceptable.
+
+### Backend: Why Guard `linkedRequest.Status != Resolved`
+
+Defensive. The only normal path to `Resolved` is THIS sync code, so under normal flow the linked MR will never already be `Resolved` when the sync fires. But:
+
+- A landlord could theoretically toggle status `Completed → Assigned → Completed` (a "re-complete"). The first toggle to `Completed` resolves the MR. The toggle back to `Assigned` does NOT un-resolve (no sync code runs because the transition is to a non-Completed status — AC #2). The second toggle to `Completed` would attempt `TransitionTo(Resolved)` on an already-`Resolved` MR, which the entity rejects with `BusinessRuleException`.
+- Without the guard, the second toggle would surface as a confusing 400 to the user. With the guard, it's a clean no-op.
+
+Per AC #8 — this is explicitly tested.
+
+### Backend: Logger Injection — Existing Handler Has None
+
+The current `UpdateWorkOrderCommandHandler` does not inject `ILogger`. We add it for the structured log line `"Linked maintenance request {RequestId} marked Resolved due to work order {WorkOrderId} completion"` (AC #9). This is a minor constructor signature change — verify the controller `WorkOrdersController` does NOT manually instantiate the handler (it doesn't — MediatR resolves it via DI, so the new logger dependency is auto-injected).
+
+### Backend: AccountId Filter on the Sync Lookup
+
+The maintenance-request lookup includes `mr.AccountId == _currentUser.AccountId` explicitly even though the EF global query filter would do it automatically. **Reason**: the work-order lookup at the top of the handler already uses an explicit `wo.AccountId == _currentUser.AccountId` predicate for the same reason (defense in depth + readability). Match the existing style.
+
+`mr.DeletedAt == null` is also explicit — soft-deleted MRs (if any) are skipped. Global filter handles this too but explicit-is-better-than-implicit per the project's standing pattern.
+
+### Backend: Test Helper — Mock Logger Pattern
+
+Existing tests in the codebase mock `ILogger<T>` as `Mock<ILogger<T>>`. To verify a specific log call, use:
+
+```csharp
+_loggerMock.Verify(
+    x => x.Log(
+        LogLevel.Information,
+        It.IsAny<EventId>(),
+        It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Linked maintenance request")),
+        It.IsAny<Exception>(),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+    Times.Once);
+```
+
+This pattern is used elsewhere (search the test project for `It.Is<It.IsAnyType>` examples — confirmed present in earlier handler tests).
+
+### Frontend: Zero Code, Just Verification
+
+The tenant dashboard, request-detail components, and landlord detail page all already render `Resolved` per Story 20.5 and 20.7 (the four statuses were wired then). This story adds zero frontend code — Task 6 + Task 7 are explicit verification steps to confirm the read-side handles `Resolved` correctly. The existing CSS class `.status-resolved` exists in both components. The status chip displays "Resolved" via `getStatusLabel` which falls through to the raw status string for `Resolved` (only `InProgress` gets the space-inserted `"In Progress"` transformation).
+
+### Status Transition State Machine Recap
+
+```
+Submitted -> InProgress   (Story 20.8 convert)
+Submitted -> Dismissed    (Story 20.9 dismiss)
+InProgress -> Resolved    (Story 20.10 — THIS STORY, via WO Completion)
+```
+
+There are no other transitions. The defensive `if (linkedRequest.Status != Resolved)` guard handles the no-op self-transition. Any other source status triggers `BusinessRuleException` — the integration test for the `Dismissed → Resolved` edge case demonstrates the 400 + rollback contract.
+
+### Why No SignalR Push for Tenant Status Updates
+
+Same trade-off as Stories 20.8 and 20.9 — the tenant sees the resolution on next dashboard load. Building real-time push is deferred (epic-level scope decision). AC #5 is satisfied by the tenant navigating to / reloading the dashboard after the landlord completes the WO. The E2E spec 1 makes the reload explicit (clear cookies + storage, fresh `loginAsTenant`).
+
+### Test Scope Assessment (Testing Pyramid)
+
+- **Unit tests (xUnit, backend) — REQUIRED.** The sync logic is conditional with several branches (status transitions to Completed vs other / linked vs unlinked / MR source status InProgress vs Resolved vs others / cross-account). Unit tests in `UpdateWorkOrderHandlerTests.cs` are the cheapest, most exhaustive coverage layer. Task 2 enumerates 10 specific test cases mapped to ACs.
+
+- **Unit tests (Vitest, frontend) — NOT REQUIRED.** This story adds ZERO new frontend code. The existing component specs for tenant-dashboard, request-detail, and maintenance-request-detail already exercise the `Resolved` rendering path. Re-running them in the suite is sufficient. Task 8 explicitly justifies the skip.
+
+- **Integration tests (WebApplicationFactory, backend) — REQUIRED.** The sync runs on a real EF Core context with real query filters and real transaction semantics. Integration tests prove (a) the cross-aggregate write commits atomically, (b) the BusinessRuleException-triggered rollback actually rolls the WO change back at the DB level, (c) the multi-tenant filter holds across the sync path, (d) the tenant 403 path is unaffected. Unit tests with mocks cannot verify any of these — they would falsely pass even if the transaction model were broken. Task 5 covers 7 integration tests.
+
+- **E2E tests (Playwright) — REQUIRED.** The story's user-visible promise is "tenant sees Resolved after landlord completes the WO" — this is a multi-screen, multi-role workflow that crosses the convert flow, the WO detail page, and the tenant dashboard. Without E2E, we have no proof the chain works end to end. Two specs in Task 10 cover the happy path and the negative path (non-Completed status does NOT propagate).
+
+This story is a clear case of "backend-heavy, frontend-zero" — the testing pyramid is shaped accordingly: many unit + integration backend tests, no new frontend unit tests, minimal but essential E2E specs.
+
+### Previous Story Intelligence
+
+From **Story 20.3**:
+- `MaintenanceRequest.TransitionTo` is the single source of truth for status changes. Throws `BusinessRuleException` mapped to 400 by `GlobalExceptionHandlerMiddleware`.
+- `MaintenanceRequest.WorkOrderId` is nullable `Guid?`. Indexed (used by 20.7 inbox queries) — the linked-request lookup in this story will use that index efficiently.
+- The DTO's `Status` is serialized as the enum string (`"Resolved"`), matching the frontend's CSS class expectations.
+- Migrations: no new schema; the `WorkOrderId` FK + `Status` column exist since Story 20.3.
+
+From **Story 20.7**:
+- The landlord detail page status chip handles all four enum values (Submitted/InProgress/Resolved/Dismissed) via `[class.status-resolved]`-style bindings (read at story-authoring time, confirmed line 95).
+- The store's `loadRequestById` already triggers a fresh GET — the landlord just needs to revisit the request page to see the synced status.
+
+From **Story 20.8 (Convert)**:
+- The convert handler is what wires `WorkOrderId` onto the maintenance request and transitions MR `Submitted → InProgress`. After convert, the WO has `Status = Reported` and the MR has `Status = InProgress, WorkOrderId = WO.Id`. THIS STORY picks up from there.
+- The explicit transaction pattern (`BeginTransactionAsync`) was needed in convert because of two SaveChanges + FK sequencing. It's NOT needed here — single SaveChanges suffices.
+- E2E spec 3 in convert cleared cookies + storage between landlord and tenant sessions on the same page context. Apply the same pattern in this story's E2E spec 1.
+
+From **Story 20.9 (Dismiss)**:
+- The dismiss handler is the closest structural precedent — single SaveChanges, no explicit transaction, calls `TransitionTo` and relies on EF's atomic save.
+- Logging pattern: `_logger.LogInformation("Dismissed maintenance request {RequestId} with reason length {ReasonLength}", ...)` — match the style for this story's "Linked maintenance request ... marked Resolved" message.
+- Test baseline post-20.9: 2196 backend tests. Cite the fresh count after Task 4.
+
+From **Story 17.10 (Inline Status Dropdown)**:
+- The WO detail page has an inline status dropdown (`mat-select`) that fires `updateWorkOrderStatus` on the store on every change. The store builds a full `UpdateWorkOrderRequest` from `selectedWorkOrder` with only `status` changed, calls the same PUT endpoint that the edit form uses. So THIS STORY's sync code path is reached identically from both the dropdown and the edit form.
+- The store does NOT navigate on status update — it just patches `selectedWorkOrder.status` and shows a snackbar. No store change needed in this story.
+- E2E spec 1 in this story must wait for the PUT response (or the "Status updated" snackbar) after clicking `Completed` in the dropdown before navigating back to confirm the sync took effect.
+
+From **Story 21.1 (MaintenanceRequestsControllerTests integration coverage)**:
+- The `SeedMaintenanceRequestAsync` helper exists in `MaintenanceRequestsControllerTests.cs` (lines 1467–1490). We replicate it locally in `WorkOrdersControllerTests.cs` because the test class is different and we don't want test classes to depend on each other.
+
+### Critical Patterns to Follow (Reminder)
+
+1. **No try/catch in handler** for domain exceptions (project-context.md §"Anti-Patterns").
+2. **Use `IAppDbContext` directly** in handler, no repository.
+3. **Domain entity owns state transitions** (`TransitionTo`); handler calls it.
+4. **`DateTime.UtcNow` only** — the auditable interceptor handles `UpdatedAt` on SaveChanges. No manual timestamp assignment.
+5. **EF's default transaction wrap** — do NOT add `BeginTransactionAsync` here. SaveChanges is atomic per Ref MCP.
+6. **Structured logging only** — `_logger.LogInformation("Linked maintenance request {RequestId} ...", id, woId)`. Do NOT interpolate.
+7. **Explicit account-id filter** in the linked-request lookup matches the existing handler style (defense in depth on top of global filter).
+8. **Guard the sync lookup** so unlinked / non-status / no-op edits incur zero extra cost.
+9. **Frontend zero-change** — verify, do not modify. The four-status UI surface is already in place.
+
+### Out of Scope
+
+- **Resolution reversal / un-resolve** — Out of scope. The state machine has no `Resolved → *` transition. If a future story needs "reopen", it must add the transition AND a corresponding UX flow.
+- **Real-time tenant push (SignalR)** — Same deferral as 20.8/20.9. Tenant sees the resolution on next dashboard load.
+- **Bulk completion / sync across multiple WOs** — Not in scope. The sync is per-WO-update.
+- **Domain events / `IMediator.Publish` infrastructure** — Per epic-20 Technical Notes: "Keep it simple: synchronous update in the same transaction, not event-driven." Defer indefinitely.
+- **NSwag regeneration** — Not needed; this story changes no API contract (no new endpoint, no new request/response shape).
+- **Resolving a MR directly without WO completion** — Not in scope. The only way to reach `Resolved` is via this sync.
+- **Notification to tenant when status changes** — Out of scope (no email / SMS / push notification work). Future story candidate.
+- **Audit log of "who completed the WO that resolved the request"** — `AuditableEntity` already tracks `UpdatedAt` on both entities. Cross-entity audit trail is out of scope.
+
+### References
+
+- Epic file: `docs/project/stories/epic-20/epic-20-tenant-portal.md` (Story 20.10 section, FR-TP17)
+- PRD: `docs/project/prd-tenant-portal.md` (FR-TP17)
+- Architecture: `docs/project/architecture.md` (Clean Architecture + CQRS sections)
+- Project Context: `docs/project/project-context.md` (anti-patterns, testing rules, structured logging)
+- Previous stories:
+  - `docs/project/stories/epic-20/20-3-maintenance-request-entity-api.md` (entity, status enum, `TransitionTo`, exception middleware mapping)
+  - `docs/project/stories/epic-20/20-7-landlord-maintenance-request-inbox.md` (detail page where the synced status renders)
+  - `docs/project/stories/epic-20/20-8-convert-request-to-work-order.md` (the upstream — wires `WorkOrderId` + sets MR `Status = InProgress`)
+  - `docs/project/stories/epic-20/20-9-dismiss-maintenance-request.md` (closest structural precedent — single-SaveChanges handler with `TransitionTo`)
+  - `docs/project/stories/epic-17/17-10-inline-status-dropdown-wo-detail.md` (the most common path to the WO status change in the live UI)
+- Backend reference implementations:
+  - Handler to extend: `backend/src/PropertyManager.Application/WorkOrders/UpdateWorkOrder.cs`
+  - Test class to extend: `backend/tests/PropertyManager.Application.Tests/WorkOrders/UpdateWorkOrderHandlerTests.cs`
+  - Integration test file to extend: `backend/tests/PropertyManager.Api.Tests/WorkOrdersControllerTests.cs`
+  - Entity: `backend/src/PropertyManager.Domain/Entities/MaintenanceRequest.cs` (`TransitionTo` lines 39–56)
+  - Enum: `backend/src/PropertyManager.Domain/Enums/MaintenanceRequestStatus.cs`
+  - Enum: `backend/src/PropertyManager.Domain/Enums/WorkOrderStatus.cs`
+  - `IAppDbContext`: `backend/src/PropertyManager.Application/Common/Interfaces/IAppDbContext.cs` (has both `WorkOrders` and `MaintenanceRequests` DbSets — line 27 + 34)
+  - Exception middleware: `backend/src/PropertyManager.Api/Middleware/GlobalExceptionHandlerMiddleware.cs` (line 133 — `BusinessRuleException` → 400)
+  - Authorization policy (already in place — `CanManageWorkOrders` on `PUT /work-orders/{id}`): `backend/src/PropertyManager.Api/Controllers/WorkOrdersController.cs` line 165
+  - WebApplicationFactory: `backend/tests/PropertyManager.Api.Tests/PropertyManagerWebApplicationFactory.cs`
+  - Maintenance request seed pattern (to replicate locally): `backend/tests/PropertyManager.Api.Tests/MaintenanceRequestsControllerTests.cs` lines 1467–1490
+- Frontend reference (verification only — no edits):
+  - Tenant dashboard: `frontend/src/app/features/tenant-dashboard/tenant-dashboard.component.ts` lines 66–86 (status switch handles `Resolved`)
+  - Tenant request detail: `frontend/src/app/features/tenant-dashboard/components/request-detail/request-detail.component.ts`
+  - Landlord detail: `frontend/src/app/features/maintenance-requests/components/maintenance-request-detail/maintenance-request-detail.component.ts` (status-resolved CSS class line 95, styles line 341)
+  - Work order store (status update method): `frontend/src/app/features/work-orders/stores/work-order.store.ts` (`updateWorkOrderStatus` lines 520–562)
+  - Work order detail (inline dropdown): `frontend/src/app/features/work-orders/pages/work-order-detail/work-order-detail.component.ts` (`onStatusChange` line 829)
+- E2E reference:
+  - Tenant helpers: `frontend/e2e/helpers/tenant.helper.ts` (`loginAsLandlord`, `loginAsTenant`, `setupTenantContext`, `submitMaintenanceRequestViaApi`)
+  - Convert dialog page (reused in spec): `frontend/e2e/pages/convert-request-dialog.page.ts`
+  - Convert spec (precedent for the multi-role flow): `frontend/e2e/tests/maintenance-requests/convert-request.spec.ts`
+  - Dismiss spec (precedent for the cookie-clear pattern): `frontend/e2e/tests/maintenance-requests/dismiss-request.spec.ts`
+  - Fixtures: `frontend/e2e/fixtures/test-fixtures.ts`
+  - BasePage: `frontend/e2e/pages/base.page.ts`
+- External documentation verified during story authoring (Ref MCP):
+  - EF Core `SaveChanges` transactional default for multiple operations — `https://learn.microsoft.com/en-us/ef/core/saving/basic#multiple-operations-in-a-single-savechanges` (confirms no explicit `BeginTransactionAsync` is needed for this handler).
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.7 (1M context) via `/dev-story` skill.
+
+### Debug Log References
+
+- Backend build: `dotnet build` → 0 errors, 0 warnings (after change).
+- Backend tests: `dotnet test` → 1271 + 98 + 844 = **2213 passed, 0 failed** across
+  PropertyManager.Application.Tests, PropertyManager.Infrastructure.Tests, PropertyManager.Api.Tests.
+  New unit tests in `UpdateWorkOrderHandlerTests`: 10 added (17 → 27). New integration
+  tests in `WorkOrdersControllerTests`: 7 added.
+- Frontend build: `npm run build` → clean (1 pre-existing bundle-budget warning,
+  initial 579.70 kB vs 575 kB budget — unchanged from prior baseline; zero frontend
+  code in this story).
+- Frontend unit tests: `npm test` → **2881 passed, 0 failed** across 129 test files.
+- E2E: `npx playwright test e2e/tests/maintenance-requests/ --workers=1` → **16 passed,
+  0 failed** (14 prior specs + 2 new `resolution-sync.spec.ts` specs). Backend was
+  restarted before the E2E run to load the rebuilt `UpdateWorkOrderCommandHandler` DLL.
+
+### Completion Notes List
+
+- The sync block placement (right before `SaveChangesAsync`) lets EF's implicit
+  transactional `SaveChanges` atomically commit both the work-order field changes and
+  the linked `MaintenanceRequest` status transition. The integration test
+  `UpdateWorkOrder_StatusToCompleted_LinkedRequestDismissed_Returns400_RollsBackWO`
+  proves the rollback contract end-to-end (the WO description does NOT stick).
+- One test-housekeeping ripple: the existing `Handle_StatusParsing_IsCaseInsensitive`
+  test parameterized with `"Completed"` now reaches the new sync lookup. Added a single
+  `SetupMaintenanceRequestsDbSet()` call (empty list — returns null → no-op) to keep
+  the test green without altering its assertion. Other prior tests don't transition
+  to Completed and were untouched (AC #12 satisfied).
+- E2E spec 1 initially failed because the running `dotnet run` process had been
+  started against the pre-change DLL. After restarting the backend with the rebuilt
+  handler, both specs pass deterministically.
+- Test scope: Unit REQUIRED ✓, Integration REQUIRED ✓, Frontend unit NOT REQUIRED
+  (verified Tasks 6/7 — zero frontend code), E2E REQUIRED ✓.
+
+### File List
+
+**Modified:**
+- `backend/src/PropertyManager.Application/WorkOrders/UpdateWorkOrder.cs` — added
+  `ILogger<UpdateWorkOrderCommandHandler>` injection, captured `priorStatus`, and
+  added the guarded sync block that transitions the linked maintenance request to
+  `Resolved` when the work order transitions into `Completed`.
+- `backend/tests/PropertyManager.Application.Tests/WorkOrders/UpdateWorkOrderHandlerTests.cs`
+  — added `_loggerMock`, the `SetupMaintenanceRequestsDbSet` helper, a
+  `CreateMaintenanceRequest` helper, and 10 new unit tests in a
+  `#region Sync Resolution Tests (Story 20-10)` block; added a single
+  `SetupMaintenanceRequestsDbSet()` call to the existing
+  `Handle_StatusParsing_IsCaseInsensitive` test for the `Completed` row.
+- `backend/tests/PropertyManager.Api.Tests/WorkOrdersControllerTests.cs` — added
+  the `// PUT /api/v1/work-orders/{id} — Story 20.10 resolution sync` region with
+  7 integration tests, plus 4 helper methods
+  (`CreateUserPropertyAndCaptureContextAsync`, `LoginUserAsync`,
+  `CreateWorkOrderAsync`, `SeedMaintenanceRequestLinkedToAsync`) and the
+  `using PropertyManager.Domain.Entities`/`PropertyManager.Domain.Enums` imports.
+- `docs/project/sprint-status.yaml` — `20-10-request-resolution-sync` flipped from
+  `ready-for-dev` → `in-progress` → `review`.
+- `docs/project/stories/epic-20/20-10-request-resolution-sync.md` — status flipped
+  to `review`, all tasks marked `[x]`, Dev Agent Record populated.
+
+**Created:**
+- `frontend/e2e/tests/maintenance-requests/resolution-sync.spec.ts` — 2 E2E specs
+  covering the happy path (landlord completes → tenant sees Resolved) and the
+  negative path (non-Completed transition leaves request In Progress).
+
+**No frontend source code changes** — Tasks 6/7/8 confirmed the existing tenant
+dashboard, request-detail, and landlord-detail components already render `Resolved`
+correctly per Story 20.5/20.7.
+
+### Review Log
+
+- Task 1 (Backend handler change): Spec PASS (1 iter — all ACs mapped); Quality
+  APPROVE (1 iter — comment cites Story+rationale, no issues warranting changes).
+  Reviewed inline by the dev agent (subagent dispatch tool not available in this
+  environment); evidence is the diff at `UpdateWorkOrder.cs` + the 27 passing unit
+  tests that exercise every branch of the sync block.
+- Task 2 (Backend unit tests): Spec PASS (1 iter — all 10 tests map to listed ACs
+  in story Task 2.5; covered ACs #1, #2, #3, #4, #7, #8, #9, #11, #12, #13); Quality
+  APPROVE (1 iter — naming follows `Method_Scenario_ExpectedResult`, helpers
+  factored, no duplication).
+- Task 3 (Domain entity confirmation): SKIPPED (trivial — verification only, no code
+  change; `TransitionTo` already enforces `InProgress → Resolved` per Story 20.3).
+- Task 4 (Backend build + test gate): SKIPPED (trivial — gate-only, no source
+  change; evidence is the 2213-passing test run cited in Debug Log References).
+- Task 5 (Backend integration tests): Spec PASS (1 iter — all 7 tests map to story
+  Task 5.3 specs and the named ACs #1, #2, #3, #4, #5, #7, #10); Quality APPROVE
+  (1 iter — uses `IgnoreQueryFilters()` for cross-account assertions, helpers
+  mirror the existing `SeedMaintenanceRequestAsync` pattern, no duplication).
+- Task 6 (Tenant dashboard verification): SKIPPED (trivial — read-only verification;
+  `getStatusColor`/`getStatusLabel` confirmed at lines 66–86, `Resolved` returns
+  `accent` and falls through to render "Resolved").
+- Task 7 (Landlord detail page verification): SKIPPED (trivial — read-only
+  verification; `status-resolved` class binding confirmed at line 95, CSS at
+  line 341; Convert/Dismiss buttons gated at line 52 on `req.status === 'Submitted'`).
+- Task 8 (Frontend unit test justification): SKIPPED (trivial — story explicitly
+  defers frontend unit tests; existing 2881-passing suite already covers `Resolved`
+  rendering paths).
+- Task 9 (Frontend Vitest + ng build gate): SKIPPED (trivial — gate-only; 2881
+  unit tests pass, build produces 579.70 kB initial bundle matching the 580 kB
+  baseline cited in story Task 9.2).
+- Task 10 (E2E resolution-sync spec): Spec PASS (1 iter — both required specs from
+  Task 10.1 implemented, cover the happy path and AC #2 negative path); Quality
+  APPROVE (2 iters — removed an "unused lint silencer" `workOrderUrl` constant on
+  cleanup pass, both specs still green).
+- Task 11 (Sprint status): SKIPPED (trivial — process-only; sprint-status.yaml
+  flipped to `review` per the `/dev-story` Step 5 protocol).

--- a/frontend/e2e/tests/maintenance-requests/resolution-sync.spec.ts
+++ b/frontend/e2e/tests/maintenance-requests/resolution-sync.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * E2E Tests: Maintenance Request Resolution Sync (Story 20.10)
+ *
+ * Verifies the end-to-end contract from epic-20 FR-TP17:
+ * - When the landlord completes a WorkOrder linked to a MaintenanceRequest,
+ *   the request's status is automatically set to Resolved.
+ * - The tenant sees the Resolved status on the dashboard after reload.
+ * - A non-Completed status change does NOT propagate to the linked request.
+ *
+ * Test isolation mirrors the convert-request and dismiss-request specs:
+ * throwaway landlord via invitation, throwaway property, throwaway tenant,
+ * per-run unique descriptions/emails (Date.now() + random suffix).
+ */
+import { test, expect } from '../../fixtures/test-fixtures';
+import {
+  createLandlordViaInvitation,
+  createPropertyViaApi,
+  inviteTenantViaApi,
+  acceptTenantInvitation,
+  getAccessToken,
+  loginAsLandlord,
+  loginAsTenant,
+  submitMaintenanceRequestViaApi,
+} from '../../helpers/tenant.helper';
+
+test.describe('Maintenance Request Resolution Sync E2E (Story 20.10)', () => {
+  // ─────────────────────────────────────────────────────────────────────────
+  // Spec 1 — Happy path: landlord completes WO → tenant sees Resolved
+  // (AC #1, #5)
+  // ─────────────────────────────────────────────────────────────────────────
+  test('landlord completing the linked work order resolves the request for the tenant', async ({
+    page,
+    mailhog,
+    maintenanceRequestsListPage,
+    maintenanceRequestDetailPage,
+    convertRequestDialogPage,
+    tenantDashboardPage,
+  }) => {
+    const landlord = await createLandlordViaInvitation(mailhog);
+    const propertyId = await createPropertyViaApi(landlord.token, {
+      name: `Resolve-Happy-Prop ${Date.now()}`,
+    });
+    const tenantPassword = 'Throwaway@123456';
+    const tenantEmail = `e2e-mr-resolve-happy-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}@example.com`;
+    await inviteTenantViaApi(landlord.token, propertyId, tenantEmail);
+    await acceptTenantInvitation(page, mailhog, tenantEmail, tenantPassword);
+    const tenantToken = await getAccessToken(tenantEmail, tenantPassword);
+
+    const description = `Resolve happy path ${Date.now()}`;
+    await submitMaintenanceRequestViaApi(tenantToken, description);
+
+    // Landlord logs in, opens detail, converts → MR is InProgress, WO is Reported.
+    await loginAsLandlord(page, landlord.email, landlord.password);
+    await maintenanceRequestsListPage.goto();
+    await maintenanceRequestsListPage.clickRow(description);
+    await page.waitForURL(/\/maintenance-requests\/[a-f0-9-]+$/);
+    const requestUrl = page.url();
+    const requestId = requestUrl.split('/').pop()!;
+
+    await page.locator('[data-testid="convert-button"]').click();
+    await convertRequestDialogPage.expectVisible();
+    await convertRequestDialogPage.submit();
+    await page.waitForURL(/\/work-orders\/[a-f0-9-]+$/);
+
+    // Change WO status from Reported → Completed via the Story 17-10 dropdown.
+    await page.locator('mat-select').first().click();
+    const statusPutPromise = page.waitForResponse(
+      (r) => r.url().includes('/api/v1/work-orders/') && r.request().method() === 'PUT',
+    );
+    await page.locator('mat-option:has-text("Completed")').click();
+    await statusPutPromise;
+    await page.locator('[matsnackbarlabel]').filter({ hasText: 'Status updated' }).first().waitFor({
+      state: 'visible',
+      timeout: 5000,
+    });
+
+    // Landlord reloads the request detail — status chip should now read "Resolved".
+    await page.goto(`/maintenance-requests/${requestId}`);
+    await expect(maintenanceRequestDetailPage.statusChip).toHaveText('Resolved');
+
+    // Tenant logs in fresh and verifies the dashboard reflects Resolved.
+    await page.context().clearCookies();
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+
+    await loginAsTenant(page, tenantEmail, tenantPassword);
+    await tenantDashboardPage.goto();
+    await tenantDashboardPage.expectStatusBadge(description, 'Resolved');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Spec 2 — Non-Completed status change does NOT resolve the request (AC #2)
+  // ─────────────────────────────────────────────────────────────────────────
+  test('changing the work-order status to a non-Completed value leaves the request In Progress', async ({
+    page,
+    mailhog,
+    maintenanceRequestsListPage,
+    maintenanceRequestDetailPage,
+    convertRequestDialogPage,
+  }) => {
+    const landlord = await createLandlordViaInvitation(mailhog);
+    const propertyId = await createPropertyViaApi(landlord.token, {
+      name: `Resolve-NonComplete-Prop ${Date.now()}`,
+    });
+    const tenantPassword = 'Throwaway@123456';
+    const tenantEmail = `e2e-mr-resolve-noncomplete-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}@example.com`;
+    await inviteTenantViaApi(landlord.token, propertyId, tenantEmail);
+    await acceptTenantInvitation(page, mailhog, tenantEmail, tenantPassword);
+    const tenantToken = await getAccessToken(tenantEmail, tenantPassword);
+
+    const description = `Resolve negative path ${Date.now()}`;
+    await submitMaintenanceRequestViaApi(tenantToken, description);
+
+    // Landlord converts → MR is InProgress, WO is Reported.
+    await loginAsLandlord(page, landlord.email, landlord.password);
+    await maintenanceRequestsListPage.goto();
+    await maintenanceRequestsListPage.clickRow(description);
+    await page.waitForURL(/\/maintenance-requests\/[a-f0-9-]+$/);
+    const requestUrl = page.url();
+    const requestId = requestUrl.split('/').pop()!;
+
+    await page.locator('[data-testid="convert-button"]').click();
+    await convertRequestDialogPage.expectVisible();
+    await convertRequestDialogPage.submit();
+    await page.waitForURL(/\/work-orders\/[a-f0-9-]+$/);
+
+    // Change WO status from Reported → Assigned (NOT Completed).
+    await page.locator('mat-select').first().click();
+    const statusPutPromise = page.waitForResponse(
+      (r) => r.url().includes('/api/v1/work-orders/') && r.request().method() === 'PUT',
+    );
+    await page.locator('mat-option:has-text("Assigned")').click();
+    await statusPutPromise;
+    await page.locator('[matsnackbarlabel]').filter({ hasText: 'Status updated' }).first().waitFor({
+      state: 'visible',
+      timeout: 5000,
+    });
+
+    // Landlord reloads the request detail — status chip MUST still read
+    // "In Progress" (label transform from the InProgress enum).
+    await page.goto(`/maintenance-requests/${requestId}`);
+    await expect(maintenanceRequestDetailPage.statusChip).toHaveText('In Progress');
+  });
+});


### PR DESCRIPTION
## Summary

- Story 20.10 (FR-TP17) — when a landlord changes a linked work order's status to `Completed` via `PUT /api/v1/work-orders/{id}`, the linked `MaintenanceRequest` auto-transitions from `InProgress` to `Resolved` in the same `SaveChanges` transaction.
- Sync is guarded on `priorStatus != Completed && newStatus == Completed`, so no-op saves and `Resolved → Resolved` re-saves do not re-trigger the transition.
- Unlinked work orders incur zero additional DB lookup.

## Implementation

- `UpdateWorkOrderCommandHandler` captures `priorStatus`, then inside the same SaveChanges window looks up the linked `MaintenanceRequest` (account-scoped, soft-delete-filtered) and calls `TransitionTo(Resolved)`. EF Core wraps both writes in a single transaction by default.
- `ILogger` injected; emits a structured `Linked maintenance request {id} marked Resolved` line on sync.
- Defensive `Status != Resolved` guard prevents `BusinessRuleException` if the request is already Resolved (e.g., landlord toggling status).
- No frontend source changes — `Resolved` already renders from stories 20.5 and 20.7.

## Tests

- Backend unit: **+10** in `UpdateWorkOrderHandlerTests` (happy path, non-Completed transitions, no-op Completed save, unlinked WO, already-Resolved guard, BRE on Dismissed source, cross-account isolation, soft-deleted MR, logger Times.Once, lookup Times.Never on non-transitions).
- Backend integration: **+7** in `WorkOrdersControllerTests` proving cross-aggregate atomicity, BRE-triggered rollback at the DB level, multi-tenancy in the sync path, and tenant 403 path.
- E2E: **+2** in `frontend/e2e/tests/maintenance-requests/resolution-sync.spec.ts` (happy path + non-Completed negative path).
- All suites: backend 2213/2213, frontend unit 2881/2881, maintenance-requests E2E 16/16.

## Test plan

- [ ] Backend `dotnet build && dotnet test` clean in CI
- [ ] Frontend `ng build && npm test` clean in CI
- [ ] Playwright E2E job green in CI
- [ ] Manually: landlord converts a request → sets WO to Completed → tenant dashboard shows "Resolved" on next load

🤖 Generated with [Claude Code](https://claude.com/claude-code)