### PR TITLE
fix(test): delete MaintenanceRequests in test reset before Properties

### DIFF
--- a/backend/src/PropertyManager.Api/Controllers/TestController.cs
+++ b/backend/src/PropertyManager.Api/Controllers/TestController.cs
@@ -135,13 +135,25 @@ public class TestController : ControllerBase
             .Where(gr => gr.AccountId == accountId)
             .ExecuteDeleteAsync(cancellationToken);
 
-        // 13. Properties (has AccountId)
+        // 13a. MaintenanceRequestPhotos (has AccountId) — child of MaintenanceRequest
+        response.MaintenanceRequestPhotos = await _dbContext.MaintenanceRequestPhotos
+            .IgnoreQueryFilters()
+            .Where(p => p.AccountId == accountId)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        // 13b. MaintenanceRequests (has AccountId) — FK to Property is Restrict, must be deleted before Properties
+        response.MaintenanceRequests = await _dbContext.MaintenanceRequests
+            .IgnoreQueryFilters()
+            .Where(mr => mr.AccountId == accountId)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        // 14. Properties (has AccountId)
         response.Properties = await _dbContext.Properties
             .IgnoreQueryFilters()
             .Where(p => p.AccountId == accountId)
             .ExecuteDeleteAsync(cancellationToken);
 
-        // 14. RefreshTokens (has AccountId)
+        // 15. RefreshTokens (has AccountId)
         response.RefreshTokens = await _dbContext.RefreshTokens
             .IgnoreQueryFilters()
             .Where(rt => rt.AccountId == accountId)
@@ -172,9 +184,12 @@ public record TestResetResponse
     public int PropertyPhotos { get; set; }
     public int Receipts { get; set; }
     public int GeneratedReports { get; set; }
+    public int MaintenanceRequestPhotos { get; set; }
+    public int MaintenanceRequests { get; set; }
     public int Properties { get; set; }
     public int RefreshTokens { get; set; }
     public int TotalDeleted => WorkOrderTagAssignments + WorkOrderPhotos + Notes +
         Expenses + Income + WorkOrders + VendorTradeTagAssignments + Vendors +
-        Persons + PropertyPhotos + Receipts + GeneratedReports + Properties + RefreshTokens;
+        Persons + PropertyPhotos + Receipts + GeneratedReports +
+        MaintenanceRequestPhotos + MaintenanceRequests + Properties + RefreshTokens;
 }


### PR DESCRIPTION
## Problem

The `POST /api/v1/test/reset` endpoint (Development-only, used by the E2E suite to clean per-account data between tests) deletes 14 entity types but never deletes `MaintenanceRequests`. Those rows have a `Restrict` FK to `Properties` (`FK_MaintenanceRequests_Properties_PropertyId`).

As a result the reset is **not idempotent**: a run that creates maintenance-request data leaves it behind, and the *next* run's reset throws a 500 FK violation when it tries to delete `Properties`. Because nearly every E2E spec depends on that reset in setup, this cascades into the entire suite failing (250/250) on any re-run.

This was surfaced by running the full E2E suite twice in a row: first run green, second run all-fail with:

```
23503: update or delete on table "Properties" violates foreign key constraint
"FK_MaintenanceRequests_Properties_PropertyId" on table "MaintenanceRequests"
```

## Fix

Delete `MaintenanceRequestPhotos` then `MaintenanceRequests` before `Properties` in the reset order, and surface their counts in `TestResetResponse`. `MaintenanceRequest.WorkOrder` is `SetNull` and `WorkOrder.Property` is `Restrict` (WorkOrders already deleted earlier), so the new ordering is FK-safe.

## Verification

- `dotnet build` — 0 errors
- Full backend test suite — 2,386 passing, 0 failures
- Full E2E suite (`playwright test --workers=1`), run twice consecutively — **250 passed, 0 failed** both times; reset no longer 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)