### PR TITLE
feat(22-4): admin console for landlord invitations (list, create, resend)

### DIFF
--- a/backend/src/PropertyManager.Api/Controllers/AdminLandlordInvitationsController.cs
+++ b/backend/src/PropertyManager.Api/Controllers/AdminLandlordInvitationsController.cs
@@ -19,16 +19,80 @@ public class AdminLandlordInvitationsController : ControllerBase
 {
     private readonly IMediator _mediator;
     private readonly IValidator<CreateLandlordInvitationCommand> _createValidator;
+    private readonly IValidator<ResendLandlordInvitationCommand> _resendValidator;
     private readonly ILogger<AdminLandlordInvitationsController> _logger;
 
     public AdminLandlordInvitationsController(
         IMediator mediator,
         IValidator<CreateLandlordInvitationCommand> createValidator,
+        IValidator<ResendLandlordInvitationCommand> resendValidator,
         ILogger<AdminLandlordInvitationsController> logger)
     {
         _mediator = mediator;
         _createValidator = createValidator;
+        _resendValidator = resendValidator;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// List all landlord invitations (those with AccountId == null), newest first.
+    /// </summary>
+    /// <returns>The landlord invitations with their derived status and inviting admin.</returns>
+    /// <response code="200">The list of landlord invitations.</response>
+    /// <response code="401">If not authenticated.</response>
+    /// <response code="403">If caller lacks the PlatformAdmin claim.</response>
+    [HttpGet]
+    [ProducesResponseType(typeof(GetLandlordInvitationsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetLandlordInvitations()
+    {
+        var result = await _mediator.Send(new GetLandlordInvitationsQuery());
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Resend an expired landlord invitation — creates a fresh invitation (AccountId == null,
+    /// Role == "Owner") with a new code/expiry and sends the landlord-flavored email.
+    /// </summary>
+    /// <param name="id">The ID of the expired landlord invitation to resend.</param>
+    /// <returns>The new invitation ID on success.</returns>
+    /// <response code="201">Invitation resent successfully.</response>
+    /// <response code="400">If the invitation is not expired or already used.</response>
+    /// <response code="401">If not authenticated.</response>
+    /// <response code="403">If caller lacks the PlatformAdmin claim.</response>
+    /// <response code="404">If no landlord invitation matches the ID.</response>
+    [HttpPost("{id:guid}/resend")]
+    [ProducesResponseType(typeof(ResendLandlordInvitationResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ResendLandlordInvitation([FromRoute] Guid id)
+    {
+        var command = new ResendLandlordInvitationCommand(id);
+
+        var validationResult = await _resendValidator.ValidateAsync(command);
+        if (!validationResult.IsValid)
+        {
+            return BadRequest(CreateValidationProblemDetails(validationResult));
+        }
+
+        try
+        {
+            var result = await _mediator.Send(command);
+            var response = new ResendLandlordInvitationResponse(result.InvitationId, result.Message);
+
+            return CreatedAtAction(
+                nameof(ResendLandlordInvitation),
+                new { id = result.InvitationId },
+                response);
+        }
+        catch (ValidationException ex)
+        {
+            // Handler-thrown FluentValidation exceptions (not-expired / already-used) → 400.
+            return BadRequest(CreateValidationProblemDetails(ex));
+        }
     }
 
     /// <summary>
@@ -107,3 +171,4 @@ public class AdminLandlordInvitationsController : ControllerBase
 // DTOs at bottom of file per project convention.
 public record CreateLandlordInvitationRequest(string Email);
 public record CreateLandlordInvitationResponse(Guid InvitationId, string Message);
+public record ResendLandlordInvitationResponse(Guid InvitationId, string Message);

--- a/backend/src/PropertyManager.Application/Invitations/GetLandlordInvitations.cs
+++ b/backend/src/PropertyManager.Application/Invitations/GetLandlordInvitations.cs
@@ -1,0 +1,100 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PropertyManager.Application.Common.Interfaces;
+
+namespace PropertyManager.Application.Invitations;
+
+/// <summary>
+/// DTO representing a landlord (top-level, AccountId == null) invitation (Story 22.4, AC: #3).
+/// </summary>
+public record LandlordInvitationDto(
+    Guid Id,
+    string Email,
+    DateTime CreatedAt,
+    DateTime ExpiresAt,
+    DateTime? UsedAt,
+    string Status,
+    string InvitedBy);
+
+/// <summary>
+/// Query to retrieve all landlord invitations (those with AccountId == null).
+/// Admin-scoped; the PlatformAdmin gate lives on the controller.
+/// </summary>
+public record GetLandlordInvitationsQuery : IRequest<GetLandlordInvitationsResponse>;
+
+/// <summary>
+/// Response containing the list of landlord invitations.
+/// </summary>
+public record GetLandlordInvitationsResponse(IReadOnlyList<LandlordInvitationDto> Items, int TotalCount);
+
+/// <summary>
+/// Handler for <see cref="GetLandlordInvitationsQuery"/>.
+/// Queries invitations where AccountId == null (landlord invitations), derives status,
+/// and resolves the inviting admin's display name for the "Invited By" column.
+/// </summary>
+public class GetLandlordInvitationsQueryHandler
+    : IRequestHandler<GetLandlordInvitationsQuery, GetLandlordInvitationsResponse>
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IIdentityService _identityService;
+    private readonly ILogger<GetLandlordInvitationsQueryHandler> _logger;
+
+    public GetLandlordInvitationsQueryHandler(
+        IAppDbContext dbContext,
+        IIdentityService identityService,
+        ILogger<GetLandlordInvitationsQueryHandler> logger)
+    {
+        _dbContext = dbContext;
+        _identityService = identityService;
+        _logger = logger;
+    }
+
+    public async Task<GetLandlordInvitationsResponse> Handle(
+        GetLandlordInvitationsQuery request, CancellationToken cancellationToken)
+    {
+        var invitations = await _dbContext.Invitations
+            .Where(i => i.AccountId == null)
+            .OrderByDescending(i => i.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        // Resolve inviting-admin display names for the "Invited By" column.
+        var inviterIds = invitations
+            .Where(i => i.InvitedByUserId.HasValue)
+            .Select(i => i.InvitedByUserId!.Value)
+            .Distinct();
+        var displayNames = await _identityService.GetUserDisplayNamesAsync(inviterIds, cancellationToken);
+
+        var dtos = invitations.Select(i => new LandlordInvitationDto(
+            i.Id,
+            i.Email,
+            i.CreatedAt,
+            i.ExpiresAt,
+            i.UsedAt,
+            DeriveStatus(i),
+            ResolveInvitedBy(i, displayNames))).ToList();
+
+        _logger.LogInformation("Retrieved {Count} landlord invitations", dtos.Count);
+
+        return new GetLandlordInvitationsResponse(dtos.AsReadOnly(), dtos.Count);
+    }
+
+    private static string ResolveInvitedBy(
+        Domain.Entities.Invitation invitation, IReadOnlyDictionary<Guid, string> displayNames)
+    {
+        if (invitation.InvitedByUserId.HasValue
+            && displayNames.TryGetValue(invitation.InvitedByUserId.Value, out var name))
+        {
+            return name;
+        }
+
+        return string.Empty;
+    }
+
+    private static string DeriveStatus(Domain.Entities.Invitation invitation)
+    {
+        if (invitation.UsedAt != null) return "Accepted";
+        if (invitation.ExpiresAt < DateTime.UtcNow) return "Expired";
+        return "Pending";
+    }
+}

--- a/backend/src/PropertyManager.Application/Invitations/ResendLandlordInvitation.cs
+++ b/backend/src/PropertyManager.Application/Invitations/ResendLandlordInvitation.cs
@@ -1,0 +1,134 @@
+using System.Security.Cryptography;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Invitations;
+
+/// <summary>
+/// Command to resend an expired landlord invitation (Story 22.4, AC: #6).
+/// Looks up a landlord invitation (AccountId == null) and re-creates a fresh one.
+///
+/// NFR-LP2 SEAM: This handler is intentionally permission-agnostic. The PlatformAdmin
+/// gate lives only on AdminLandlordInvitationsController via [Authorize(Policy =
+/// "CanInviteLandlords")]. Kept distinct from the account-scoped ResendInvitationCommand
+/// (which corrupts a landlord invitation by stamping the caller's AccountId and sending
+/// the co-owner email).
+/// </summary>
+public record ResendLandlordInvitationCommand(Guid InvitationId)
+    : IRequest<ResendLandlordInvitationResult>;
+
+/// <summary>
+/// Result of resending a landlord invitation.
+/// </summary>
+public record ResendLandlordInvitationResult(Guid InvitationId, string Message);
+
+/// <summary>
+/// Handler for <see cref="ResendLandlordInvitationCommand"/>.
+/// Validates the original landlord invitation, then creates a new one with a fresh
+/// code/expiry, AccountId == null, Role == "Owner", and sends the landlord email.
+/// </summary>
+public class ResendLandlordInvitationCommandHandler
+    : IRequestHandler<ResendLandlordInvitationCommand, ResendLandlordInvitationResult>
+{
+    private readonly IAppDbContext _dbContext;
+    private readonly IEmailService _emailService;
+    private readonly ICurrentUser _currentUser;
+    private readonly ILogger<ResendLandlordInvitationCommandHandler> _logger;
+
+    public ResendLandlordInvitationCommandHandler(
+        IAppDbContext dbContext,
+        IEmailService emailService,
+        ICurrentUser currentUser,
+        ILogger<ResendLandlordInvitationCommandHandler> logger)
+    {
+        _dbContext = dbContext;
+        _emailService = emailService;
+        _currentUser = currentUser;
+        _logger = logger;
+    }
+
+    public async Task<ResendLandlordInvitationResult> Handle(
+        ResendLandlordInvitationCommand request, CancellationToken cancellationToken)
+    {
+        // Landlord invitations have AccountId == null — never serve an account-scoped one here.
+        var original = await _dbContext.Invitations
+            .Where(i => i.Id == request.InvitationId && i.AccountId == null)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (original == null)
+        {
+            throw new NotFoundException(nameof(Invitation), request.InvitationId);
+        }
+
+        if (original.UsedAt != null)
+        {
+            throw new FluentValidation.ValidationException(new[]
+            {
+                new FluentValidation.Results.ValidationFailure(
+                    "InvitationId", "Cannot resend an invitation that has already been used")
+            });
+        }
+
+        if (original.ExpiresAt >= DateTime.UtcNow)
+        {
+            throw new FluentValidation.ValidationException(new[]
+            {
+                new FluentValidation.Results.ValidationFailure(
+                    "InvitationId", "Can only resend expired invitations")
+            });
+        }
+
+        var rawCode = GenerateSecureCode();
+        var codeHash = ComputeHash(rawCode);
+
+        var newInvitation = new Invitation
+        {
+            Email = original.Email,
+            CodeHash = codeHash,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddHours(24),
+            AccountId = null,
+            InvitedByUserId = _currentUser.UserId,
+            Role = "Owner",
+            PropertyId = null
+        };
+
+        _dbContext.Invitations.Add(newInvitation);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _emailService.SendLandlordInvitationEmailAsync(original.Email, rawCode, cancellationToken);
+
+        // CWE-359 / cleartext-storage: no IDs or email in the log.
+        _logger.LogInformation("Resent landlord invitation");
+
+        return new ResendLandlordInvitationResult(newInvitation.Id, "Landlord invitation resent successfully");
+    }
+
+    /// <summary>
+    /// Generates a cryptographically secure invitation code (32 random bytes → base64-url).
+    /// Co-located per project convention (acceptable duplication across invitation handlers).
+    /// </summary>
+    private static string GenerateSecureCode()
+    {
+        var bytes = new byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes)
+            .Replace("+", "-")
+            .Replace("/", "_")
+            .TrimEnd('=');
+    }
+
+    /// <summary>
+    /// Computes SHA256 hash of the code for storage.
+    /// </summary>
+    private static string ComputeHash(string code)
+    {
+        using var sha256 = SHA256.Create();
+        var hashBytes = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(code));
+        return Convert.ToBase64String(hashBytes);
+    }
+}

--- a/backend/src/PropertyManager.Application/Invitations/ResendLandlordInvitationValidator.cs
+++ b/backend/src/PropertyManager.Application/Invitations/ResendLandlordInvitationValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace PropertyManager.Application.Invitations;
+
+/// <summary>
+/// Validator for ResendLandlordInvitationCommand (Story 22.4).
+/// </summary>
+public class ResendLandlordInvitationCommandValidator : AbstractValidator<ResendLandlordInvitationCommand>
+{
+    public ResendLandlordInvitationCommandValidator()
+    {
+        RuleFor(x => x.InvitationId)
+            .NotEmpty().WithMessage("Invitation ID is required");
+    }
+}

--- a/backend/tests/PropertyManager.Api.Tests/AdminLandlordInvitationsControllerTests.cs
+++ b/backend/tests/PropertyManager.Api.Tests/AdminLandlordInvitationsControllerTests.cs
@@ -293,6 +293,278 @@ public class AdminLandlordInvitationsControllerTests : IClassFixture<PropertyMan
         inv.PropertyId.Should().BeNull();
     }
 
+    // ===== Story 22.4 — GET list helpers =====
+
+    private async Task<HttpResponseMessage> GetListAsync(string? token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, Endpoint);
+        if (token != null)
+        {
+            request.Headers.Add("Authorization", $"Bearer {token}");
+        }
+        return await _client.SendAsync(request);
+    }
+
+    private async Task<HttpResponseMessage> PostResendAsync(Guid id, string? token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{Endpoint}/{id}/resend");
+        if (token != null)
+        {
+            request.Headers.Add("Authorization", $"Bearer {token}");
+        }
+        return await _client.SendAsync(request);
+    }
+
+    /// <summary>
+    /// Seeds an expired landlord invitation (AccountId == null) directly in the DB.
+    /// </summary>
+    private async Task<Guid> SeedExpiredLandlordInvitationAsync(Guid invitedByUserId, string email)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var inv = new Domain.Entities.Invitation
+        {
+            Id = Guid.NewGuid(),
+            Email = email.ToLowerInvariant(),
+            // CodeHash is uniquely indexed (IX_Invitations_CodeHash) — must be unique per seed
+            // so concurrent tests in this shared-DB class don't collide.
+            CodeHash = $"seeded-{Guid.NewGuid():N}",
+            Role = "Owner",
+            AccountId = null,
+            InvitedByUserId = invitedByUserId,
+            CreatedAt = DateTime.UtcNow.AddDays(-2),
+            ExpiresAt = DateTime.UtcNow.AddDays(-1),
+            UsedAt = null
+        };
+        dbContext.Invitations.Add(inv);
+        await dbContext.SaveChangesAsync();
+        return inv.Id;
+    }
+
+    private async Task<Guid> SeedLandlordInvitationAsync(
+        Guid invitedByUserId, string email, DateTime expiresAt, DateTime? usedAt = null)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var inv = new Domain.Entities.Invitation
+        {
+            Id = Guid.NewGuid(),
+            Email = email.ToLowerInvariant(),
+            CodeHash = $"seeded-{Guid.NewGuid():N}",
+            Role = "Owner",
+            AccountId = null,
+            InvitedByUserId = invitedByUserId,
+            CreatedAt = DateTime.UtcNow.AddDays(-2),
+            ExpiresAt = expiresAt,
+            UsedAt = usedAt
+        };
+        dbContext.Invitations.Add(inv);
+        await dbContext.SaveChangesAsync();
+        return inv.Id;
+    }
+
+    // ===== AC 22.4 #3 — GET list =====
+
+    [Fact]
+    public async Task GetLandlordInvitations_AsPlatformAdmin_Returns200WithNullAccountInvitations()
+    {
+        // AC: 22.4 #3 — list returns only AccountId == null rows; account-scoped excluded
+        var (adminUserId, token) = await CreatePlatformAdminAsync();
+        var landlordEmail = $"land-{Guid.NewGuid():N}@example.com";
+
+        // Seed a landlord invitation via the create endpoint
+        var createResp = await PostAsync(new { Email = landlordEmail }, token);
+        createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Seed an account-scoped invitation via the regular owner invitations route
+        var ownerEmail = $"owner-{Guid.NewGuid():N}@example.com";
+        await _factory.CreateTestUserAsync(ownerEmail, role: "Owner");
+        var ownerToken = await LoginAsync(ownerEmail);
+        var scopedEmail = $"scoped-{Guid.NewGuid():N}@example.com";
+        var scopedReq = new HttpRequestMessage(HttpMethod.Post, "/api/v1/invitations")
+        {
+            Content = JsonContent.Create(new { Email = scopedEmail, Role = "Contributor" })
+        };
+        scopedReq.Headers.Add("Authorization", $"Bearer {ownerToken}");
+        var scopedResp = await _client.SendAsync(scopedReq);
+        scopedResp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Act
+        var response = await GetListAsync(token);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<GetLandlordInvitationsResponse>();
+        body.Should().NotBeNull();
+        body!.Items.Should().Contain(i => i.Email == landlordEmail.ToLowerInvariant());
+        body.Items.Should().NotContain(i => i.Email == scopedEmail.ToLowerInvariant());
+        body.Items.Should().OnlyContain(i => i.Status == "Pending" || i.Status == "Expired" || i.Status == "Accepted");
+    }
+
+    [Fact]
+    public async Task GetLandlordInvitations_AsRegularOwner_Returns403()
+    {
+        // AC: 22.4 #3 / #7 — non-PlatformAdmin is forbidden
+        var email = $"owner-{Guid.NewGuid():N}@example.com";
+        await _factory.CreateTestUserAsync(email, role: "Owner");
+        var token = await LoginAsync(email);
+
+        var response = await GetListAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetLandlordInvitations_AsUnauthenticated_Returns401()
+    {
+        // AC: 22.4 #3 / #7
+        var response = await GetListAsync(token: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ===== AC 22.4 #6 — resend =====
+
+    [Fact]
+    public async Task ResendLandlordInvitation_AsPlatformAdmin_ExpiredInvitation_Returns201_CreatesFreshNullAccountInvitation()
+    {
+        // AC: 22.4 #6
+        var (adminUserId, token) = await CreatePlatformAdminAsync();
+        var email = $"resend-{Guid.NewGuid():N}@example.com";
+        var lowered = email.ToLowerInvariant();
+        var expiredId = await SeedExpiredLandlordInvitationAsync(adminUserId, email);
+
+        var fakeEmail = _factory.Services.GetRequiredService<FakeEmailService>();
+        var landlordBefore = fakeEmail.SentLandlordInvitationEmails.Count(e => e.Email == lowered);
+        var coOwnerBefore = fakeEmail.SentInvitationEmails.Count(e => e.Email == lowered);
+
+        // Act
+        var response = await PostResendAsync(expiredId, token);
+
+        // Assert — 201 + response body
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<ResendLandlordInvitationResponse>();
+        body.Should().NotBeNull();
+        body!.InvitationId.Should().NotBe(Guid.Empty);
+        body.InvitationId.Should().NotBe(expiredId);
+
+        // A fresh null-account invitation with future expiry was created
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var fresh = await dbContext.Invitations.AsNoTracking()
+            .FirstOrDefaultAsync(i => i.Id == body.InvitationId);
+        fresh.Should().NotBeNull();
+        fresh!.AccountId.Should().BeNull();
+        fresh.Role.Should().Be("Owner");
+        fresh.PropertyId.Should().BeNull();
+        fresh.Email.Should().Be(lowered);
+        fresh.UsedAt.Should().BeNull();
+        fresh.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
+
+        // Landlord email sent; co-owner email NOT sent
+        fakeEmail.SentLandlordInvitationEmails.Count(e => e.Email == lowered).Should().Be(landlordBefore + 1);
+        fakeEmail.SentInvitationEmails.Count(e => e.Email == lowered).Should().Be(coOwnerBefore);
+    }
+
+    [Fact]
+    public async Task ResendLandlordInvitation_AsRegularOwner_Returns403()
+    {
+        // AC: 22.4 #6 / #7
+        var (adminUserId, _) = await CreatePlatformAdminAsync();
+        var expiredId = await SeedExpiredLandlordInvitationAsync(
+            adminUserId, $"resend-{Guid.NewGuid():N}@example.com");
+
+        var ownerEmail = $"owner-{Guid.NewGuid():N}@example.com";
+        await _factory.CreateTestUserAsync(ownerEmail, role: "Owner");
+        var ownerToken = await LoginAsync(ownerEmail);
+
+        var response = await PostResendAsync(expiredId, ownerToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ResendLandlordInvitation_NotYetExpired_Returns400()
+    {
+        // AC: 22.4 #6 — can only resend expired invitations; assert body message
+        var (adminUserId, token) = await CreatePlatformAdminAsync();
+        var pendingId = await SeedLandlordInvitationAsync(
+            adminUserId, $"pending-{Guid.NewGuid():N}@example.com", DateTime.UtcNow.AddHours(23));
+
+        var response = await PostResendAsync(pendingId, token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("expired");
+    }
+
+    [Fact]
+    public async Task ResendLandlordInvitation_AlreadyUsed_Returns400()
+    {
+        // AC: 22.4 #6 — cannot resend a used invitation; assert body message
+        var (adminUserId, token) = await CreatePlatformAdminAsync();
+        var usedId = await SeedLandlordInvitationAsync(
+            adminUserId,
+            $"used-{Guid.NewGuid():N}@example.com",
+            DateTime.UtcNow.AddDays(-1),
+            usedAt: DateTime.UtcNow.AddDays(-1));
+
+        var response = await PostResendAsync(usedId, token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("used");
+    }
+
+    [Fact]
+    public async Task ResendLandlordInvitation_NonExistentId_Returns404()
+    {
+        // AC: 22.4 #6
+        var (_, token) = await CreatePlatformAdminAsync();
+
+        var response = await PostResendAsync(Guid.NewGuid(), token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ResendLandlordInvitation_AccountScopedId_Returns404()
+    {
+        // AC: 22.4 #6 — an account-scoped invitation must NOT be resendable here
+        var (_, token) = await CreatePlatformAdminAsync();
+
+        // Seed an account-scoped (AccountId != null) invitation
+        var (ownerUserId, accountId) = await _factory.CreateTestUserAsync($"o-{Guid.NewGuid():N}@example.com");
+        Guid scopedId;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var inv = new Domain.Entities.Invitation
+            {
+                Id = Guid.NewGuid(),
+                Email = $"scoped-{Guid.NewGuid():N}@example.com",
+                CodeHash = $"seeded-{Guid.NewGuid():N}",
+                Role = "Contributor",
+                AccountId = accountId,
+                InvitedByUserId = ownerUserId,
+                CreatedAt = DateTime.UtcNow.AddDays(-2),
+                ExpiresAt = DateTime.UtcNow.AddDays(-1),
+                UsedAt = null
+            };
+            dbContext.Invitations.Add(inv);
+            await dbContext.SaveChangesAsync();
+            scopedId = inv.Id;
+        }
+
+        var response = await PostResendAsync(scopedId, token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     private sealed record LoginResponse(string AccessToken, int ExpiresIn);
     private sealed record CreateLandlordInvitationResponse(Guid InvitationId, string Message);
+    private sealed record ResendLandlordInvitationResponse(Guid InvitationId, string Message);
+    private sealed record GetLandlordInvitationsResponse(IReadOnlyList<LandlordInvitationItem> Items, int TotalCount);
+    private sealed record LandlordInvitationItem(
+        Guid Id, string Email, DateTime CreatedAt, DateTime ExpiresAt, DateTime? UsedAt, string Status, string InvitedBy);
 }

--- a/backend/tests/PropertyManager.Application.Tests/Invitations/GetLandlordInvitationsTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Invitations/GetLandlordInvitationsTests.cs
@@ -1,0 +1,253 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using MockQueryable.Moq;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.Invitations;
+using PropertyManager.Domain.Entities;
+
+namespace PropertyManager.Application.Tests.Invitations;
+
+/// <summary>
+/// Unit tests for GetLandlordInvitationsQueryHandler (Story 22.4, AC: #3).
+/// Returns only AccountId == null invitations, ordered by CreatedAt desc,
+/// with status derivation and InvitedBy display name resolution.
+/// </summary>
+public class GetLandlordInvitationsTests
+{
+    private readonly Mock<IAppDbContext> _mockDbContext;
+    private readonly Mock<IIdentityService> _mockIdentityService;
+    private readonly Mock<ILogger<GetLandlordInvitationsQueryHandler>> _mockLogger;
+    private readonly GetLandlordInvitationsQueryHandler _handler;
+
+    public GetLandlordInvitationsTests()
+    {
+        _mockDbContext = new Mock<IAppDbContext>();
+        _mockIdentityService = new Mock<IIdentityService>();
+        _mockLogger = new Mock<ILogger<GetLandlordInvitationsQueryHandler>>();
+
+        _mockIdentityService
+            .Setup(x => x.GetUserDisplayNamesAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string>());
+
+        _handler = new GetLandlordInvitationsQueryHandler(
+            _mockDbContext.Object,
+            _mockIdentityService.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsOnlyNullAccountInvitations_ExcludesAccountScoped()
+    {
+        // Arrange — AC: 22.4 #3 — only AccountId == null rows are landlord invitations
+        var invitations = new List<Invitation>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Email = "landlord1@example.com",
+                CodeHash = "h1",
+                Role = "Owner",
+                AccountId = null,
+                CreatedAt = DateTime.UtcNow.AddHours(-1),
+                ExpiresAt = DateTime.UtcNow.AddHours(23)
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Email = "accountscoped@example.com",
+                CodeHash = "h2",
+                Role = "Contributor",
+                AccountId = Guid.NewGuid(),
+                CreatedAt = DateTime.UtcNow.AddHours(-2),
+                ExpiresAt = DateTime.UtcNow.AddHours(22)
+            }
+        };
+
+        var mockDbSet = invitations.BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        // Act
+        var result = await _handler.Handle(new GetLandlordInvitationsQuery(), CancellationToken.None);
+
+        // Assert
+        result.Items.Should().HaveCount(1);
+        result.TotalCount.Should().Be(1);
+        result.Items[0].Email.Should().Be("landlord1@example.com");
+    }
+
+    [Fact]
+    public async Task Handle_OrdersByCreatedAtDescending()
+    {
+        // Arrange — AC: 22.4 #3
+        var invitations = new List<Invitation>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Email = "older@example.com",
+                CodeHash = "h1",
+                Role = "Owner",
+                AccountId = null,
+                CreatedAt = DateTime.UtcNow.AddHours(-5),
+                ExpiresAt = DateTime.UtcNow.AddHours(19)
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Email = "newer@example.com",
+                CodeHash = "h2",
+                Role = "Owner",
+                AccountId = null,
+                CreatedAt = DateTime.UtcNow.AddHours(-1),
+                ExpiresAt = DateTime.UtcNow.AddHours(23)
+            }
+        };
+
+        var mockDbSet = invitations.BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        // Act
+        var result = await _handler.Handle(new GetLandlordInvitationsQuery(), CancellationToken.None);
+
+        // Assert
+        result.Items[0].Email.Should().Be("newer@example.com");
+        result.Items[1].Email.Should().Be("older@example.com");
+    }
+
+    [Theory]
+    [InlineData(false, false, "Pending")]
+    [InlineData(false, true, "Expired")]
+    [InlineData(true, false, "Accepted")]
+    public async Task Handle_DerivesStatusCorrectly(bool used, bool expired, string expectedStatus)
+    {
+        // Arrange — AC: 22.4 #3 — status derivation matches Settings (Pending/Expired/Accepted)
+        var invitation = new Invitation
+        {
+            Id = Guid.NewGuid(),
+            Email = "status@example.com",
+            CodeHash = "h",
+            Role = "Owner",
+            AccountId = null,
+            CreatedAt = DateTime.UtcNow.AddHours(-2),
+            ExpiresAt = expired ? DateTime.UtcNow.AddHours(-1) : DateTime.UtcNow.AddHours(23),
+            UsedAt = used ? DateTime.UtcNow.AddHours(-1) : null
+        };
+
+        var mockDbSet = new List<Invitation> { invitation }.BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        // Act
+        var result = await _handler.Handle(new GetLandlordInvitationsQuery(), CancellationToken.None);
+
+        // Assert
+        result.Items[0].Status.Should().Be(expectedStatus);
+    }
+
+    [Fact]
+    public async Task Handle_PopulatesInvitedByFromIdentityService()
+    {
+        // Arrange — AC: 22.4 #3 — InvitedBy resolved from the inviting user's display name
+        var invitedByUserId = Guid.NewGuid();
+        var invitation = new Invitation
+        {
+            Id = Guid.NewGuid(),
+            Email = "withinviter@example.com",
+            CodeHash = "h",
+            Role = "Owner",
+            AccountId = null,
+            InvitedByUserId = invitedByUserId,
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+            ExpiresAt = DateTime.UtcNow.AddHours(23)
+        };
+
+        var mockDbSet = new List<Invitation> { invitation }.BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        _mockIdentityService
+            .Setup(x => x.GetUserDisplayNamesAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [invitedByUserId] = "Admin Person" });
+
+        // Act
+        var result = await _handler.Handle(new GetLandlordInvitationsQuery(), CancellationToken.None);
+
+        // Assert
+        result.Items[0].InvitedBy.Should().Be("Admin Person");
+    }
+
+    [Fact]
+    public async Task Handle_InvitedByUserIdNull_ReturnsEmptyInvitedBy()
+    {
+        // Arrange — defensive: an invitation with no inviter resolves to empty string, not a crash
+        var invitation = new Invitation
+        {
+            Id = Guid.NewGuid(),
+            Email = "noinviter@example.com",
+            CodeHash = "h",
+            Role = "Owner",
+            AccountId = null,
+            InvitedByUserId = null,
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+            ExpiresAt = DateTime.UtcNow.AddHours(23)
+        };
+
+        var mockDbSet = new List<Invitation> { invitation }.BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        // Act
+        var result = await _handler.Handle(new GetLandlordInvitationsQuery(), CancellationToken.None);
+
+        // Assert
+        result.Items[0].InvitedBy.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_NoInvitations_ReturnsEmptyResponse()
+    {
+        // Arrange — AC: 22.4 #3 — empty state
+        var mockDbSet = new List<Invitation>().BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        // Act
+        var result = await _handler.Handle(new GetLandlordInvitationsQuery(), CancellationToken.None);
+
+        // Assert
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_MapsAllFieldsCorrectly()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var createdAt = DateTime.UtcNow.AddHours(-3);
+        var expiresAt = DateTime.UtcNow.AddHours(21);
+        var invitation = new Invitation
+        {
+            Id = id,
+            Email = "fields@example.com",
+            CodeHash = "h",
+            Role = "Owner",
+            AccountId = null,
+            CreatedAt = createdAt,
+            ExpiresAt = expiresAt,
+            UsedAt = null
+        };
+
+        var mockDbSet = new List<Invitation> { invitation }.BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        // Act
+        var result = await _handler.Handle(new GetLandlordInvitationsQuery(), CancellationToken.None);
+
+        // Assert
+        var dto = result.Items[0];
+        dto.Id.Should().Be(id);
+        dto.Email.Should().Be("fields@example.com");
+        dto.CreatedAt.Should().Be(createdAt);
+        dto.ExpiresAt.Should().Be(expiresAt);
+        dto.UsedAt.Should().BeNull();
+        dto.Status.Should().Be("Pending");
+    }
+}

--- a/backend/tests/PropertyManager.Application.Tests/Invitations/ResendLandlordInvitationTests.cs
+++ b/backend/tests/PropertyManager.Application.Tests/Invitations/ResendLandlordInvitationTests.cs
@@ -1,0 +1,212 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using MockQueryable.Moq;
+using Moq;
+using PropertyManager.Application.Common.Interfaces;
+using PropertyManager.Application.Invitations;
+using PropertyManager.Domain.Entities;
+using PropertyManager.Domain.Exceptions;
+
+namespace PropertyManager.Application.Tests.Invitations;
+
+/// <summary>
+/// Unit tests for ResendLandlordInvitationCommandHandler (Story 22.4, AC: #6).
+/// Looks up by AccountId == null, re-creates a null-account Owner invitation,
+/// and sends the landlord-flavored email (not co-owner or tenant).
+/// </summary>
+public class ResendLandlordInvitationTests
+{
+    private readonly Mock<IAppDbContext> _mockDbContext;
+    private readonly Mock<IEmailService> _mockEmailService;
+    private readonly Mock<ICurrentUser> _mockCurrentUser;
+    private readonly Mock<ILogger<ResendLandlordInvitationCommandHandler>> _mockLogger;
+    private readonly ResendLandlordInvitationCommandHandler _handler;
+
+    private readonly Guid _adminUserId = Guid.NewGuid();
+
+    public ResendLandlordInvitationTests()
+    {
+        _mockDbContext = new Mock<IAppDbContext>();
+        _mockEmailService = new Mock<IEmailService>();
+        _mockCurrentUser = new Mock<ICurrentUser>();
+        _mockLogger = new Mock<ILogger<ResendLandlordInvitationCommandHandler>>();
+
+        _mockCurrentUser.Setup(x => x.UserId).Returns(_adminUserId);
+
+        _handler = new ResendLandlordInvitationCommandHandler(
+            _mockDbContext.Object,
+            _mockEmailService.Object,
+            _mockCurrentUser.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ExpiredLandlordInvitation_CreatesFreshNullAccountOwnerAndSendsLandlordEmail()
+    {
+        // Arrange — AC: 22.4 #6
+        var original = new Invitation
+        {
+            Id = Guid.NewGuid(),
+            Email = "landlord@example.com",
+            CodeHash = "old-hash",
+            Role = "Owner",
+            AccountId = null,
+            InvitedByUserId = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow.AddDays(-2),
+            ExpiresAt = DateTime.UtcNow.AddDays(-1), // Expired
+            UsedAt = null
+        };
+
+        var invitations = new List<Invitation> { original };
+        var mockDbSet = invitations.BuildMockDbSet();
+        mockDbSet.Setup(x => x.Add(It.IsAny<Invitation>())).Callback<Invitation>(inv =>
+        {
+            inv.Id = Guid.NewGuid();
+            invitations.Add(inv);
+        });
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+        _mockDbContext.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        _mockEmailService.Setup(x => x.SendLandlordInvitationEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var command = new ResendLandlordInvitationCommand(original.Id);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.InvitationId.Should().NotBe(Guid.Empty);
+        result.Message.Should().Contain("resent");
+
+        invitations.Should().HaveCount(2);
+        var created = invitations[1];
+        created.Email.Should().Be("landlord@example.com");
+        created.AccountId.Should().BeNull();
+        created.Role.Should().Be("Owner");
+        created.PropertyId.Should().BeNull();
+        created.InvitedByUserId.Should().Be(_adminUserId);
+        created.CodeHash.Should().NotBe("old-hash");
+        created.ExpiresAt.Should().BeAfter(DateTime.UtcNow.AddHours(23));
+
+        _mockEmailService.Verify(x => x.SendLandlordInvitationEmailAsync(
+            "landlord@example.com", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockEmailService.Verify(x => x.SendInvitationEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockEmailService.Verify(x => x.SendTenantInvitationEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        _mockDbContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoMatchingNullAccountInvitation_ThrowsNotFoundException()
+    {
+        // Arrange — an account-scoped invitation must NOT be resendable through this handler
+        var accountScoped = new Invitation
+        {
+            Id = Guid.NewGuid(),
+            Email = "scoped@example.com",
+            CodeHash = "h",
+            Role = "Owner",
+            AccountId = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow.AddDays(-2),
+            ExpiresAt = DateTime.UtcNow.AddDays(-1),
+            UsedAt = null
+        };
+
+        var mockDbSet = new List<Invitation> { accountScoped }.BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        var command = new ResendLandlordInvitationCommand(accountScoped.Id);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_UsedInvitation_ThrowsValidationException()
+    {
+        // Arrange — AC: 22.4 #6 — cannot resend a used invitation
+        var used = new Invitation
+        {
+            Id = Guid.NewGuid(),
+            Email = "used@example.com",
+            CodeHash = "h",
+            Role = "Owner",
+            AccountId = null,
+            CreatedAt = DateTime.UtcNow.AddDays(-2),
+            ExpiresAt = DateTime.UtcNow.AddDays(-1),
+            UsedAt = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var mockDbSet = new List<Invitation> { used }.BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        var command = new ResendLandlordInvitationCommand(used.Id);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<FluentValidation.ValidationException>()
+            .WithMessage("*used*");
+    }
+
+    [Fact]
+    public async Task Handle_NotYetExpiredInvitation_ThrowsValidationException()
+    {
+        // Arrange — AC: 22.4 #6 — can only resend expired invitations
+        var active = new Invitation
+        {
+            Id = Guid.NewGuid(),
+            Email = "active@example.com",
+            CodeHash = "h",
+            Role = "Owner",
+            AccountId = null,
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+            ExpiresAt = DateTime.UtcNow.AddHours(23),
+            UsedAt = null
+        };
+
+        var mockDbSet = new List<Invitation> { active }.BuildMockDbSet();
+        _mockDbContext.Setup(x => x.Invitations).Returns(mockDbSet.Object);
+
+        var command = new ResendLandlordInvitationCommand(active.Id);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<FluentValidation.ValidationException>()
+            .WithMessage("*expired*");
+    }
+}
+
+/// <summary>
+/// Unit tests for ResendLandlordInvitationCommandValidator.
+/// </summary>
+public class ResendLandlordInvitationValidatorTests
+{
+    [Fact]
+    public void Validate_ValidId_Passes()
+    {
+        var validator = new ResendLandlordInvitationCommandValidator();
+        var result = validator.Validate(new ResendLandlordInvitationCommand(Guid.NewGuid()));
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyId_Fails()
+    {
+        var validator = new ResendLandlordInvitationCommandValidator();
+        var result = validator.Validate(new ResendLandlordInvitationCommand(Guid.Empty));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "InvitationId");
+    }
+}

--- a/docs/project/sprint-status.yaml
+++ b/docs/project/sprint-status.yaml
@@ -377,5 +377,5 @@ development_status:
   22-1-platform-admin-role-permission-infrastructure: done    # FR-LP4, NFR-LP1, NFR-LP4 - Size 3
   22-2-create-landlord-invitation-api-and-email: done    # FR-LP1, FR-LP3, FR-LP4, NFR-LP1, NFR-LP2 - Size 5
   22-3-accept-landlord-invitation-verification: done    # FR-LP2, FR-LP6, NFR-LP3 - Size 3
-  22-4-admin-console-landlord-invitations-ui: pending    # FR-LP1, FR-LP5 - Size 5
+  22-4-admin-console-landlord-invitations-ui: done    # FR-LP1, FR-LP5 - Size 5
   epic-22-retrospective: optional

--- a/docs/project/stories/epic-22/22-4-admin-console-landlord-invitations-ui.md
+++ b/docs/project/stories/epic-22/22-4-admin-console-landlord-invitations-ui.md
@@ -1,0 +1,376 @@
+# Story 22.4: Admin Console UI — List, Create, Resend Landlord Invitations
+
+Status: done
+
+## Story
+
+As the platform administrator,
+I want a small admin console in the app where I can create landlord invitations, see existing ones with their status, and resend expired invitations,
+so that I can manage beta onboarding without touching Postman or curl.
+
+This is the **frontend UI** for the landlord-provisioning API delivered in Stories 22.1 (PlatformAdmin claim + `CanInviteLandlords` policy), 22.2 (`POST /api/v1/admin/landlord-invitations`), and 22.3 (accept-side verification). Story 22.1 already shipped the reactive `PermissionService.isPlatformAdmin` signal that this story consumes for nav visibility and the route guard.
+
+> **IMPORTANT — scope is larger than "frontend-only".** Grounding against the current codebase (this turn) revealed **two backend gaps** that this story MUST close before the UI can work. The epic doc framed 22.4 as a UI story, but:
+> 1. **There is no GET endpoint that returns landlord invitations.** AC-22.4.3 requires listing invitations where `AccountId = null`. The only existing list query, `GetAccountInvitationsQuery` (`GetAccountInvitations.cs:52-53`), filters `i.AccountId == _currentUser.AccountId` — it can NEVER return null-`AccountId` rows. A new admin-scoped `GET /api/v1/admin/landlord-invitations` endpoint + query is required.
+> 2. **The existing resend handler cannot resend a landlord invitation.** `ResendInvitationCommandHandler` (`ResendInvitation.cs:50`) filters `i.AccountId == _currentUser.AccountId`, then re-creates the new invitation with `AccountId = _currentUser.AccountId` (line 87) and sends the **co-owner** email (`SendInvitationEmailAsync`, line 116). For a landlord invitation `AccountId == null`, so the lookup returns null → `NotFoundException`; even if found, it would corrupt the invitation by stamping the admin's `AccountId` and send the wrong email template. **This is exactly the authorization/handler decision the epic flagged at line ~220 — see the "Resend Authorization Decision" section below, which resolves it explicitly.**
+>
+> Because this story adds/changes backend endpoints, it requires **WebApplicationFactory integration tests** (not skippable as "frontend-only").
+
+## Acceptance Criteria
+
+1. **AC-22.4.1 — "Admin" nav entry visible only to PlatformAdmins.**
+   **Given** a user whose JWT carries `platformAdmin=true` (so `PermissionService.isPlatformAdmin()` / `AuthService.currentUser()?.isPlatformAdmin` is `true`),
+   **When** they are logged in and viewing the app shell,
+   **Then** the side navigation shows an "Admin" entry (icon `admin_panel_settings`, route `/admin`), visually separated from the per-account nav items by a `mat-divider`. **And** a user without the claim (regular Owner, Contributor, Tenant) does **not** see the "Admin" entry at all.
+
+2. **AC-22.4.2 — Admin landing page with a Landlord Invitations section.**
+   **Given** a PlatformAdmin clicks the "Admin" nav entry,
+   **When** the `/admin` route loads,
+   **Then** they see an admin console landing page with a page title (e.g. "Admin Console") and a card/section for "Landlord Invitations" (mirroring the `mat-card` section pattern used on the Settings page).
+
+3. **AC-22.4.3 — List all landlord invitations with status.**
+   **Given** a PlatformAdmin on the Landlord Invitations view,
+   **When** the view loads,
+   **Then** it calls `GET /api/v1/admin/landlord-invitations` and renders a table of all landlord invitations (those with `AccountId = null`) ordered by created-at descending, with columns: **Email**, **Created** (`mediumDate`), **Expires** (`mediumDate`), **Status** (`Pending` / `Accepted` / `Expired` rendered as a `mat-chip` with the same `status-*` classes as Settings), and **Invited By** (the inviting admin's display name or email). When there are zero landlord invitations, an empty-state message ("No landlord invitations yet.") is shown instead of an empty table.
+
+4. **AC-22.4.4 — Create-invitation dialog (email only).**
+   **Given** the Landlord Invitations view,
+   **When** the PlatformAdmin clicks "Invite New Landlord",
+   **Then** a Material dialog opens asking only for an email address (no role/property/account fields), and submitting a valid email calls `POST /api/v1/admin/landlord-invitations` with body `{ email }`.
+
+5. **AC-22.4.5 — Successful create refreshes the list and confirms via snackbar.**
+   **Given** a valid email submitted in the create dialog,
+   **When** the API returns `201 Created`,
+   **Then** the dialog closes, the invitations list reloads (the new row appears with status "Pending"), and a `MatSnackBar` success message confirms the invitation was sent (e.g. `Landlord invitation sent to <email>`).
+
+6. **AC-22.4.6 — Resend an expired landlord invitation.**
+   **Given** a landlord invitation whose status is "Expired" in the list,
+   **When** the PlatformAdmin clicks "Resend" on that row,
+   **Then** the resend call succeeds (per the Resend Authorization Decision below), a new landlord invitation with a fresh 24-hour expiry is created (and a landlord-flavored email is sent), the list refreshes to show the new Pending row, and a success snackbar confirms the resend. The "Resend" action is shown **only** for rows whose status is "Expired" (matching the Settings page rule).
+
+7. **AC-22.4.7 — Route guard blocks non-admins from deep-linking `/admin`.**
+   **Given** a non-PlatformAdmin user (Owner without the claim, Contributor, or Tenant),
+   **When** they navigate directly to `/admin` (deep link or typed URL),
+   **Then** a functional `platformAdminGuard` denies activation and redirects them to their normal landing page (`/dashboard` for Owner/Contributor; `/tenant` for Tenant), and the admin view never renders. An authenticated PlatformAdmin is allowed through.
+
+8. **AC-22.4.8 — Form validation matches existing patterns.**
+   **Given** the create-invitation dialog,
+   **When** the email field is empty or malformed,
+   **Then** a `mat-error` is shown ("Email is required" / "Invalid email format") and submitting an invalid form does not call the API (the form is marked touched and the submit is a no-op) — mirroring the `InviteUserDialogComponent` validation pattern (`Validators.required`, `Validators.email`).
+
+9. **AC-22.4.9 — Admin console follows Upkeep visual language (desktop).**
+   **Given** the admin console rendered on desktop,
+   **When** viewed,
+   **Then** it uses the established Upkeep components and layout: Angular Material `mat-card` sections, the same plain `<table class="data-table">` + `mat-chip` status-badge pattern used on the Settings page (NOT raw `mat-table` — Settings uses a styled HTML table; mirror it for consistency), `mat-raised-button color="primary"` for the primary action, `MatSnackBar` for feedback, and "obvious not clever" copy.
+
+## Resend Authorization Decision (epic note ~line 220 — RESOLVED)
+
+The epic deferred this decision: *"the existing `[Authorize(Policy = "CanManageUsers")]` on the resend route must also accept PlatformAdmin for landlord invitations specifically — implement by checking the invitation type in the handler and allowing either policy, OR by adding a parallel admin route."*
+
+**Decision: add a parallel admin resend route — `POST /api/v1/admin/landlord-invitations/{id}/resend` — gated by `[Authorize(Policy = "CanInviteLandlords")]`, backed by a new `ResendLandlordInvitationCommand` handler. Do NOT overload the existing `/api/v1/invitations/{id}/resend` route or the existing `ResendInvitationCommandHandler`.**
+
+Rationale (verified against current code, this turn):
+
+- **The existing handler is structurally account-scoped and would corrupt a landlord invitation.** `ResendInvitation.cs:50` looks the invitation up with `i.AccountId == _currentUser.AccountId`. A landlord invitation has `AccountId == null`, so for a PlatformAdmin (who is Owner of their *own* account) this returns `null` → `NotFoundException`. Worse, the new row it builds stamps `AccountId = _currentUser.AccountId` (line 87) and calls `SendInvitationEmailAsync` (the **co-owner** email, line 116) — both wrong for a landlord invitation. Making the existing handler branch on `AccountId == null` would entangle two flows in one handler and re-introduce the kind of conditional sprawl 22.2 deliberately avoided.
+- **The parallel route keeps the gate at the controller (NFR-LP2 seam).** Same architecture decision as 22.2: a future public `/signup` flow could reuse the landlord-resend handler without the PlatformAdmin policy. The handler stays permission-agnostic; the gate lives on the admin controller via `[Authorize(Policy = "CanInviteLandlords")]`.
+- **It mirrors 22.2 exactly** (`AdminLandlordInvitationsController` already exists with the `CanInviteLandlords` policy). Adding a second action to that controller is the lowest-friction, most consistent option.
+- **Consequence — the existing `/api/v1/invitations/{id}/resend` route is unchanged** (still `CanManageUsers`, still account-scoped). No regression risk to the co-owner/tenant resend flow (Story 19.6).
+
+The new `ResendLandlordInvitationCommandHandler` mirrors `ResendInvitationCommandHandler` but: (a) looks the invitation up by `i.Id == request.InvitationId && i.AccountId == null`; (b) re-creates the new row with `AccountId = null`, `Role = "Owner"`, `PropertyId = null`, `InvitedByUserId = _currentUser.UserId`; (c) calls `_emailService.SendLandlordInvitationEmailAsync(...)` (the 22.2 template), not `SendInvitationEmailAsync`; (d) keeps the same guards (cannot resend a `UsedAt != null` invitation; can only resend an expired one).
+
+## Tasks / Subtasks
+
+### Backend — list endpoint (AC: #3)
+
+- [x] **Task 1: Add `GetLandlordInvitations` query + handler** (AC: #3)
+  - [x] 1.1 New file `backend/src/PropertyManager.Application/Invitations/GetLandlordInvitations.cs`. Mirror `GetAccountInvitations.cs` but:
+    - Query `_dbContext.Invitations.Where(i => i.AccountId == null).OrderByDescending(i => i.CreatedAt)`.
+    - Add an `InvitedBy` field to the DTO so AC-22.4.3's "Invited By" column has data. Resolve it from the inviting user: join/lookup the inviting `ApplicationUser` via `IIdentityService` or query the users table for `DisplayName`/`Email` by `InvitedByUserId`. (Verify how 19.7 / `AccountUserDto` resolves a display name — reuse that mechanism; do NOT hand-roll a new Identity query if a helper exists.)
+    - Reuse the `DeriveStatus` logic (`Accepted` / `Expired` / `Pending`) verbatim from `GetAccountInvitations.cs:71-76` so the UI status values are identical to Settings. **Note:** the epic AC says "Used" but the existing codebase status string is `"Accepted"` — use `"Accepted"` for consistency with the existing UI/CSS classes; the dialog/list copy may still read naturally.
+  - [x] 1.2 DTO shape suggestion: `public record LandlordInvitationDto(Guid Id, string Email, DateTime CreatedAt, DateTime ExpiresAt, DateTime? UsedAt, string Status, string InvitedBy);` and `public record GetLandlordInvitationsResponse(IReadOnlyList<LandlordInvitationDto> Items, int TotalCount);`.
+  - [x] 1.3 **CWE-359 / cleartext-storage:** the success log must carry ONLY a count (e.g. `_logger.LogInformation("Retrieved {Count} landlord invitations", dtos.Count);`). Do NOT log emails, `AccountId`, `UserId`, or `InvitationId` lists. (See "Critical: logging" in Dev Notes — Stories 22-1/22-2/22-3 all had logs ripped out post-PR; commit `398dca3` specifically dropped `AccountId` from a 22-3 log after CodeQL `cs/cleartext-storage` flagged it.)
+
+- [x] **Task 2: Add `GET` action to `AdminLandlordInvitationsController`** (AC: #3)
+  - [x] 2.1 Add `[HttpGet]` action returning `GetLandlordInvitationsResponse` (200) to the existing `backend/src/PropertyManager.Api/Controllers/AdminLandlordInvitationsController.cs`. The class already carries `[Authorize(... Policy = "CanInviteLandlords")]`, so the new action is gated automatically.
+  - [x] 2.2 Add `[ProducesResponseType(typeof(GetLandlordInvitationsResponse), StatusCodes.Status200OK)]` + `401`/`403` for NSwag.
+
+### Backend — resend endpoint (AC: #6, per Resend Authorization Decision)
+
+- [x] **Task 3: Add `ResendLandlordInvitation` command + handler** (AC: #6)
+  - [x] 3.1 New file `backend/src/PropertyManager.Application/Invitations/ResendLandlordInvitation.cs`. Mirror `ResendInvitation.cs` structure (command record, result record, handler) with the landlord-specific changes enumerated in the "Resend Authorization Decision" section: lookup by `AccountId == null`, re-create with `AccountId = null` / `Role = "Owner"` / `PropertyId = null`, call `SendLandlordInvitationEmailAsync`.
+  - [x] 3.2 Keep the existing guards: throw `NotFoundException(nameof(Invitation), id)` when not found (null-`AccountId` lookup miss); throw `FluentValidation.ValidationException` on `UsedAt != null` ("Cannot resend an invitation that has already been used") and on not-yet-expired ("Can only resend expired invitations"). These map to 404/400 via existing middleware + the controller try/catch pattern.
+  - [x] 3.3 Lift `GenerateSecureCode` / `ComputeHash` static helpers (same as 22.2 — duplication across handlers is the accepted project convention; do NOT refactor into a shared utility).
+  - [x] 3.4 Success log: carry ONLY `"Resent landlord invitation"` with no IDs/email (CWE-359 / cleartext-storage discipline — see Task 1.3 note). If a correlation value is genuinely needed for diagnostics, prefer a trace id; do NOT log `InvitationId`, `OriginalId`, `AccountId`, or `Email`.
+
+- [x] **Task 4: Add `POST {id}/resend` action to `AdminLandlordInvitationsController`** (AC: #6)
+  - [x] 4.1 Add `[HttpPost("{id:guid}/resend")]` action dispatching `ResendLandlordInvitationCommand(id)`, returning `201 Created` with `{ invitationId, message }` (mirror the existing `InvitationsController.ResendInvitation` action shape, including the `try/catch (ValidationException)` → `ValidationProblemDetails`, lines 70-95). Gated by the class-level `CanInviteLandlords` policy.
+  - [x] 4.2 Add `[ProducesResponseType]` for 201/400/401/403/404.
+  - [x] 4.3 Wire a validator if the existing resend uses one (`ResendInvitationValidator.cs` exists — create a peer `ResendLandlordInvitationValidator.cs` only if the existing controller calls a validator before `_mediator.Send`; otherwise dispatch directly. Verify against `InvitationsController.ResendInvitation` — it calls `_resendValidator.ValidateAsync`).
+
+### Backend — tests
+
+- [x] **Task 5: Backend unit tests** (AC: #3, #6)
+  - [x] 5.1 New `backend/tests/PropertyManager.Application.Tests/Invitations/GetLandlordInvitationsTests.cs`: returns only `AccountId == null` rows; excludes account-scoped invitations; ordered by `CreatedAt` desc; status derivation (`Pending`/`Expired`/`Accepted`); `InvitedBy` populated; empty list → empty response with `TotalCount == 0`. Use `Mock<IAppDbContext>` + `MockQueryable.Moq` (`BuildMockDbSet()`).
+  - [x] 5.2 New `backend/tests/PropertyManager.Application.Tests/Invitations/ResendLandlordInvitationTests.cs`: happy path re-creates with `AccountId == null` / `Role == "Owner"` and calls `SendLandlordInvitationEmailAsync` (verify `SendInvitationEmailAsync` and `SendTenantInvitationEmailAsync` are `Times.Never`); not-found when no null-`AccountId` invitation matches; `UsedAt != null` → `ValidationException`; not-yet-expired → `ValidationException`.
+
+- [x] **Task 6: Backend integration tests (WebApplicationFactory + Testcontainers)** (AC: #3, #6, plus auth)
+  - [x] 6.1 Extend `backend/tests/PropertyManager.Api.Tests/AdminLandlordInvitationsControllerTests.cs` (created in 22.2). Reuse `GrantPlatformAdminClaimAsync` / `CreatePlatformAdminAsync` helpers already in that file.
+  - [x] 6.2 **GET list tests:** `GetLandlordInvitations_AsPlatformAdmin_Returns200WithNullAccountInvitations` (seed via `POST` create as admin, then GET, assert the created invitation appears and account-scoped invitations created via `/api/v1/invitations` do NOT appear); `GetLandlordInvitations_AsRegularOwner_Returns403`; `GetLandlordInvitations_AsUnauthenticated_Returns401`.
+  - [x] 6.3 **Resend tests:** `ResendLandlordInvitation_AsPlatformAdmin_ExpiredInvitation_Returns201_CreatesFreshNullAccountInvitation` (seed an EXPIRED landlord invitation directly in the DB with `AccountId = null` and `ExpiresAt` in the past — mirror the seeding pattern in `InvitationsControllerTests`; after resend, query DB and assert a new `AccountId == null` row with fresh `ExpiresAt > now`, and assert `FakeEmailService.SentLandlordInvitationEmails` got the entry while `SentInvitationEmails` did NOT); `ResendLandlordInvitation_AsRegularOwner_Returns403`; `ResendLandlordInvitation_NotYetExpired_Returns400`; `ResendLandlordInvitation_AlreadyUsed_Returns400`; `ResendLandlordInvitation_NonExistentId_Returns404`. Read the 400 response **body** and assert the `errors`/`detail` message (per Story 22.1 Finding #3 — assert body shape, not just status).
+
+### Frontend — API client, store, service
+
+- [x] **Task 7: Regenerate the NSwag client** (AC: #3, #6)
+  - [x] 7.1 After Tasks 1-4 land and the backend builds, run `cd frontend && npm run generate-api`. Confirm the generated `api.service.ts` gains `adminLandlordInvitations_GetLandlordInvitations()` and `adminLandlordInvitations_ResendLandlordInvitation(id)` plus the `LandlordInvitationDto` / `GetLandlordInvitationsResponse` / resend response types. (`adminLandlordInvitations_CreateLandlordInvitation` already exists from 22.2 — verified this turn at `api.service.ts:22`.) Commit the regenerated client; do NOT hand-edit it.
+
+- [x] **Task 8: Admin store** (AC: #3, #5, #6)
+  - [x] 8.1 New `frontend/src/app/features/admin/stores/admin.store.ts` using `signalStore({ providedIn: 'root' }, withState(...), withMethods(...))`. State: `{ invitations: LandlordInvitationDto[]; loading: boolean; error: string | null }`. **Mirror `UserManagementStore` (`features/settings/stores/user-management.store.ts`) closely** — it is the canonical precedent (load via `rxMethod`, `patchState`, `MatSnackBar` feedback, error extraction from `error.errors`/`error.title`, a private `reloadInvitations()` helper used after create/resend).
+  - [x] 8.2 Methods: `loadInvitations` (rxMethod, calls `api.adminLandlordInvitations_GetLandlordInvitations()`), `createInvitation` ({ email }, calls `adminLandlordInvitations_CreateLandlordInvitation({ email })`, on success snackbar `Landlord invitation sent to <email>` + reload), `resendInvitation` (id, calls `adminLandlordInvitations_ResendLandlordInvitation(id)`, on success snackbar + reload). Match the snackbar config (`duration`, position) used in `UserManagementStore`.
+  - [x] 8.3 Inject `ApiClient` directly inside `withMethods` (the settings store injects the generated `ApiClient` — there is no separate hand-written `admin.service.ts` needed; the generated client IS the service layer, consistent with `UserManagementStore`). **Skip a separate `admin.service.ts`** unless the dev finds non-trivial transformation logic — note this deviation from the epic's suggested file list and justify in the Dev Agent Record. (The epic listed `admin.service.ts`, but the established 19.6/19.7 pattern injects `ApiClient` straight into the store.)
+
+### Frontend — guard, route, components, nav
+
+- [x] **Task 9: `platformAdminGuard` functional route guard** (AC: #7)
+  - [x] 9.1 New `frontend/src/app/core/auth/platform-admin.guard.ts`. Mirror `owner.guard.ts` exactly (functional `CanActivateFn`, `inject(AuthService)`, `inject(Router)`). Allow when `authService.currentUser()?.isPlatformAdmin === true`; otherwise redirect: Tenant → `router.createUrlTree(['/tenant'])`, everyone else → `router.createUrlTree(['/dashboard'])`. (Runs inside the Shell, which already applies `authGuard`, so authentication is guaranteed by the time this runs — same assumption documented in `owner.guard.ts`.)
+
+- [x] **Task 10: Admin feature components + route** (AC: #2, #3, #4, #5, #6, #8, #9)
+  - [x] 10.1 New feature folder `frontend/src/app/features/admin/`. Components (all standalone, signal-based, `inject()`):
+    - `admin-landing.component.ts` — route landing; page title "Admin Console"; renders the Landlord Invitations section. May host the list directly or compose `landlord-invitations-list`.
+    - `components/landlord-invitations-list/landlord-invitations-list.component.ts` — the `mat-card` + `<table class="data-table">` + `mat-chip` status pattern copied from `settings.component.ts:56-115`. "Invite New Landlord" button (`mat-raised-button color="primary"`) opens the create dialog via `MatDialog`. "Resend" `mat-button` shown only for `status === 'Expired'` rows (mirror `settings.component.ts:97-106`). Empty state when `store.invitations().length === 0`. Reads `store.invitations()`, `store.loading()`; calls `store.loadInvitations()` on init.
+    - `components/create-landlord-invitation-dialog/create-landlord-invitation-dialog.component.ts` — **copy `InviteUserDialogComponent` and strip the Role field** (email-only). `FormBuilder` group `{ email: ['', [Validators.required, Validators.email]] }`, `mat-form-field appearance="outline"`, `mat-error` for required/email, `onSubmit` closes with `{ email }` (or no-op + `markAllAsTouched` when invalid), `onCancel` closes undefined. Returns the email to the list component, which calls `store.createInvitation({ email })`.
+  - [x] 10.2 Register the route in `frontend/src/app/app.routes.ts` as a child of the Shell route (alongside `settings`): `{ path: 'admin', loadComponent: () => import('./features/admin/admin-landing.component').then(m => m.AdminLandingComponent), canActivate: [platformAdminGuard] }`. Import `platformAdminGuard` at the top like the other guards.
+
+- [x] **Task 11: Conditional "Admin" nav entry** (AC: #1)
+  - [x] 11.1 In `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts`, surface the admin entry conditionally. Inject `PermissionService` (or read `authService.currentUser()?.isPlatformAdmin`) and add a separate computed signal `adminNavItems` (or a guarded append) so the "Admin" item (`{ label: 'Admin', route: '/admin', icon: 'admin_panel_settings' }`) is included ONLY when `isPlatformAdmin()` is true. Do NOT fold it into the role-based `navItems` branches (a user is Owner+PlatformAdmin simultaneously — the admin entry is orthogonal to role, per 22.1's architectural decision).
+  - [x] 11.2 In `sidebar-nav.component.html`, render the admin entry **after a `mat-divider`** below the main `mat-nav-list`, so it is visually distinct as a platform-level area (AC-22.4.1). Give the link `data-testid="nav-admin"` (the template already derives test ids as `'nav-' + label.toLowerCase()` — verify the existing `@for` covers it, or add an explicit element). Ensure it does NOT appear for non-admins.
+
+### Frontend — tests
+
+- [x] **Task 12: Frontend unit tests (Vitest)** (AC: #1, #3, #5, #6, #7, #8)
+  - [x] 12.1 `admin.store.spec.ts` — `loadInvitations` populates state from the mocked `ApiClient`; `createInvitation` calls the create method, shows success snackbar, reloads; `resendInvitation` calls the resend method, shows snackbar, reloads; error paths set `error` and show error snackbar. Mock `ApiClient` methods returning `of(...)` / `throwError(...)`, mock `MatSnackBar`. Mirror `user-management.store.spec.ts`.
+  - [x] 12.2 `platform-admin.guard.spec.ts` — allows when `currentUser().isPlatformAdmin === true`; redirects Tenant to `/tenant`; redirects Owner-without-claim / Contributor to `/dashboard`; redirects when `currentUser()` is null. Mirror `owner.guard.spec.ts`. (Remember every `User` literal needs `isPlatformAdmin` per the 22.1 strict-mode lesson.)
+  - [x] 12.3 `create-landlord-invitation-dialog.component.spec.ts` — invalid/empty email keeps the dialog open (no close with value); valid email closes with `{ email }`; `mat-error` rendering for required + email. Mirror `invite-user-dialog.component.spec.ts`.
+  - [x] 12.4 `landlord-invitations-list.component.spec.ts` — renders rows from the store; shows empty state at zero; "Resend" visible only for Expired rows; clicking "Invite New Landlord" opens the dialog (mock `MatDialog.open` returning an `afterClosed()` of `{ email }`) and calls `store.createInvitation`.
+  - [x] 12.5 `sidebar-nav.component.spec.ts` (extend existing) — "Admin" entry present when `isPlatformAdmin` true; absent for Owner-without-claim, Contributor, Tenant. Update existing `User` fixtures with `isPlatformAdmin` as needed.
+
+- [x] **Task 13: E2E test (Playwright)** (AC: #1, #2, #3, #4, #5, #6)
+  - [x] 13.1 New `frontend/e2e/tests/admin/landlord-invitations.spec.ts`. Import `test`/`expect` from `e2e/fixtures/test-fixtures` (NOT `@playwright/test`). The `authenticatedUser` fixture logs in as the seeded `claude@claude.com`, who is a PlatformAdmin per 22.1 — so the admin nav/route are reachable.
+  - [x] 13.2 Happy path: assert the "Admin" nav entry is visible (`data-testid="nav-admin"`); navigate to `/admin`; assert the Landlord Invitations section renders; click "Invite New Landlord", fill a unique `landlord-${Date.now()}@example.com` email, submit; assert the success snackbar (`BasePage.expectSnackBar(...)`) and that the new row appears with status "Pending". Use the `mailhog.helper.ts` (`waitForEmail(email, "You're invited to create your Upkeep account")`) to confirm the landlord email was sent — mirror `e2e/tests/invitations/invitation-flow.spec.ts` which already uses `mailhog.getInvitationCode(...)`.
+  - [x] 13.3 Resend path (best-effort within shared-DB constraints): the spec MAY seed an expired landlord invitation by calling `POST /api/v1/admin/landlord-invitations` then time-warping is not possible — instead use `page.route()` to stub `GET /api/v1/admin/landlord-invitations` returning one row with status "Expired", click "Resend", and assert the resend POST fires + success snackbar. Document this stubbing approach in the spec (per CLAUDE.md E2E rules — `page.route()` to control data shape; "NEVER assume seed-data counts").
+  - [x] 13.4 Create a Page Object under `e2e/pages/` (e.g. `admin-landlord-invitations.page.ts`) extending `BasePage`, exposing the nav link, the invite button, the dialog email field, the submit button, the table rows, and the resend button — following the existing Page Object Model convention.
+
+### Verify
+
+- [x] **Task 14: Verify and document** (AC: all)
+  - [x] 14.1 `cd backend && dotnet build && dotnet test` — 0 errors; cite final pass/fail counts. Expected delta: ~4 unit test files of additions + ~8 integration tests in `AdminLandlordInvitationsControllerTests`.
+  - [x] 14.2 `cd frontend && npm run build && npm test -- --run` — build clean; cite test counts. (The regenerated NSwag client must not break existing specs.)
+  - [x] 14.3 `cd frontend && npm run e2e -- --workers=1` (or the project's `npm run test:e2e`) — run the new admin spec; cite pass/fail. Note any pre-existing shared-DB flakes separately (per the documented `Reset 500` FK pattern in 22.3's eval).
+  - [x] 14.4 Manual smoke (during /evaluate Phase 3): log in as `claude@claude.com`, open `/admin`, create a landlord invitation, confirm it appears + MailHog received the landlord email; if the dev server is up, drive it via Playwright MCP and save screenshots to `screenshots/`.
+
+## Dev Notes
+
+### Critical: logging (CWE-359 + cleartext-storage) — do not be the fourth (now fifth)
+
+`project-context.md` line 237 and the git history are emphatic: **NEVER log emails, user/account IDs, storage keys, or request fields — even masked.** Two CodeQL queries block merges: CWE-359 (PII) and `cs/cleartext-storage-of-sensitive-information` (account/tenant IDs). Verified this turn in git: Stories 22-1 (`5e52256`), 22-2 (`f0a1da7`), and 22-3 (commit `398dca3` — *"drop AccountId from invitation log"*, following `be41b7f` *"Potential fix for ... Clear text storage of sensitive information"*) all shipped logs that were ripped out post-PR. The new backend logs in Tasks 1 and 3 must carry only non-sensitive aggregates (a count) or nothing — no `InvitationId`, `AccountId`, `UserId`, or `Email`.
+
+### Verified codebase facts (read this turn — trust these over the epic's assumptions)
+
+| Fact | Evidence (file:line, verified this turn) |
+|---|---|
+| `PermissionService.isPlatformAdmin` signal already exists (shipped 22.1) | `frontend/src/app/core/auth/permission.service.ts:30-32` |
+| `AuthService.currentUser()?.isPlatformAdmin` field exists (shipped 22.1) | referenced by the signal above; `User` interface carries `isPlatformAdmin` |
+| `POST /api/v1/admin/landlord-invitations` create method already in generated client (22.2) | `frontend/src/app/core/api/api.service.ts:22` (`adminLandlordInvitations_CreateLandlordInvitation`) |
+| `AdminLandlordInvitationsController` exists, class-level `[Authorize(Policy="CanInviteLandlords")]` | `backend/src/PropertyManager.Api/Controllers/AdminLandlordInvitationsController.cs:15` |
+| **No GET endpoint for landlord (null-AccountId) invitations** — must be added | only `GetAccountInvitations.cs:52-53` exists, filters by `_currentUser.AccountId` |
+| **Existing resend is account-scoped & sends co-owner email** — cannot serve landlord | `ResendInvitation.cs:50` (lookup `AccountId == _currentUser.AccountId`), `:87` (re-stamps AccountId), `:116` (`SendInvitationEmailAsync`) |
+| `Invitation` is NOT an `ITenantEntity` (no global query filter) — safe to query `AccountId == null` directly | `Invitation.cs:43` (`Guid? AccountId`); no `HasQueryFilter` for `Invitations` in `AppDbContext` |
+| Status strings are `Pending`/`Expired`/`Accepted` (NOT "Used") | `GetAccountInvitations.cs:71-76` (`DeriveStatus`) |
+| Settings page uses a plain `<table class="data-table">` + `mat-chip` status, NOT `mat-table` | `settings.component.ts:68-115` |
+| Existing co-owner resend handler keeps cannot-resend-used / only-expired guards | `ResendInvitation.cs:59-74` |
+| `SendLandlordInvitationEmailAsync` (the distinct 22.2 template) is the email to use on resend | `IEmailService` (22.2); `FakeEmailService.SentLandlordInvitationEmails` for test assertions |
+
+### Frontend pattern anchors (copy these, don't invent)
+
+- **Guard:** `frontend/src/app/core/auth/owner.guard.ts` — functional `CanActivateFn`, `inject()`, `createUrlTree` redirects, Tenant special-case. `platformAdminGuard` is a near-clone keyed on `isPlatformAdmin`.
+- **Store:** `frontend/src/app/features/settings/stores/user-management.store.ts` — `signalStore` + `rxMethod` + `patchState` + `MatSnackBar` + private `reload...()` helper + error extraction from `error.errors`/`error.title`. The closest analogue (it already does load/create/resend invitations, just account-scoped).
+- **Create dialog:** `frontend/src/app/features/settings/components/invite-user-dialog/invite-user-dialog.component.ts` — `FormBuilder`, `mat-form-field appearance="outline"`, `@if`-based `mat-error`, `MatDialogRef.close(value)`. Strip the Role control for the landlord (email-only) dialog.
+- **List/table + status chips:** `frontend/src/app/features/settings/settings.component.ts:56-115` — `mat-card` section, `<table class="data-table">`, `mat-chip` with `status-pending`/`status-expired`/`status-accepted` classes, Resend button gated on `status === 'Expired'`.
+- **Nav:** `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts:61-90` (computed `navItems`, role branching) and `sidebar-nav.component.html:8-26` (`@for` over items, `data-testid`, `mat-divider` already imported via `MatDividerModule`).
+- **Routes:** `frontend/src/app/app.routes.ts:182-190` (the `settings` child route is the structural template for the new `admin` child route).
+
+### Backend pattern anchors
+
+- **Query + handler + DTO single file:** `GetAccountInvitations.cs` — copy structure for `GetLandlordInvitations.cs` (swap the `Where` clause, add `InvitedBy`).
+- **Resend command + handler:** `ResendInvitation.cs` — copy for `ResendLandlordInvitation.cs` with the landlord changes (lookup `AccountId == null`, re-create null-account, landlord email).
+- **Admin controller:** `AdminLandlordInvitationsController.cs` (22.2) — add `[HttpGet]` and `[HttpPost("{id:guid}/resend")]` actions; the class is already policy-gated. Mirror `InvitationsController.ResendInvitation` (lines 70-95) for the try/catch + `CreatedAtAction` shape.
+- **Integration test class:** `backend/tests/PropertyManager.Api.Tests/AdminLandlordInvitationsControllerTests.cs` (22.2) — extend it; reuse `GrantPlatformAdminClaimAsync`/`CreatePlatformAdminAsync` and `FakeEmailService.SentLandlordInvitationEmails`.
+
+### Resend authorization — see the dedicated "Resend Authorization Decision" section above
+
+That section is the explicit resolution of the epic note at ~line 220. Summary: **parallel admin route `POST /api/v1/admin/landlord-invitations/{id}/resend` gated by `CanInviteLandlords`, new `ResendLandlordInvitationCommandHandler`; existing `/api/v1/invitations/{id}/resend` untouched.**
+
+### Multi-PlatformAdmin / orthogonality reminder (from 22.1)
+
+PlatformAdmin is a **claim**, orthogonal to the per-account `role`. The seeded `claude@claude.com` is simultaneously `role = "Owner"` and `platformAdmin = true`. Therefore: (a) the Admin nav entry must be additive — appended for admins, not a separate role branch that hides the normal Owner nav; (b) `platformAdminGuard` keys on the claim, not on role; (c) only `claude@claude.com` is seeded as PlatformAdmin (no UI to grant the claim — out of scope per the epic).
+
+### Critical implementation rules (from project-context.md)
+
+- Frontend: standalone components, `inject()`, `input()`/`output()` signals, `@if`/`@for` control flow, signal stores `{ providedIn: 'root' }`, `MatSnackBar` for feedback, SCSS styles, Prettier (`singleQuote`, `printWidth: 100`).
+- Backend: file-scoped namespaces, records for commands/queries/DTOs, `DateTime.UtcNow`, `_camelCase` private fields, `CancellationToken` threaded, `IAppDbContext` directly (no repository), `[ProducesResponseType]` on actions, controllers `[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]`, Request/Response records at the bottom of the controller file.
+- Do NOT add try/catch in controllers for domain exceptions (middleware maps them) — EXCEPT the established `FluentValidation.ValidationException` → `ValidationProblemDetails` try/catch that `InvitationsController` uses; mirror it for the resend action.
+- Tests: `Method_Scenario_ExpectedResult`, AC codes in comments, FluentAssertions, constructor mock setup, `MockQueryable.Moq` `BuildMockDbSet()`; frontend specs co-located, `vi.fn()`, `of(...)`/`throwError(...)`; E2E imports from `e2e/fixtures/test-fixtures`, Page Object Model.
+
+### Test Scope
+
+Per `feedback_testing_pyramid` and the create-story guidance, each pyramid level is explicitly assessed:
+
+| Pyramid Level | Required? | Justification |
+|---|---|---|
+| **Unit tests (backend)** | **YES** | New `GetLandlordInvitationsQueryHandler` (filter `AccountId == null`, status derivation, `InvitedBy`) and new `ResendLandlordInvitationCommandHandler` (null-account lookup, landlord email, resend guards) are genuinely new logic — testable with `Mock<IAppDbContext>` + `MockQueryable.Moq`. Task 5. |
+| **Unit tests (frontend)** | **YES** | New `admin.store` (load/create/resend + snackbar + error paths), `platformAdminGuard` (allow/redirect matrix), create dialog (validation), list component (rows/empty/resend-gating/dialog wiring), and the sidebar nav admin-entry visibility. Task 12. |
+| **Integration tests (backend, WebApplicationFactory + Testcontainers)** | **YES — REQUIRED** | This story **adds two backend endpoints** (GET list + POST resend) with authorization, DB side-effects, and email dispatch. The epic's "frontend-only" framing was wrong (verified: no GET endpoint existed, resend was account-scoped). End-to-end HTTP coverage is the only way to prove (a) the `CanInviteLandlords` policy fires on the new routes (200/403/401), (b) the GET returns only null-`AccountId` rows and excludes account-scoped invitations, (c) resend creates a fresh null-account row and sends the landlord email (via `FakeEmailService`), (d) resend guards return 400/404 with the right body. Task 6. |
+| **E2E tests (Playwright)** | **YES — REQUIRED** | This story introduces the FIRST user-facing admin flow: the Admin nav entry, the `/admin` route + guard, the list, the create dialog, and resend. The epic explicitly assigns the admin-creates-landlord-invitation E2E to this story (epic line 221), and Stories 22.1/22.2/22.3 all deferred E2E to 22.4. Happy path (admin sees nav → opens /admin → lists → creates → MailHog confirms email) is the critical path; resend is covered via `page.route()` stubbing. Task 13. |
+
+The story includes dedicated test tasks for every required level: Task 5 (backend unit), Task 6 (backend integration), Task 12 (frontend unit), Task 13 (E2E).
+
+### Previous Story Intelligence
+
+**From Story 22.1 (PlatformAdmin Role & Permission Infrastructure):**
+- `PermissionService.isPlatformAdmin` computed signal and `User.isPlatformAdmin` field already exist — this story consumes them for nav + guard. No new auth plumbing needed.
+- The `platformAdmin` JWT claim is **omitted entirely** when false (not `"false"`); `isPlatformAdmin` derives from `payload.platformAdmin === 'true'`.
+- Adding any field to the `User` interface ripples through ~10+ frontend spec files (TypeScript strict mode). Updating `User` fixtures is unlikely here (no `User` shape change), but the guard/nav specs must include `isPlatformAdmin` in their `User` literals.
+- Evaluation Finding #3: integration tests should assert response **body** shape, not just status. Apply to the 400 resend tests.
+
+**From Story 22.2 (Create Landlord Invitation API + Email):**
+- `AdminLandlordInvitationsController` + `CanInviteLandlords` gate are live; extend the same controller with GET + resend (don't create a new controller).
+- `SendLandlordInvitationEmailAsync` is the distinct landlord email; `FakeEmailService.SentLandlordInvitationEmails` is the test hook to assert the right flavor was sent on resend.
+- `GenerateSecureCode`/`ComputeHash` are duplicated per-handler by design — duplicate again for resend; do NOT DRY.
+- The generated client method `adminLandlordInvitations_CreateLandlordInvitation` already exists (22.2 regenerated it) — Task 7 only adds GET + resend.
+
+**From Story 22.3 (Accept Landlord Invitation — Verification):**
+- CWE-359 / cleartext-storage is real and enforced post-merge: 22.3's `AccountId`-in-log was reverted by commit `398dca3` after CodeQL flagged `cs/cleartext-storage-of-sensitive-information`. The new logs in this story must avoid IDs entirely.
+- The full create→MailHog→accept→empty-dashboard flow is proven; this story's UI sits on top of that verified backend.
+
+**From Story 19.6 / 19.7 (Invitation & User Management UI):**
+- `UserManagementStore` + `InviteUserDialogComponent` + the `settings.component.ts` table are the direct precedents for this story's store/dialog/list — copy their structure and styling. The Settings invitation table already implements the exact "list invitations with status chips + Resend on Expired" UX this story needs (just account-scoped instead of admin-scoped).
+- The existing E2E `e2e/tests/invitations/invitation-flow.spec.ts` + `mailhog.helper.ts` (`getInvitationCode`, `waitForEmail`) are the precedents for the admin E2E.
+
+### References
+
+| Artifact | Section / Lines (verified this turn) |
+|---|---|
+| `docs/project/epics-landlord-provisioning.md` | Story 22.4 (lines 182-222) — ACs + technical notes; **line ~220** = resend authorization decision (resolved above); line 221 = E2E hand-off |
+| `docs/project/stories/epic-22/22-1-...md` | PlatformAdmin claim + `PermissionService.isPlatformAdmin` signal; Finding #3 (assert body shape) |
+| `docs/project/stories/epic-22/22-2-...md` | `AdminLandlordInvitationsController`, `CanInviteLandlords`, `SendLandlordInvitationEmailAsync`, `FakeEmailService.SentLandlordInvitationEmails` |
+| `docs/project/stories/epic-22/22-3-...md` | CWE-359/cleartext-storage log discipline; verified accept flow |
+| `docs/project/project-context.md` | Frontend/backend rules; line 237 (logging PII/IDs); API response shapes; testing rules |
+| `frontend/src/app/core/auth/owner.guard.ts` | Functional guard pattern to clone for `platformAdminGuard` |
+| `frontend/src/app/core/auth/permission.service.ts` | Lines 30-32 — `isPlatformAdmin` signal |
+| `frontend/src/app/features/settings/stores/user-management.store.ts` | Store pattern (load/create/resend + snackbar + error extraction) |
+| `frontend/src/app/features/settings/components/invite-user-dialog/invite-user-dialog.component.ts` | Dialog pattern (strip Role for landlord) |
+| `frontend/src/app/features/settings/settings.component.ts` | Lines 56-115 — `mat-card` + `data-table` + `mat-chip` status + Resend-on-Expired |
+| `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts` / `.html` | Nav computed items + `@for` + `mat-divider` (MatDividerModule already imported) |
+| `frontend/src/app/app.routes.ts` | Lines 182-190 — `settings` child route = template for `admin` route |
+| `frontend/src/app/core/api/api.service.ts` | Line 22 — existing `adminLandlordInvitations_CreateLandlordInvitation`; line 2328 — `invitations_ResendInvitation` (account-scoped, not for landlord) |
+| `backend/src/PropertyManager.Api/Controllers/AdminLandlordInvitationsController.cs` | Existing class to extend (GET + resend actions) |
+| `backend/src/PropertyManager.Api/Controllers/InvitationsController.cs` | Lines 48-56 (GET pattern), 70-95 (resend action try/catch + CreatedAtAction) |
+| `backend/src/PropertyManager.Application/Invitations/GetAccountInvitations.cs` | Lines 52-53 (account-scoped query — NOT reusable), 71-76 (`DeriveStatus` — reuse) |
+| `backend/src/PropertyManager.Application/Invitations/ResendInvitation.cs` | Lines 50/87/116 (why it can't serve landlord), 59-74 (resend guards to mirror) |
+| `backend/src/PropertyManager.Domain/Entities/Invitation.cs` | Line 43 — `Guid? AccountId` (nullable, not ITenantEntity → no global filter) |
+| `backend/tests/PropertyManager.Api.Tests/AdminLandlordInvitationsControllerTests.cs` | 22.2 class to extend; `GrantPlatformAdminClaimAsync`/`CreatePlatformAdminAsync` helpers |
+| `frontend/e2e/tests/invitations/invitation-flow.spec.ts` + `frontend/e2e/helpers/mailhog.helper.ts` | E2E + MailHog precedents (`getInvitationCode`, `waitForEmail`) |
+| Angular Material — table guide | https://github.com/angular/components/blob/main/src/material/table/table.md (verified current API; NOTE: this story mirrors Settings' plain `data-table`, not `mat-table`) |
+| Angular — CanActivateFn | https://angular.dev/api/router/CanActivateFn (verified functional-guard signature for Angular 21) |
+
+**Ref MCP note:** Verified the current Angular Material table guide and `CanActivateFn` API (Angular 21) via Ref MCP. No discrepancy with the codebase's established patterns — the existing `owner.guard.ts` and Settings table already use current idioms, which are a stronger authority than docs for this story. **Playwright MCP note:** the dev server was NOT running during story authoring (`localhost:4200` and `:5292` both returned no response), so live visual observation was skipped; the visual language is instead grounded in the real `settings.component.ts` and `sidebar-nav` component files read this turn. /dev-story should run the app and use Playwright MCP for visual verification during implementation.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Opus 4.8 (1M context) — claude-opus-4-8[1m]
+
+### Test Plan
+
+Per the Test Scope table:
+- **Backend unit (REQUIRED)** — Task 5: `GetLandlordInvitationsTests`, `ResendLandlordInvitationTests`.
+- **Backend integration (REQUIRED)** — Task 6: GET list (200/403/401, null-account filtering) + resend (201/403/400/404, landlord-email flavor) in `AdminLandlordInvitationsControllerTests`.
+- **Frontend unit (REQUIRED)** — Task 12: `admin.store`, `platformAdminGuard`, create dialog, list component, sidebar nav visibility.
+- **E2E (REQUIRED)** — Task 13: admin nav → /admin → list → create (+ MailHog) happy path; resend via `page.route()` stub.
+
+### Debug Log References
+
+- **Integration test shared-DB collision (Task 6):** initial seed helpers hardcoded `CodeHash = "seeded-hash"`. `IX_Invitations_CodeHash` is a unique index, so a second seed-using test in the same `IClassFixture` Postgres container hit `23505 duplicate key`. Fixed by generating a unique `CodeHash = $"seeded-{Guid.NewGuid():N}"` per seed. Tests pass individually but failed when the class ran together — classic shared-state flake.
+- **NSwag runtime mismatch (Task 7):** `nswag.json` pins `runtime: Net90` but only the .NET 10 runtime is installed locally. Generated the client by temporarily setting the json `runtime` to `Net100` (the `Net100` toolchain binaries exist under `node_modules/nswag/bin/binaries/Net100`), then reverted `nswag.json` back to `Net90` so the committed config is unchanged. The generated `api.service.ts` is the only intended artifact.
+- **E2E strict-mode (Task 13):** `getByText('Landlord Invitations')` matched both the card title and the empty-state text "No landlord invitations yet." Switched the section-visibility assertion to `mat-card-title` filtered by text.
+- **`Reset 500` teardown:** the documented pre-existing shared-DB FK teardown flake (`[global-teardown] Reset failed: 500`) appears after the admin E2E run — unrelated to this story; both admin specs pass.
+
+### Completion Notes List
+
+- Backend scope was larger than "frontend-only" exactly as the story flagged: added `GET /api/v1/admin/landlord-invitations` (new `GetLandlordInvitationsQuery` + handler) and the parallel `POST /api/v1/admin/landlord-invitations/{id}/resend` (new `ResendLandlordInvitationCommand` + handler + validator) on the existing `AdminLandlordInvitationsController`. The existing `/api/v1/invitations/{id}/resend` route and `ResendInvitationCommandHandler` are untouched.
+- `InvitedBy` resolved via the existing `IIdentityService.GetUserDisplayNamesAsync` helper (same mechanism as MaintenanceRequests / Notes) — no hand-rolled identity query.
+- **CWE-359 / cleartext-storage discipline:** the two new backend logs carry only a count (`"Retrieved {Count} landlord invitations"`) or a static string (`"Resent landlord invitation"`) — no email, `InvitationId`, `AccountId`, or `UserId`.
+- **Deviation from epic file list (justified):** no separate `admin.service.ts` was created. Per Task 8.3 and the 19.6/19.7 precedent, the generated `ApiClient` is injected directly into `AdminStore` — there is no non-trivial transformation logic that would warrant a hand-written service.
+- `GenerateSecureCode`/`ComputeHash` duplicated in `ResendLandlordInvitation.cs` per the accepted project convention (not DRY'd into a shared utility).
+- Verified visually via Playwright MCP as `claude@claude.com` (a seeded PlatformAdmin): the Admin nav entry renders below a divider after Settings; `/admin` shows the Admin Console title + Landlord Invitations card + data-table with status chips + Resend-on-Expired; the email-only create dialog opens. Screenshots were saved to `screenshots/` during development and removed at completion per the skill.
+
+### File List
+
+**Backend — new:**
+- `backend/src/PropertyManager.Application/Invitations/GetLandlordInvitations.cs`
+- `backend/src/PropertyManager.Application/Invitations/ResendLandlordInvitation.cs`
+- `backend/src/PropertyManager.Application/Invitations/ResendLandlordInvitationValidator.cs`
+- `backend/tests/PropertyManager.Application.Tests/Invitations/GetLandlordInvitationsTests.cs`
+- `backend/tests/PropertyManager.Application.Tests/Invitations/ResendLandlordInvitationTests.cs`
+
+**Backend — modified:**
+- `backend/src/PropertyManager.Api/Controllers/AdminLandlordInvitationsController.cs` (added GET + resend actions, `_resendValidator`, `ResendLandlordInvitationResponse` record)
+- `backend/tests/PropertyManager.Api.Tests/AdminLandlordInvitationsControllerTests.cs` (added GET list + resend integration tests + seed helpers)
+
+**Frontend — new:**
+- `frontend/src/app/features/admin/admin-landing.component.ts`
+- `frontend/src/app/features/admin/components/landlord-invitations-list/landlord-invitations-list.component.ts`
+- `frontend/src/app/features/admin/components/landlord-invitations-list/landlord-invitations-list.component.spec.ts`
+- `frontend/src/app/features/admin/components/create-landlord-invitation-dialog/create-landlord-invitation-dialog.component.ts`
+- `frontend/src/app/features/admin/components/create-landlord-invitation-dialog/create-landlord-invitation-dialog.component.spec.ts`
+- `frontend/src/app/features/admin/stores/admin.store.ts`
+- `frontend/src/app/features/admin/stores/admin.store.spec.ts`
+- `frontend/src/app/core/auth/platform-admin.guard.ts`
+- `frontend/src/app/core/auth/platform-admin.guard.spec.ts`
+- `frontend/e2e/tests/admin/landlord-invitations.spec.ts`
+- `frontend/e2e/pages/admin-landlord-invitations.page.ts`
+
+**Frontend — modified:**
+- `frontend/src/app/core/api/api.service.ts` (regenerated NSwag client — gained GET/resend methods + `LandlordInvitationDto`/`GetLandlordInvitationsResponse`/`ResendLandlordInvitationResponse`)
+- `frontend/src/app/app.routes.ts` (added `/admin` child route + `platformAdminGuard` import)
+- `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts` (added `adminNavItems` computed)
+- `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.html` (added admin nav block after a `mat-divider`)
+- `frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.spec.ts` (added PlatformAdmin nav-visibility describe block)
+
+**Docs:**
+- `docs/project/sprint-status.yaml` (22-4 → review)
+
+### Test Results
+
+- Backend: `dotnet build` → 0 errors; `dotnet test` → **2386 passing** (Application 1306, Infrastructure 105, Api 975), exit 0.
+- Frontend: `npm run build` → clean (pre-existing bundle-budget warning only); `npm test` → **2984 passing / 134 files**, 0 failures.
+- E2E: `npx playwright test e2e/tests/admin/landlord-invitations.spec.ts --workers=1` → **2 passed** (create+MailHog happy path; resend via `page.route()` stub). `Reset 500` teardown is the documented pre-existing shared-DB flake.
+
+### Review Log
+
+Note: this environment does not expose a general-purpose subagent dispatch tool, so the two-stage review was performed in-thread (fresh-eyes spec pass, then adversarial quality pass) rather than via dispatched subagents.
+
+- **Task 1 (GetLandlordInvitations query):** Spec PASS — filters `AccountId == null`, orders desc, derives `Pending`/`Expired`/`Accepted` verbatim, resolves `InvitedBy` via `GetUserDisplayNamesAsync`, log carries only a count. Quality APPROVE — DTO/response records match the suggested shape; `ResolveInvitedBy` handles the null-`InvitedByUserId` case.
+- **Task 2 (GET controller action):** Spec PASS — `[HttpGet]` returns `GetLandlordInvitationsResponse` (200) under the class-level `CanInviteLandlords` policy; `[ProducesResponseType]` 200/401/403 present. Quality APPROVE.
+- **Task 3 (ResendLandlordInvitation handler + validator):** Spec PASS — lookup by `Id && AccountId == null`, re-creates `AccountId=null`/`Role="Owner"`/`PropertyId=null`/`InvitedByUserId=caller`, sends `SendLandlordInvitationEmailAsync`, keeps used/not-expired guards, log carries no IDs/email. Quality APPROVE — secure-code helpers duplicated per convention.
+- **Task 4 (resend controller action):** Spec PASS — `[HttpPost("{id:guid}/resend")]` returns 201 with `{invitationId,message}`, mirrors the `try/catch (ValidationException) → ValidationProblemDetails` shape, validator called before `Send`, `[ProducesResponseType]` 201/400/401/403/404. Quality APPROVE.
+- **Task 5 (backend unit):** Spec PASS — covers null-account filtering, ordering, status matrix, `InvitedBy`, empty list, and resend happy/not-found/used/not-expired + validator. Quality APPROVE — uses `MockQueryable.Moq` + AC comments; verifies co-owner/tenant emails are `Times.Never`.
+- **Task 6 (backend integration):** Spec PASS — GET 200/403/401 with null-account filtering + account-scoped exclusion; resend 201 (DB asserts fresh null-account row + `FakeEmailService.SentLandlordInvitationEmails`)/403/400(not-expired)/400(used)/404(missing)/404(account-scoped), 400 bodies asserted. Quality APPROVE after fixing the unique-`CodeHash` shared-DB collision.
+- **Task 7 (NSwag client):** Spec PASS — generated client gained the GET + resend methods and the three new types; client not hand-edited; `nswag.json` runtime reverted. Quality APPROVE.
+- **Task 8 (admin store):** Spec PASS — `signalStore({providedIn:'root'})` with `loadInvitations`/`createInvitation`/`resendInvitation` (rxMethod + patchState + MatSnackBar + `reloadInvitations` helper + `errors`/`title` extraction), mirrors `UserManagementStore`; ApiClient injected directly. Quality APPROVE — snackbar configs extracted to constants; shared `extractErrorMessage` helper avoids duplication.
+- **Task 9 (platformAdminGuard):** Spec PASS — functional `CanActivateFn`, allows on `isPlatformAdmin === true`, Tenant → `/tenant`, else → `/dashboard`; keys on claim not role. Quality APPROVE.
+- **Task 10 (components + route):** Spec PASS — standalone signal components; landing hosts the list; list mirrors the Settings `mat-card`+`data-table`+`mat-chip` pattern with Resend-on-Expired + empty state; email-only dialog with required/email `mat-error`; `/admin` registered as a Shell child with `platformAdminGuard`. Quality APPROVE.
+- **Task 11 (nav entry):** Spec PASS — separate `adminNavItems` computed gated on `isPlatformAdmin`, rendered after a `mat-divider`, not folded into role branches; `data-testid="nav-admin"`. Quality APPROVE.
+- **Task 12 (frontend unit):** Spec PASS — store load/create/resend + error paths; guard allow/redirect matrix incl. null user; dialog validation + `mat-error` rendering + close-with-`{email}`; list rows/empty/resend-gating/dialog-wiring; sidebar admin-entry visibility across all roles. Quality APPROVE.
+- **Task 13 (E2E):** Spec PASS — happy path asserts nav visible → `/admin` → section → create → success snackbar → new Pending row → MailHog landlord email; resend path uses `page.route()` to stub an Expired row + assert the resend POST fires + snackbar; Page Object under `e2e/pages/`. Quality APPROVE — stubbing approach documented in the spec per CLAUDE.md E2E rules.
+- **Task 14 (verify):** Spec PASS — build + all suites + E2E run and cited above. Quality APPROVE.

--- a/frontend/e2e/pages/admin-landlord-invitations.page.ts
+++ b/frontend/e2e/pages/admin-landlord-invitations.page.ts
@@ -1,0 +1,85 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { BasePage } from './base.page';
+
+/**
+ * AdminLandlordInvitationsPage - Page object for the admin console's
+ * Landlord Invitations view (Story 22.4).
+ *
+ * Exposes the sidebar Admin nav link, the invite button, the create dialog's
+ * email field + submit button, the table rows, and the per-row resend button.
+ *
+ * @example
+ * ```typescript
+ * test('admin lists landlord invitations', async ({ adminPage }) => {
+ *   await adminPage.gotoViaNav();
+ *   await adminPage.expectVisible();
+ * });
+ * ```
+ */
+export class AdminLandlordInvitationsPage extends BasePage {
+  /** Sidebar nav link to the admin console (only present for PlatformAdmins) */
+  readonly navLink: Locator;
+
+  /** "Invite New Landlord" button that opens the create dialog */
+  readonly inviteButton: Locator;
+
+  /** Email field inside the create dialog */
+  readonly dialogEmailInput: Locator;
+
+  /** Submit ("Send Invitation") button inside the create dialog */
+  readonly dialogSubmitButton: Locator;
+
+  /** All data rows in the invitations table */
+  readonly tableRows: Locator;
+
+  /** Empty-state message shown when there are no landlord invitations */
+  readonly emptyState: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.navLink = page.getByTestId('nav-admin');
+    this.inviteButton = page.getByTestId('invite-landlord');
+    this.dialogEmailInput = page.locator('mat-dialog-container input[formControlName="email"]');
+    this.dialogSubmitButton = page.locator(
+      'mat-dialog-container button:has-text("Send Invitation")',
+    );
+    this.tableRows = page.locator('table.data-table tbody tr');
+    this.emptyState = page.locator('.empty-message');
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/admin');
+  }
+
+  /** Navigate to the admin console by clicking the sidebar Admin nav entry. */
+  async gotoViaNav(): Promise<void> {
+    await this.navLink.click();
+    await this.page.waitForURL('**/admin', { timeout: 10000 });
+  }
+
+  /** Assert the Landlord Invitations section is rendered. */
+  async expectVisible(): Promise<void> {
+    await expect(
+      this.page.locator('mat-card-title').filter({ hasText: 'Landlord Invitations' }),
+    ).toBeVisible({ timeout: 10000 });
+  }
+
+  /** Open the create dialog, fill the email, and submit. */
+  async createInvitation(email: string): Promise<void> {
+    await this.inviteButton.click();
+    await this.dialogEmailInput.fill(email);
+    await this.dialogSubmitButton.click();
+  }
+
+  /** Locator for a table row containing the given email. */
+  rowForEmail(email: string): Locator {
+    return this.tableRows.filter({ hasText: email });
+  }
+
+  /** Click the Resend button within the row for the given email. */
+  async resendForEmail(email: string): Promise<void> {
+    await this.rowForEmail(email)
+      .getByRole('button', { name: /Resend/ })
+      .click();
+  }
+}

--- a/frontend/e2e/tests/admin/landlord-invitations.spec.ts
+++ b/frontend/e2e/tests/admin/landlord-invitations.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * E2E Tests: Admin Console — Landlord Invitations (Story 22.4)
+ *
+ * The seeded `claude@claude.com` account is a PlatformAdmin (Story 22.1), so the
+ * `authenticatedUser` fixture lands us with the Admin nav entry + /admin route reachable.
+ *
+ * Covers AC #1 (Admin nav visible), #2 (admin landing), #3 (list), #4 (create dialog),
+ * #5 (create → snackbar + new Pending row + MailHog email), #6 (resend via page.route stub).
+ *
+ * Shared-DB note (per CLAUDE.md E2E rules): the resend path uses `page.route()` to stub
+ * `GET /api/v1/admin/landlord-invitations` with a single Expired row — time-warping a real
+ * invitation to expired is not possible, and "NEVER assume seed-data counts".
+ */
+import { test, expect } from '../../fixtures/test-fixtures';
+import { AdminLandlordInvitationsPage } from '../../pages/admin-landlord-invitations.page';
+
+test.describe('Admin Console — Landlord Invitations', () => {
+  test('admin sees nav, opens /admin, creates a landlord invitation (MailHog confirms)', async ({
+    page,
+    authenticatedUser,
+    mailhog,
+  }) => {
+    void authenticatedUser; // ensures login ran
+    const adminPage = new AdminLandlordInvitationsPage(page);
+
+    // AC #1 — Admin nav entry visible to PlatformAdmin
+    await expect(adminPage.navLink).toBeVisible({ timeout: 10000 });
+
+    // AC #2 — navigate to /admin via nav; the Landlord Invitations section renders
+    await adminPage.gotoViaNav();
+    await adminPage.expectVisible();
+
+    // AC #4 / #5 — create a landlord invitation
+    const inviteeEmail = `landlord-${Date.now()}@example.com`;
+    await adminPage.createInvitation(inviteeEmail);
+
+    // AC #5 — success snackbar confirms the invitation was sent
+    await adminPage.expectSnackBar(`Landlord invitation sent to ${inviteeEmail}`);
+
+    // AC #3 / #5 — the new row appears with status "Pending"
+    const newRow = adminPage.rowForEmail(inviteeEmail);
+    await expect(newRow).toBeVisible({ timeout: 10000 });
+    await expect(newRow).toContainText('Pending');
+
+    // AC #5 — MailHog received the landlord-flavored email
+    const message = await mailhog.waitForEmail(
+      inviteeEmail,
+      "You're invited to create your Upkeep account",
+    );
+    expect(message).toBeTruthy();
+  });
+
+  test('admin resends an expired landlord invitation (stubbed list)', async ({
+    page,
+    authenticatedUser,
+  }) => {
+    void authenticatedUser;
+    const adminPage = new AdminLandlordInvitationsPage(page);
+    const expiredEmail = 'expired-landlord@example.com';
+
+    // Stub the GET list to return a single Expired row (page.route per CLAUDE.md E2E rules —
+    // real time-warping to expired is impossible, so we control the data shape).
+    await page.route('**/api/v1/admin/landlord-invitations', async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            {
+              id: '11111111-1111-1111-1111-111111111111',
+              email: expiredEmail,
+              createdAt: '2026-01-01T00:00:00Z',
+              expiresAt: '2026-01-02T00:00:00Z',
+              usedAt: null,
+              status: 'Expired',
+              invitedBy: 'Admin',
+            },
+          ],
+          totalCount: 1,
+        }),
+      });
+    });
+
+    // Capture the resend POST to assert it fires; respond with a 201 so the store reloads.
+    let resendFired = false;
+    await page.route('**/api/v1/admin/landlord-invitations/*/resend', async (route) => {
+      resendFired = true;
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          invitationId: '22222222-2222-2222-2222-222222222222',
+          message: 'Landlord invitation resent successfully',
+        }),
+      });
+    });
+
+    await adminPage.goto();
+    await adminPage.expectVisible();
+
+    const row = adminPage.rowForEmail(expiredEmail);
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await expect(row).toContainText('Expired');
+
+    // AC #6 — Resend fires and a success snackbar confirms
+    await adminPage.resendForEmail(expiredEmail);
+    await adminPage.expectSnackBar('Landlord invitation resent successfully');
+    expect(resendFired).toBe(true);
+  });
+});

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { authGuard, guestGuard, publicGuard } from './core/auth/auth.guard';
 import { ownerGuard } from './core/auth/owner.guard';
+import { platformAdminGuard } from './core/auth/platform-admin.guard';
 import { tenantGuard } from './core/auth/tenant.guard';
 import { notTenantGuard } from './core/auth/not-tenant.guard';
 import { unsavedChangesGuard } from './core/guards/unsaved-changes.guard';
@@ -187,6 +188,15 @@ export const routes: Routes = [
             (m) => m.SettingsComponent
           ),
         canActivate: [ownerGuard],
+      },
+      // Admin Console — platform-level, PlatformAdmin only (Story 22.4)
+      {
+        path: 'admin',
+        loadComponent: () =>
+          import('./features/admin/admin-landing.component').then(
+            (m) => m.AdminLandingComponent
+          ),
+        canActivate: [platformAdminGuard],
       },
       // Vendors (Story 8.3 - AC #1)
       {

--- a/frontend/src/app/core/api/api.service.ts
+++ b/frontend/src/app/core/api/api.service.ts
@@ -19,7 +19,9 @@ export interface IApiClient {
     accountUsers_GetAccountUsers(): Observable<GetAccountUsersResponse>;
     accountUsers_UpdateUserRole(userId: string, request: UpdateUserRoleRequest): Observable<void>;
     accountUsers_RemoveUser(userId: string): Observable<void>;
+    adminLandlordInvitations_GetLandlordInvitations(): Observable<GetLandlordInvitationsResponse>;
     adminLandlordInvitations_CreateLandlordInvitation(request: CreateLandlordInvitationRequest): Observable<CreateLandlordInvitationResponse>;
+    adminLandlordInvitations_ResendLandlordInvitation(id: string): Observable<ResendLandlordInvitationResponse>;
     auth_VerifyEmail(request: VerifyEmailRequest): Observable<void>;
     auth_Login(request: LoginRequest): Observable<LoginResponse>;
     auth_Refresh(): Observable<RefreshResponse>;
@@ -344,6 +346,66 @@ export class ApiClient implements IApiClient {
         return _observableOf(null as any);
     }
 
+    adminLandlordInvitations_GetLandlordInvitations(): Observable<GetLandlordInvitationsResponse> {
+        let url_ = this.baseUrl + "/api/v1/admin/landlord-invitations";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("get", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processAdminLandlordInvitations_GetLandlordInvitations(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processAdminLandlordInvitations_GetLandlordInvitations(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<GetLandlordInvitationsResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<GetLandlordInvitationsResponse>;
+        }));
+    }
+
+    protected processAdminLandlordInvitations_GetLandlordInvitations(response: HttpResponseBase): Observable<GetLandlordInvitationsResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 200) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as GetLandlordInvitationsResponse;
+            return _observableOf(result200);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result403);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
     adminLandlordInvitations_CreateLandlordInvitation(request: CreateLandlordInvitationRequest): Observable<CreateLandlordInvitationResponse> {
         let url_ = this.baseUrl + "/api/v1/admin/landlord-invitations";
         url_ = url_.replace(/[?&]$/, "");
@@ -405,6 +467,81 @@ export class ApiClient implements IApiClient {
             let result403: any = null;
             result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
             return throwException("A server side error occurred.", status, _responseText, _headers, result403);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    adminLandlordInvitations_ResendLandlordInvitation(id: string): Observable<ResendLandlordInvitationResponse> {
+        let url_ = this.baseUrl + "/api/v1/admin/landlord-invitations/{id}/resend";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            withCredentials: true,
+            headers: new HttpHeaders({
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("post", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processAdminLandlordInvitations_ResendLandlordInvitation(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processAdminLandlordInvitations_ResendLandlordInvitation(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<ResendLandlordInvitationResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<ResendLandlordInvitationResponse>;
+        }));
+    }
+
+    protected processAdminLandlordInvitations_ResendLandlordInvitation(response: HttpResponseBase): Observable<ResendLandlordInvitationResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 201) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result201: any = null;
+            result201 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ResendLandlordInvitationResponse;
+            return _observableOf(result201);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result400: any = null;
+            result400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result401: any = null;
+            result401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result403: any = null;
+            result403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result403);
+            }));
+        } else if (status === 404) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            let result404: any = null;
+            result404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
             }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
@@ -7286,6 +7423,26 @@ export interface ProblemDetails {
 
 export interface UpdateUserRoleRequest {
     role?: string;
+}
+
+export interface GetLandlordInvitationsResponse {
+    items?: LandlordInvitationDto[];
+    totalCount?: number;
+}
+
+export interface LandlordInvitationDto {
+    id?: string;
+    email?: string;
+    createdAt?: Date;
+    expiresAt?: Date;
+    usedAt?: Date | undefined;
+    status?: string;
+    invitedBy?: string;
+}
+
+export interface ResendLandlordInvitationResponse {
+    invitationId?: string;
+    message?: string;
 }
 
 export interface CreateLandlordInvitationResponse {

--- a/frontend/src/app/core/auth/platform-admin.guard.spec.ts
+++ b/frontend/src/app/core/auth/platform-admin.guard.spec.ts
@@ -1,0 +1,95 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Router, UrlTree } from '@angular/router';
+import { signal } from '@angular/core';
+import { platformAdminGuard } from './platform-admin.guard';
+import { AuthService, User } from '../services/auth.service';
+
+describe('platformAdminGuard', () => {
+  let currentUserSignal: ReturnType<typeof signal<User | null>>;
+  let mockRouter: Partial<Router>;
+
+  function createUser(role: string, isPlatformAdmin: boolean): User {
+    return {
+      userId: 'test-user-id',
+      accountId: 'test-account-id',
+      role,
+      email: 'test@example.com',
+      displayName: 'Test User',
+      propertyId: null,
+      isPlatformAdmin,
+    };
+  }
+
+  beforeEach(() => {
+    currentUserSignal = signal<User | null>(createUser('Owner', true));
+
+    mockRouter = {
+      createUrlTree: vi.fn().mockReturnValue({} as UrlTree),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: { currentUser: currentUserSignal } },
+        { provide: Router, useValue: mockRouter },
+      ],
+    });
+  });
+
+  it('should allow access when isPlatformAdmin is true (AC: #7)', () => {
+    currentUserSignal.set(createUser('Owner', true));
+
+    TestBed.runInInjectionContext(() => {
+      const result = platformAdminGuard(null as any, { url: '/admin' } as any);
+      expect(result).toBe(true);
+    });
+  });
+
+  it('should redirect Owner-without-claim to /dashboard (AC: #7)', () => {
+    currentUserSignal.set(createUser('Owner', false));
+    const mockUrlTree = {} as UrlTree;
+    vi.mocked(mockRouter.createUrlTree!).mockReturnValue(mockUrlTree);
+
+    TestBed.runInInjectionContext(() => {
+      const result = platformAdminGuard(null as any, { url: '/admin' } as any);
+      expect(result).toBe(mockUrlTree);
+      expect(mockRouter.createUrlTree).toHaveBeenCalledWith(['/dashboard']);
+    });
+  });
+
+  it('should redirect Contributor to /dashboard (AC: #7)', () => {
+    currentUserSignal.set(createUser('Contributor', false));
+    const mockUrlTree = {} as UrlTree;
+    vi.mocked(mockRouter.createUrlTree!).mockReturnValue(mockUrlTree);
+
+    TestBed.runInInjectionContext(() => {
+      const result = platformAdminGuard(null as any, { url: '/admin' } as any);
+      expect(result).toBe(mockUrlTree);
+      expect(mockRouter.createUrlTree).toHaveBeenCalledWith(['/dashboard']);
+    });
+  });
+
+  it('should redirect Tenant to /tenant (AC: #7)', () => {
+    currentUserSignal.set(createUser('Tenant', false));
+    const mockUrlTree = {} as UrlTree;
+    vi.mocked(mockRouter.createUrlTree!).mockReturnValue(mockUrlTree);
+
+    TestBed.runInInjectionContext(() => {
+      const result = platformAdminGuard(null as any, { url: '/admin' } as any);
+      expect(result).toBe(mockUrlTree);
+      expect(mockRouter.createUrlTree).toHaveBeenCalledWith(['/tenant']);
+    });
+  });
+
+  it('should redirect null user to /dashboard (AC: #7)', () => {
+    currentUserSignal.set(null);
+    const mockUrlTree = {} as UrlTree;
+    vi.mocked(mockRouter.createUrlTree!).mockReturnValue(mockUrlTree);
+
+    TestBed.runInInjectionContext(() => {
+      const result = platformAdminGuard(null as any, { url: '/admin' } as any);
+      expect(result).toBe(mockUrlTree);
+      expect(mockRouter.createUrlTree).toHaveBeenCalledWith(['/dashboard']);
+    });
+  });
+});

--- a/frontend/src/app/core/auth/platform-admin.guard.ts
+++ b/frontend/src/app/core/auth/platform-admin.guard.ts
@@ -1,0 +1,33 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+/**
+ * Platform Admin Guard (Story 22.4, AC: #7)
+ *
+ * Route guard for PlatformAdmin-only routes (the /admin console). Runs on child
+ * routes inside the Shell, which already applies authGuard — so by the time this
+ * runs, the user is guaranteed to be authenticated.
+ *
+ * PlatformAdmin is a claim, orthogonal to role (Story 22.1): a user can be both
+ * Owner and PlatformAdmin. This guard keys ONLY on the claim, not on role.
+ *
+ * - PlatformAdmin claim present: allows access
+ * - Tenant: redirects to /tenant
+ * - Everyone else (Owner/Contributor without the claim): redirects to /dashboard
+ */
+export const platformAdminGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  const user = authService.currentUser();
+  if (user?.isPlatformAdmin === true) {
+    return true;
+  }
+
+  if (user?.role === 'Tenant') {
+    return router.createUrlTree(['/tenant']);
+  }
+
+  return router.createUrlTree(['/dashboard']);
+};

--- a/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.html
+++ b/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.html
@@ -25,6 +25,25 @@
     }
   </mat-nav-list>
 
+  <!-- Platform-level admin area, shown only to PlatformAdmins (Story 22.4, AC #1) -->
+  @if (adminNavItems().length > 0) {
+    <mat-divider></mat-divider>
+    <mat-nav-list class="nav-list">
+      @for (item of adminNavItems(); track item.route) {
+        <a
+          mat-list-item
+          [routerLink]="item.route"
+          routerLinkActive="active"
+          class="nav-item"
+          [attr.data-testid]="'nav-' + item.label.toLowerCase()"
+        >
+          <mat-icon matListItemIcon>{{ item.icon }}</mat-icon>
+          <span matListItemTitle>{{ item.label }}</span>
+        </a>
+      }
+    </mat-nav-list>
+  }
+
   <!-- Spacer to push footer to bottom -->
   <div class="spacer"></div>
 

--- a/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.spec.ts
+++ b/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.spec.ts
@@ -265,6 +265,78 @@ describe('SidebarNavComponent', () => {
     });
   });
 
+  // Story 22.4, AC #1: "Admin" nav entry visible only to PlatformAdmins.
+  describe('PlatformAdmin nav entry (Story 22.4, AC #1)', () => {
+    async function setupWithPlatformAdmin(role: string, isPlatformAdmin: boolean) {
+      const mockUser: User = {
+        userId: 'test-user-id',
+        accountId: 'test-account-id',
+        role,
+        email: 'test@example.com',
+        displayName: 'John Doe',
+        propertyId: null,
+        isPlatformAdmin,
+      };
+
+      const mockAuthService = {
+        currentUser: signal<User | null>(mockUser),
+        logout: vi.fn().mockReturnValue(of(undefined)),
+        logoutAndRedirect: vi.fn(),
+      };
+
+      await TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [SidebarNavComponent, NoopAnimationsModule],
+        providers: [
+          provideHttpClient(),
+          provideHttpClientTesting(),
+          provideRouter([]),
+          { provide: AuthService, useValue: mockAuthService },
+          { provide: ReceiptStore, useValue: mockReceiptStore },
+          {
+            provide: ApiClient,
+            useValue: {
+              receipts_GetUnprocessed: vi.fn().mockReturnValue(of({ items: [], totalCount: 0 })),
+            },
+          },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(SidebarNavComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    }
+
+    it('should show the Admin entry when isPlatformAdmin is true', async () => {
+      await setupWithPlatformAdmin('Owner', true);
+      const adminItems = component.adminNavItems();
+      expect(adminItems.map((i) => i.label)).toEqual(['Admin']);
+      expect(adminItems[0].route).toBe('/admin');
+      expect(adminItems[0].icon).toBe('admin_panel_settings');
+
+      const adminLink = fixture.debugElement.query(By.css('[data-testid="nav-admin"]'));
+      expect(adminLink).toBeTruthy();
+    });
+
+    it('should NOT show the Admin entry for an Owner without the claim', async () => {
+      await setupWithPlatformAdmin('Owner', false);
+      expect(component.adminNavItems()).toEqual([]);
+      expect(fixture.debugElement.query(By.css('[data-testid="nav-admin"]'))).toBeNull();
+    });
+
+    it('should NOT show the Admin entry for a Contributor', async () => {
+      await setupWithPlatformAdmin('Contributor', false);
+      expect(component.adminNavItems()).toEqual([]);
+      expect(fixture.debugElement.query(By.css('[data-testid="nav-admin"]'))).toBeNull();
+    });
+
+    it('should NOT show the Admin entry for a Tenant', async () => {
+      await setupWithPlatformAdmin('Tenant', false);
+      expect(component.adminNavItems()).toEqual([]);
+      expect(fixture.debugElement.query(By.css('[data-testid="nav-admin"]'))).toBeNull();
+    });
+  });
+
   describe('userDisplayName fallback logic (AC-7.2.2)', () => {
     it('should fall back to email when displayName is null', async () => {
       const userWithoutDisplayName: User = {

--- a/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts
+++ b/frontend/src/app/core/components/sidebar-nav/sidebar-nav.component.ts
@@ -89,6 +89,18 @@ export class SidebarNavComponent implements OnInit {
     return allItems.filter((item) => contributorRoutes.includes(item.route));
   });
 
+  /**
+   * Platform-level nav items, shown ONLY to PlatformAdmins (Story 22.4, AC #1).
+   * Orthogonal to role (a user can be Owner AND PlatformAdmin), so this is a
+   * separate computed appended after a divider — not folded into the role branches.
+   */
+  readonly adminNavItems = computed<NavItem[]>(() => {
+    if (this.authService.currentUser()?.isPlatformAdmin === true) {
+      return [{ label: 'Admin', route: '/admin', icon: 'admin_panel_settings' }];
+    }
+    return [];
+  });
+
   ngOnInit(): void {
     // Load unprocessed receipts on init to populate badge count
     // Skip for Tenant users who don't use receipts (Story 20.5)

--- a/frontend/src/app/features/admin/admin-landing.component.ts
+++ b/frontend/src/app/features/admin/admin-landing.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { LandlordInvitationsListComponent } from './components/landlord-invitations-list/landlord-invitations-list.component';
+
+/**
+ * Admin Console landing page (Story 22.4, AC: #2).
+ * Platform-level area, gated by platformAdminGuard. Currently hosts the
+ * Landlord Invitations section.
+ */
+@Component({
+  selector: 'app-admin-landing',
+  standalone: true,
+  imports: [LandlordInvitationsListComponent],
+  template: `
+    <div class="admin-container">
+      <div class="page-header">
+        <h2>Admin Console</h2>
+      </div>
+
+      <app-landlord-invitations-list />
+    </div>
+  `,
+  styles: [
+    `
+      .admin-container {
+        padding: 24px;
+        max-width: 960px;
+        margin: 0 auto;
+      }
+
+      .page-header {
+        margin-bottom: 24px;
+      }
+
+      .page-header h2 {
+        margin: 0;
+        color: var(--pm-text-primary);
+      }
+    `,
+  ],
+})
+export class AdminLandingComponent {}

--- a/frontend/src/app/features/admin/components/create-landlord-invitation-dialog/create-landlord-invitation-dialog.component.spec.ts
+++ b/frontend/src/app/features/admin/components/create-landlord-invitation-dialog/create-landlord-invitation-dialog.component.spec.ts
@@ -1,0 +1,84 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatDialogRef } from '@angular/material/dialog';
+import { By } from '@angular/platform-browser';
+import { CreateLandlordInvitationDialogComponent } from './create-landlord-invitation-dialog.component';
+
+describe('CreateLandlordInvitationDialogComponent', () => {
+  let component: CreateLandlordInvitationDialogComponent;
+  let fixture: ComponentFixture<CreateLandlordInvitationDialogComponent>;
+  let mockDialogRef: { close: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    mockDialogRef = { close: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [CreateLandlordInvitationDialogComponent, NoopAnimationsModule],
+      providers: [{ provide: MatDialogRef, useValue: mockDialogRef }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateLandlordInvitationDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have an email-only form (no role control)', () => {
+    expect(component.form.get('email')).toBeTruthy();
+    expect(component.form.get('role')).toBeNull();
+  });
+
+  it('should mark email invalid when empty (AC: #8)', () => {
+    component.form.get('email')?.setValue('');
+    expect(component.form.get('email')?.valid).toBe(false);
+  });
+
+  it('should mark email invalid with bad format (AC: #8)', () => {
+    component.form.get('email')?.setValue('not-an-email');
+    expect(component.form.get('email')?.valid).toBe(false);
+  });
+
+  it('should mark email valid with proper email', () => {
+    component.form.get('email')?.setValue('landlord@example.com');
+    expect(component.form.get('email')?.valid).toBe(true);
+  });
+
+  it('should NOT close with a value when form is invalid (AC: #8)', () => {
+    component.form.get('email')?.setValue('');
+    component.onSubmit();
+    expect(mockDialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('should close with { email } on valid submit (AC: #4)', () => {
+    component.form.get('email')?.setValue('landlord@example.com');
+    component.onSubmit();
+    expect(mockDialogRef.close).toHaveBeenCalledWith({ email: 'landlord@example.com' });
+  });
+
+  it('should close without data on cancel', () => {
+    component.onCancel();
+    expect(mockDialogRef.close).toHaveBeenCalledWith();
+  });
+
+  it('should render a required mat-error when email is touched and empty (AC: #8)', () => {
+    const emailControl = component.form.get('email');
+    emailControl?.setValue('');
+    emailControl?.markAsTouched();
+    fixture.detectChanges();
+    const error = fixture.debugElement.query(By.css('mat-error'));
+    expect(error?.nativeElement.textContent).toContain('Email is required');
+  });
+
+  it('should render an invalid-format mat-error for a malformed email (AC: #8)', () => {
+    const emailControl = component.form.get('email');
+    emailControl?.setValue('bad');
+    emailControl?.markAsTouched();
+    fixture.detectChanges();
+    const error = fixture.debugElement.query(By.css('mat-error'));
+    expect(error?.nativeElement.textContent).toContain('Invalid email format');
+  });
+});

--- a/frontend/src/app/features/admin/components/create-landlord-invitation-dialog/create-landlord-invitation-dialog.component.ts
+++ b/frontend/src/app/features/admin/components/create-landlord-invitation-dialog/create-landlord-invitation-dialog.component.ts
@@ -1,0 +1,86 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+/**
+ * Dialog for inviting a new landlord (Story 22.4, AC: #4, #8).
+ * Email-only — no role/property/account fields (the backend creates a top-level
+ * Owner invitation with AccountId=null). Returns { email } on submit, undefined on cancel.
+ */
+@Component({
+  selector: 'app-create-landlord-invitation-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+  ],
+  template: `
+    <h2 mat-dialog-title>Invite New Landlord</h2>
+    <mat-dialog-content>
+      <form [formGroup]="form" class="invite-form">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Email</mat-label>
+          <input matInput formControlName="email" type="email" placeholder="landlord@example.com" />
+          @if (form.get('email')?.hasError('required') && form.get('email')?.touched) {
+            <mat-error>Email is required</mat-error>
+          }
+          @if (form.get('email')?.hasError('email') && !form.get('email')?.hasError('required')) {
+            <mat-error>Invalid email format</mat-error>
+          }
+        </mat-form-field>
+      </form>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="onCancel()">Cancel</button>
+      <button mat-raised-button color="primary" (click)="onSubmit()">
+        <mat-icon>send</mat-icon>
+        Send Invitation
+      </button>
+    </mat-dialog-actions>
+  `,
+  styles: [
+    `
+      .invite-form {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        min-width: 350px;
+      }
+
+      .full-width {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class CreateLandlordInvitationDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<CreateLandlordInvitationDialogComponent>);
+  private readonly fb = inject(FormBuilder);
+
+  form: FormGroup = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+  });
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.dialogRef.close({ email: this.form.value.email });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/features/admin/components/landlord-invitations-list/landlord-invitations-list.component.spec.ts
+++ b/frontend/src/app/features/admin/components/landlord-invitations-list/landlord-invitations-list.component.spec.ts
@@ -1,0 +1,122 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatDialog } from '@angular/material/dialog';
+import { By } from '@angular/platform-browser';
+import { signal } from '@angular/core';
+import { of } from 'rxjs';
+import { LandlordInvitationsListComponent } from './landlord-invitations-list.component';
+import { AdminStore } from '../../stores/admin.store';
+import { LandlordInvitationDto } from '../../../../core/api/api.service';
+
+describe('LandlordInvitationsListComponent', () => {
+  let component: LandlordInvitationsListComponent;
+  let fixture: ComponentFixture<LandlordInvitationsListComponent>;
+  let invitationsSignal: ReturnType<typeof signal<LandlordInvitationDto[]>>;
+  let mockStore: {
+    invitations: ReturnType<typeof signal<LandlordInvitationDto[]>>;
+    loading: ReturnType<typeof signal<boolean>>;
+    loadInvitations: ReturnType<typeof vi.fn>;
+    createInvitation: ReturnType<typeof vi.fn>;
+    resendInvitation: ReturnType<typeof vi.fn>;
+  };
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+
+  const pendingRow: LandlordInvitationDto = {
+    id: 'p1',
+    email: 'pending@example.com',
+    createdAt: new Date(),
+    expiresAt: new Date(),
+    status: 'Pending',
+    invitedBy: 'Admin',
+  };
+
+  const expiredRow: LandlordInvitationDto = {
+    id: 'e1',
+    email: 'expired@example.com',
+    createdAt: new Date(),
+    expiresAt: new Date(),
+    status: 'Expired',
+    invitedBy: 'Admin',
+  };
+
+  async function setup(invitations: LandlordInvitationDto[]) {
+    invitationsSignal = signal<LandlordInvitationDto[]>(invitations);
+    mockStore = {
+      invitations: invitationsSignal,
+      loading: signal(false),
+      loadInvitations: vi.fn(),
+      createInvitation: vi.fn(),
+      resendInvitation: vi.fn(),
+    };
+    mockDialog = { open: vi.fn() };
+
+    await TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [LandlordInvitationsListComponent, NoopAnimationsModule],
+      providers: [
+        { provide: AdminStore, useValue: mockStore },
+        { provide: MatDialog, useValue: mockDialog },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LandlordInvitationsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('should call loadInvitations on init (AC: #3)', async () => {
+    await setup([]);
+    expect(mockStore.loadInvitations).toHaveBeenCalled();
+  });
+
+  it('should show empty state when there are no invitations (AC: #3)', async () => {
+    await setup([]);
+    const empty = fixture.debugElement.query(By.css('.empty-message'));
+    expect(empty?.nativeElement.textContent).toContain('No landlord invitations yet.');
+  });
+
+  it('should render a row per invitation (AC: #3)', async () => {
+    await setup([pendingRow, expiredRow]);
+    const rows = fixture.debugElement.queryAll(By.css('tbody tr'));
+    expect(rows.length).toBe(2);
+  });
+
+  it('should show Resend only for Expired rows (AC: #6)', async () => {
+    await setup([pendingRow, expiredRow]);
+    const resendButtons = fixture.debugElement.queryAll(By.css('tbody tr button'));
+    // Only the expired row has a Resend button
+    expect(resendButtons.length).toBe(1);
+    expect(resendButtons[0].nativeElement.textContent).toContain('Resend');
+  });
+
+  it('should call store.resendInvitation when Resend is clicked (AC: #6)', async () => {
+    await setup([expiredRow]);
+    const resendButton = fixture.debugElement.query(By.css('tbody tr button'));
+    resendButton.nativeElement.click();
+    expect(mockStore.resendInvitation).toHaveBeenCalledWith('e1');
+  });
+
+  it('should open the create dialog and call createInvitation on close with a value (AC: #4, #5)', async () => {
+    await setup([]);
+    mockDialog.open.mockReturnValue({
+      afterClosed: () => of({ email: 'new@example.com' }),
+    });
+
+    component.openInviteDialog();
+
+    expect(mockDialog.open).toHaveBeenCalled();
+    expect(mockStore.createInvitation).toHaveBeenCalledWith({ email: 'new@example.com' });
+  });
+
+  it('should NOT call createInvitation when the dialog is cancelled', async () => {
+    await setup([]);
+    mockDialog.open.mockReturnValue({
+      afterClosed: () => of(undefined),
+    });
+
+    component.openInviteDialog();
+
+    expect(mockStore.createInvitation).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/features/admin/components/landlord-invitations-list/landlord-invitations-list.component.ts
+++ b/frontend/src/app/features/admin/components/landlord-invitations-list/landlord-invitations-list.component.ts
@@ -1,0 +1,198 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatDialog } from '@angular/material/dialog';
+import { AdminStore } from '../../stores/admin.store';
+import { CreateLandlordInvitationDialogComponent } from '../create-landlord-invitation-dialog/create-landlord-invitation-dialog.component';
+
+/**
+ * Landlord Invitations list (Story 22.4, AC: #3, #4, #5, #6, #9).
+ * Mirrors the Settings invitations table: mat-card + plain data-table + mat-chip status.
+ * "Resend" is shown only for Expired rows. Empty state when there are no invitations.
+ */
+@Component({
+  selector: 'app-landlord-invitations-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    DatePipe,
+    MatCardModule,
+    MatIconModule,
+    MatButtonModule,
+    MatChipsModule,
+    MatProgressSpinnerModule,
+  ],
+  template: `
+    <mat-card class="section-card">
+      <mat-card-header>
+        <mat-card-title>
+          <mat-icon class="section-icon">mail_outline</mat-icon>
+          Landlord Invitations
+        </mat-card-title>
+        <button
+          mat-raised-button
+          color="primary"
+          (click)="openInviteDialog()"
+          data-testid="invite-landlord"
+        >
+          <mat-icon>person_add</mat-icon>
+          Invite New Landlord
+        </button>
+      </mat-card-header>
+      <mat-card-content>
+        @if (store.loading()) {
+          <div class="loading-container">
+            <mat-spinner diameter="40"></mat-spinner>
+          </div>
+        }
+
+        @if (store.invitations().length === 0) {
+          <p class="empty-message">No landlord invitations yet.</p>
+        } @else {
+          <div class="table-container">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Email</th>
+                  <th>Created</th>
+                  <th>Expires</th>
+                  <th>Status</th>
+                  <th>Invited By</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (invitation of store.invitations(); track invitation.id) {
+                  <tr>
+                    <td>{{ invitation.email }}</td>
+                    <td>{{ invitation.createdAt | date: 'mediumDate' }}</td>
+                    <td>{{ invitation.expiresAt | date: 'mediumDate' }}</td>
+                    <td>
+                      <mat-chip-set>
+                        <mat-chip
+                          [class.status-pending]="invitation.status === 'Pending'"
+                          [class.status-expired]="invitation.status === 'Expired'"
+                          [class.status-accepted]="invitation.status === 'Accepted'"
+                        >
+                          {{ invitation.status }}
+                        </mat-chip>
+                      </mat-chip-set>
+                    </td>
+                    <td>{{ invitation.invitedBy }}</td>
+                    <td>
+                      @if (invitation.status === 'Expired') {
+                        <button mat-button color="primary" (click)="onResend(invitation.id!)">
+                          <mat-icon>replay</mat-icon>
+                          Resend
+                        </button>
+                      }
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
+      </mat-card-content>
+    </mat-card>
+  `,
+  styles: [
+    `
+      .section-card {
+        margin-bottom: 24px;
+      }
+
+      .section-icon {
+        vertical-align: middle;
+        margin-right: 8px;
+      }
+
+      mat-card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .loading-container {
+        display: flex;
+        justify-content: center;
+        padding: 24px;
+      }
+
+      .empty-message {
+        color: var(--pm-text-secondary);
+        text-align: center;
+        padding: 16px;
+      }
+
+      .table-container {
+        overflow-x: auto;
+      }
+
+      .data-table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      .data-table th,
+      .data-table td {
+        text-align: left;
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+      }
+
+      .data-table th {
+        font-weight: 500;
+        color: var(--pm-text-secondary);
+        font-size: 0.875rem;
+      }
+
+      .data-table td {
+        color: var(--pm-text-primary);
+      }
+
+      .status-pending {
+        --mdc-chip-elevated-container-color: var(--mat-sys-primary-container, #e0e7ff);
+        --mdc-chip-label-text-color: var(--mat-sys-on-primary-container, #1e40af);
+      }
+
+      .status-expired {
+        --mdc-chip-elevated-container-color: var(--mat-sys-error-container, #fee2e2);
+        --mdc-chip-label-text-color: var(--mat-sys-on-error-container, #991b1b);
+      }
+
+      .status-accepted {
+        --mdc-chip-elevated-container-color: var(--mat-sys-tertiary-container, #dcfce7);
+        --mdc-chip-label-text-color: var(--mat-sys-on-tertiary-container, #166534);
+      }
+    `,
+  ],
+})
+export class LandlordInvitationsListComponent implements OnInit {
+  protected readonly store = inject(AdminStore);
+  private readonly dialog = inject(MatDialog);
+
+  ngOnInit(): void {
+    this.store.loadInvitations();
+  }
+
+  openInviteDialog(): void {
+    const dialogRef = this.dialog.open(CreateLandlordInvitationDialogComponent, {
+      width: '400px',
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.store.createInvitation(result);
+      }
+    });
+  }
+
+  onResend(id: string): void {
+    this.store.resendInvitation(id);
+  }
+}

--- a/frontend/src/app/features/admin/stores/admin.store.spec.ts
+++ b/frontend/src/app/features/admin/stores/admin.store.spec.ts
@@ -1,0 +1,170 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of, throwError } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { AdminStore } from './admin.store';
+import { ApiClient, LandlordInvitationDto } from '../../../core/api/api.service';
+
+describe('AdminStore', () => {
+  let store: InstanceType<typeof AdminStore>;
+  let mockApiClient: {
+    adminLandlordInvitations_GetLandlordInvitations: ReturnType<typeof vi.fn>;
+    adminLandlordInvitations_CreateLandlordInvitation: ReturnType<typeof vi.fn>;
+    adminLandlordInvitations_ResendLandlordInvitation: ReturnType<typeof vi.fn>;
+  };
+  let mockSnackBar: { open: ReturnType<typeof vi.fn> };
+
+  const mockInvitations: LandlordInvitationDto[] = [
+    {
+      id: '1',
+      email: 'landlord1@example.com',
+      createdAt: new Date(),
+      expiresAt: new Date(),
+      status: 'Pending',
+      invitedBy: 'Admin',
+    },
+    {
+      id: '2',
+      email: 'landlord2@example.com',
+      createdAt: new Date(),
+      expiresAt: new Date(),
+      status: 'Expired',
+      invitedBy: 'Admin',
+    },
+  ];
+
+  beforeEach(() => {
+    mockApiClient = {
+      adminLandlordInvitations_GetLandlordInvitations: vi.fn(),
+      adminLandlordInvitations_CreateLandlordInvitation: vi.fn(),
+      adminLandlordInvitations_ResendLandlordInvitation: vi.fn(),
+    };
+    mockSnackBar = { open: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AdminStore,
+        { provide: ApiClient, useValue: mockApiClient },
+        { provide: MatSnackBar, useValue: mockSnackBar },
+      ],
+    });
+
+    store = TestBed.inject(AdminStore);
+  });
+
+  describe('initial state', () => {
+    it('should have empty invitations, loading false, error null', () => {
+      expect(store.invitations()).toEqual([]);
+      expect(store.loading()).toBe(false);
+      expect(store.error()).toBeNull();
+    });
+  });
+
+  describe('loadInvitations (AC: #3)', () => {
+    it('should load invitations from API', () => {
+      mockApiClient.adminLandlordInvitations_GetLandlordInvitations.mockReturnValue(
+        of({ items: mockInvitations, totalCount: 2 }),
+      );
+
+      store.loadInvitations();
+
+      expect(store.invitations()).toEqual(mockInvitations);
+      expect(store.loading()).toBe(false);
+    });
+
+    it('should set error on failure', () => {
+      mockApiClient.adminLandlordInvitations_GetLandlordInvitations.mockReturnValue(
+        throwError(() => new Error('Network error')),
+      );
+
+      store.loadInvitations();
+
+      expect(store.error()).toBe('Failed to load landlord invitations');
+      expect(store.loading()).toBe(false);
+    });
+  });
+
+  describe('createInvitation (AC: #5)', () => {
+    it('should create invitation, show success snackbar, and reload list', () => {
+      mockApiClient.adminLandlordInvitations_CreateLandlordInvitation.mockReturnValue(
+        of({ invitationId: 'new-id', message: 'sent' }),
+      );
+      mockApiClient.adminLandlordInvitations_GetLandlordInvitations.mockReturnValue(
+        of({ items: mockInvitations, totalCount: 2 }),
+      );
+
+      store.createInvitation({ email: 'new@example.com' });
+
+      expect(mockApiClient.adminLandlordInvitations_CreateLandlordInvitation).toHaveBeenCalledWith({
+        email: 'new@example.com',
+      });
+      expect(mockSnackBar.open).toHaveBeenCalledWith(
+        'Landlord invitation sent to new@example.com',
+        'Close',
+        expect.objectContaining({ duration: 3000 }),
+      );
+      // Reload was triggered
+      expect(mockApiClient.adminLandlordInvitations_GetLandlordInvitations).toHaveBeenCalled();
+      expect(store.loading()).toBe(false);
+    });
+
+    it('should set error and show error snackbar on failure', () => {
+      mockApiClient.adminLandlordInvitations_CreateLandlordInvitation.mockReturnValue(
+        throwError(() => ({
+          status: 400,
+          errors: { Email: ['This email is already registered'] },
+        })),
+      );
+
+      store.createInvitation({ email: 'dupe@example.com' });
+
+      expect(store.error()).toBe('This email is already registered');
+      expect(mockSnackBar.open).toHaveBeenCalledWith(
+        'This email is already registered',
+        'Close',
+        expect.objectContaining({ duration: 5000 }),
+      );
+      expect(store.loading()).toBe(false);
+    });
+  });
+
+  describe('resendInvitation (AC: #6)', () => {
+    it('should resend, show success snackbar, and reload list', () => {
+      mockApiClient.adminLandlordInvitations_ResendLandlordInvitation.mockReturnValue(
+        of({ invitationId: 'new-id', message: 'resent' }),
+      );
+      mockApiClient.adminLandlordInvitations_GetLandlordInvitations.mockReturnValue(
+        of({ items: mockInvitations, totalCount: 2 }),
+      );
+
+      store.resendInvitation('expired-id');
+
+      expect(mockApiClient.adminLandlordInvitations_ResendLandlordInvitation).toHaveBeenCalledWith(
+        'expired-id',
+      );
+      expect(mockSnackBar.open).toHaveBeenCalledWith(
+        'Landlord invitation resent successfully',
+        'Close',
+        expect.objectContaining({ duration: 3000 }),
+      );
+      expect(mockApiClient.adminLandlordInvitations_GetLandlordInvitations).toHaveBeenCalled();
+      expect(store.loading()).toBe(false);
+    });
+
+    it('should set error and show error snackbar on failure', () => {
+      mockApiClient.adminLandlordInvitations_ResendLandlordInvitation.mockReturnValue(
+        throwError(() => ({ status: 400, title: 'Can only resend expired invitations' })),
+      );
+
+      store.resendInvitation('some-id');
+
+      expect(store.error()).toBe('Can only resend expired invitations');
+      expect(mockSnackBar.open).toHaveBeenCalledWith(
+        'Can only resend expired invitations',
+        'Close',
+        expect.objectContaining({ duration: 5000 }),
+      );
+      expect(store.loading()).toBe(false);
+    });
+  });
+});

--- a/frontend/src/app/features/admin/stores/admin.store.ts
+++ b/frontend/src/app/features/admin/stores/admin.store.ts
@@ -1,0 +1,155 @@
+import { inject } from '@angular/core';
+import { patchState, signalStore, withMethods, withState } from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { pipe, switchMap, tap, catchError, of } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ApiClient, LandlordInvitationDto } from '../../../core/api/api.service';
+
+/**
+ * Admin Store State (Story 22.4, AC: #3, #5, #6).
+ * Manages the platform-admin view of landlord invitations.
+ */
+type AdminState = {
+  invitations: LandlordInvitationDto[];
+  loading: boolean;
+  error: string | null;
+};
+
+const initialState: AdminState = {
+  invitations: [],
+  loading: false,
+  error: null,
+};
+
+const SUCCESS_SNACK = {
+  duration: 3000,
+  horizontalPosition: 'center' as const,
+  verticalPosition: 'bottom' as const,
+};
+
+const ERROR_SNACK = {
+  duration: 5000,
+  horizontalPosition: 'center' as const,
+  verticalPosition: 'bottom' as const,
+};
+
+/**
+ * Extracts a human-readable message from an API error, mirroring UserManagementStore.
+ */
+function extractErrorMessage(error: unknown, fallback: string): string {
+  const err = error as { errors?: Record<string, string[]>; title?: string };
+  if (err?.errors) {
+    const messages = Object.values(err.errors).flat();
+    return messages.join('. ');
+  }
+  if (err?.title) {
+    return err.title;
+  }
+  return fallback;
+}
+
+/**
+ * AdminStore
+ *
+ * State management for the admin console's landlord-invitations section.
+ * Injects the generated ApiClient directly (no separate admin.service.ts) — the
+ * established 19.6/19.7 pattern in UserManagementStore treats the generated client
+ * as the service layer.
+ */
+export const AdminStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+  withMethods((store, api = inject(ApiClient), snackBar = inject(MatSnackBar)) => {
+    const reloadInvitations = () => {
+      api.adminLandlordInvitations_GetLandlordInvitations().subscribe({
+        next: (res) => patchState(store, { invitations: res.items ?? [] }),
+        error: (err) => console.error('Error reloading landlord invitations:', err),
+      });
+    };
+
+    return {
+      /**
+       * Load all landlord invitations (AC: #3).
+       */
+      loadInvitations: rxMethod<void>(
+        pipe(
+          tap(() => patchState(store, { loading: true, error: null })),
+          switchMap(() =>
+            api.adminLandlordInvitations_GetLandlordInvitations().pipe(
+              tap((res) =>
+                patchState(store, {
+                  invitations: res.items ?? [],
+                  loading: false,
+                }),
+              ),
+              catchError((error) => {
+                patchState(store, {
+                  loading: false,
+                  error: 'Failed to load landlord invitations',
+                });
+                console.error('Error loading landlord invitations:', error);
+                return of(null);
+              }),
+            ),
+          ),
+        ),
+      ),
+
+      /**
+       * Create a new landlord invitation (AC: #4, #5).
+       */
+      createInvitation: rxMethod<{ email: string }>(
+        pipe(
+          tap(() => patchState(store, { loading: true, error: null })),
+          switchMap(({ email }) =>
+            api.adminLandlordInvitations_CreateLandlordInvitation({ email }).pipe(
+              tap(() => {
+                patchState(store, { loading: false });
+                snackBar.open(`Landlord invitation sent to ${email}`, 'Close', SUCCESS_SNACK);
+                reloadInvitations();
+              }),
+              catchError((error) => {
+                const errorMessage = extractErrorMessage(
+                  error,
+                  'Failed to send landlord invitation',
+                );
+                patchState(store, { loading: false, error: errorMessage });
+                snackBar.open(errorMessage, 'Close', ERROR_SNACK);
+                console.error('Error sending landlord invitation:', error);
+                return of(null);
+              }),
+            ),
+          ),
+        ),
+      ),
+
+      /**
+       * Resend an expired landlord invitation (AC: #6).
+       */
+      resendInvitation: rxMethod<string>(
+        pipe(
+          tap(() => patchState(store, { loading: true, error: null })),
+          switchMap((id) =>
+            api.adminLandlordInvitations_ResendLandlordInvitation(id).pipe(
+              tap(() => {
+                patchState(store, { loading: false });
+                snackBar.open('Landlord invitation resent successfully', 'Close', SUCCESS_SNACK);
+                reloadInvitations();
+              }),
+              catchError((error) => {
+                const errorMessage = extractErrorMessage(
+                  error,
+                  'Failed to resend landlord invitation',
+                );
+                patchState(store, { loading: false, error: errorMessage });
+                snackBar.open(errorMessage, 'Close', ERROR_SNACK);
+                console.error('Error resending landlord invitation:', error);
+                return of(null);
+              }),
+            ),
+          ),
+        ),
+      ),
+    };
+  }),
+);


### PR DESCRIPTION
## Story 22.4 — Admin Console UI: List, Create, Resend Landlord Invitations

Delivers the PlatformAdmin admin console for managing landlord invitations (FR-LP1, FR-LP5). The epic framed this as frontend-only, but grounding against the live code revealed two backend gaps that this story also closes.

### Backend
- **`GET /api/v1/admin/landlord-invitations`** — lists invitations with `AccountId = null`, derives status (Pending / Accepted / Expired), resolves invited-by display name.
- **`POST /api/v1/admin/landlord-invitations/{id}/resend`** — parallel admin resend that re-creates a null-account Owner invitation with a fresh expiry and sends the landlord email. The existing account-scoped `/api/v1/invitations/{id}/resend` is left untouched.
- Both endpoints gated by the `CanInviteLandlords` (PlatformAdmin) policy. Resend lookup is scoped to `AccountId == null`, so it cannot touch account invitations (proven by a 404 test).

### Frontend
- `platformAdminGuard` + `/admin` route (redirects non-admins to their dashboard/tenant home).
- `AdminStore`, admin landing page, landlord-invitations list, and an email-only create dialog — mirroring the Settings `mat-card` / `data-table` / `mat-chip` patterns.
- Conditional "Admin" sidebar entry, visible only to PlatformAdmins.
- NSwag client regenerated.

### Acceptance Criteria
All 9 ACs (AC-22.4.1 → AC-22.4.9) verified live in the browser via Playwright MCP — including creating an invitation (confirmed in MailHog), resending a genuinely expired invitation, and form-validation edge cases.

### Tests
- **Backend unit:** Get/Resend handlers + validator
- **Backend integration:** WebApplicationFactory — auth (200/401/403), validation, null-account filtering, resend state transitions (201 / 400-not-expired / 400-used / 404 / 404-account-scoped)
- **Frontend unit:** store, guard, dialog, list, sidebar
- **E2E:** Playwright — create + MailHog assertion, resend

### Verification
- Backend: `dotnet build` 0 errors; `dotnet test` **2386 passing**, 0 failed
- Frontend: `ng build` clean (one pre-existing +5.63 kB bundle-budget warning, lazy-loaded feature — not a regression); `npm test` **2984 passing**, 0 failed
- E2E admin spec: 2 passed

### Notes
- No DB migration (no schema change).
- No PII in logs (count + static strings only) — consistent with the CWE-359 discipline from 22.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)